### PR TITLE
nullmoveとpromotionの場合に評価値の差分計算と全計算の結果が異なっていたのを修正

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -927,8 +927,8 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
 
 #if defined(EVAL_NNUE)
           piece_no0 = piece_no_of(to);
-          dp.pieceNo[0] = piece_no0;
-          dp.changed_piece[0].old_piece = evalList.bona_piece(piece_no0);
+          //dp.pieceNo[0] = piece_no0;
+          //dp.changed_piece[0].old_piece = evalList.bona_piece(piece_no0);
           assert(evalList.piece_no_list_board[from] == PIECE_NUMBER_NB);
           evalList.put_piece(piece_no0, to, promotion);
           dp.changed_piece[0].new_piece = evalList.bona_piece(piece_no0);
@@ -1160,6 +1160,10 @@ void Position::do_null_move(StateInfo& newSt) {
 
   st->key ^= Zobrist::side;
   prefetch(TT.first_entry(st->key));
+
+#if defined(EVAL_NNUE)
+  st->accumulator.computed_score = false;
+#endif
 
   ++st->rule50;
   st->pliesFromNull = 0;


### PR DESCRIPTION
nullmoveとpromotionの場合に評価値の差分計算と全計算の結果が異なっていたのを修正しました。
適当にデバッグログを入れてbenchコマンドを実行し、差分計算と全計算の差異が無くなったことを確認しました。

・nullmove
　やねうら王にあわせて、do_null_move()に「st->accumulator.computed_score = false;」を追加しました。

・promotion
　例えば2二のPawnが2一でQueenに成った場合、
　　old_pieceは「2二のPawn」
　　new_pieceは「2一のQueen」
　が正しい値かと思いますが、
　これまではold_pieceが「2一のPawn」になっていたようです。

　do_move()内のpromotionの処理のところで、old_pieceを上書きしている行をコメントアウトしました（old_pieceは既に設定済みの値のままでよさそうでしたので）。
　また、その上の行の「dp.pieceNo[0] = piece_no0;」は元々常に等しいようでしたので、ついでにコメントアウトしました。
