### PR TITLE
Adding mm_malloc.h

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -29,6 +29,7 @@
 #include <ostream>
 #include <string>
 #include <vector>
+#include <mm_malloc.h>
 
 #include "types.h"
 #include "thread_win32_osx.h"


### PR DESCRIPTION
Otherwise compiling with 'modern' or 'avx2' architecture on Linux aborts with errors.