### PR TITLE
eval_nnueコマンド追加

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -35,6 +35,8 @@ Value evaluate(const Position& pos);
 
 void evaluate_with_no_return(const Position& pos);
 
+Value compute_eval(const Position& pos);
+
 #if defined(EVAL_NNUE) || defined(EVAL_LEARN)
 // 評価関数ファイルを読み込む。
 // これは、"is_ready"コマンドの応答時に1度だけ呼び出される。2度呼び出すことは想定していない。

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -400,6 +400,10 @@ void UCI::loop(int argc, char* argv[]) {
 
 #endif
 
+#if defined(EVAL_NNUE)
+      else if (token == "eval_nnue") sync_cout << "eval_nnue = " << Eval::compute_eval(pos) << sync_endl;
+#endif
+
 #if defined(EVAL_NNUE) && defined(ENABLE_TEST_CMD)
       // テストコマンド
       else if (token == "test") test_cmd(pos, is);


### PR DESCRIPTION
こんばんは。
Discordの#sf-nnue-devで

> Does SF NNUE have a way to show the static eval for a specific position? No search, just eval

と話題にあがっていましたので、eval_nnueコマンドを追加してみました。
