### PR TITLE
OpenMPの有効化

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -557,7 +557,7 @@ nnue-learn: config-sanity
 	$(MAKE) CXXFLAGS='$(CXXFLAGS) -DEVAL_LEARN -DEVAL_NNUE -DUSE_EVAL_HASH -DUSE_AVX2 -DUSE_SSE2' build
 
 nnue-learn-use-blas: config-sanity
-	$(MAKE) CXXFLAGS='$(CXXFLAGS) -DEVAL_LEARN -DEVAL_NNUE -DUSE_EVAL_HASH -DUSE_AVX2 -DUSE_SSE2 -DUSE_BLAS -I/mingw64/include/OpenBLAS' LDFLAGS='$(LDFLAGS) -lopenblas' build
+	$(MAKE) CXXFLAGS='$(CXXFLAGS) -DEVAL_LEARN -DEVAL_NNUE -DUSE_EVAL_HASH -DUSE_AVX2 -DUSE_SSE2 -DUSE_BLAS -I/mingw64/include/OpenBLAS -fopenmp' LDFLAGS='$(LDFLAGS) -lopenblas -fopenmp' build
 
 .depend:
 	-@$(CXX) $(DEPENDFLAGS) -MM $(OBJS:.o=.cpp) > $@ 2> /dev/null


### PR DESCRIPTION
こんばんは。
Stockfish + NNUE、早速コンピュータチェスの開発者の方が学習を開始されたようです！
http://talkchess.com/forum3/viewtopic.php?f=2&t=74059&start=10
https://groups.google.com/forum/#!topic/fishcooking/UnLEeExddxY
ただ、"Warning! OpenMP disabled." が出力されていて遅いとのことです。
Makefileを見ますと、OpenBLASの方は有効化されていましたが、OpenMPの方は有効化されていないようでしたので、有効化してみました。
※今このコメントを書いていて気付いたのですが、このプルリクエストでは-fopenmpをnnue-learn-use-blasにだけ追加したのですが、nnue-gen-sfen-from-original-eval等にも追加した方がよかったかもしれません...
