### PR TITLE
Makefileのobjclean:に「./eval/nnue/*.o」等を追加

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -454,7 +454,7 @@ clean: objclean profileclean
 
 # clean binaries and objects
 objclean:
-	@rm -f $(EXE) *.o ./syzygy/*.o
+	@rm -f $(EXE) *.o ./syzygy/*.o ./learn/*.o ./extra/*.o ./eval/*.o ./eval/nnue/*.o ./eval/nnue/features/*.o
 
 # clean auxiliary profiling files
 profileclean:


### PR DESCRIPTION
Makefileのobjclean:に「./eval/nnue/*.o」等を追加しました。
StockfishのNNUE評価関数、とても興味深く期待しております。
