### PR TITLE
set_from_packed_sfen()でmirrorをepSquareにも適用するように修正

### DIFF
--- a/src/extra/sfen_packer.cpp
+++ b/src/extra/sfen_packer.cpp
@@ -371,6 +371,9 @@ int Position::set_from_packed_sfen(const PackedSfen& sfen , StateInfo * si, Thre
   // En passant square. Ignore if no pawn capture is possible
   if (stream.read_one_bit()) {
     Square ep_square = static_cast<Square>(stream.read_n_bit(6));
+    if (mirror) {
+      ep_square = Mir(ep_square);
+    }
     st->epSquare = ep_square;
 
     if (!(attackers_to(st->epSquare) & pieces(sideToMove, PAWN))


### PR DESCRIPTION
set_from_packed_sfen()でmirrorをepSquareにも適用するように修正しました。
手元で少し学習を回してみました限りでは、learnコマンド実行時にqsearchのpvにillegal moveが含まれる旨ログ出力されるのはmirrorありの場合だけだったため、mirror処理を少し疑ってみました次第です。
もしかするとcastlingRightsにもmirrorを適用しなければならない可能性もあるかもしれませんが、私の理解が及んでおりません...
