### PR TITLE
"nn.bin found & loaded" 

### DIFF
--- a/src/eval/nnue/architectures/halfkp-cr-ep_256x2-32-32.h
+++ b/src/eval/nnue/architectures/halfkp-cr-ep_256x2-32-32.h
@@ -1,5 +1,8 @@
 // NNUE評価関数で用いる入力特徴量とネットワーク構造の定義
 
+#ifndef HALFKP_CR_EP_256X2_32_32_H
+#define HALFKP_CR_EP_256X2_32_32_H
+
 #include "../features/feature_set.h"
 #include "../features/half_kp.h"
 #include "../features/castling_right.h"
@@ -36,3 +39,4 @@ namespace Eval {
   }  // namespace NNUE
 
 }  // namespace Eval
+#endif // HALFKP_CR_EP_256X2_32_32_H

--- a/src/eval/nnue/architectures/halfkp_256x2-32-32.h
+++ b/src/eval/nnue/architectures/halfkp_256x2-32-32.h
@@ -1,5 +1,8 @@
 ﻿// NNUE評価関数で用いる入力特徴量とネットワーク構造の定義
 
+#ifndef HALFKP_256X2_32_32_H
+#define HALFKP_256X2_32_32_H
+
 #include "../features/feature_set.h"
 #include "../features/half_kp.h"
 
@@ -33,3 +36,4 @@ using Network = Layers::OutputLayer;
 }  // namespace NNUE
 
 }  // namespace Eval
+#endif // HALFKP_256X2_32_32_H

--- a/src/eval/nnue/architectures/k-p-cr-ep_256x2-32-32.h
+++ b/src/eval/nnue/architectures/k-p-cr-ep_256x2-32-32.h
@@ -1,5 +1,8 @@
 // NNUE評価関数で用いる入力特徴量とネットワーク構造の定義
 
+#ifndef K_P_CR_EP_256X2_32_32_H
+#define K_P_CR_EP_256X2_32_32_H
+
 #include "../features/feature_set.h"
 #include "../features/k.h"
 #include "../features/p.h"
@@ -36,3 +39,4 @@ namespace Eval {
   }  // namespace NNUE
 
 }  // namespace Eval
+#endif // K_P_CR_EP_256X2_32_32_H

--- a/src/eval/nnue/architectures/k-p-cr_256x2-32-32.h
+++ b/src/eval/nnue/architectures/k-p-cr_256x2-32-32.h
@@ -1,5 +1,8 @@
 // NNUE評価関数で用いる入力特徴量とネットワーク構造の定義
 
+#ifndef K_P_CR_256X2_32_32_H
+#define K_P_CR_256X2_32_32_H
+
 #include "../features/feature_set.h"
 #include "../features/k.h"
 #include "../features/p.h"
@@ -35,3 +38,4 @@ namespace Eval {
   }  // namespace NNUE
 
 }  // namespace Eval
+#endif // K_P_CR_256X2_32_32_H

--- a/src/eval/nnue/architectures/k-p_256x2-32-32.h
+++ b/src/eval/nnue/architectures/k-p_256x2-32-32.h
@@ -1,4 +1,6 @@
 ﻿// NNUE評価関数で用いる入力特徴量とネットワーク構造の定義
+#ifndef K_P_256X2_32_32_H
+#define K_P_256X2_32_32_H
 
 #include "../features/feature_set.h"
 #include "../features/k.h"
@@ -33,3 +35,4 @@ using Network = Layers::OutputLayer;
 }  // namespace NNUE
 
 }  // namespace Eval
+#endif // K_P_256X2_32_32_H

--- a/src/eval/nnue/evaluate_nnue.cpp
+++ b/src/eval/nnue/evaluate_nnue.cpp
@@ -250,10 +250,14 @@ void load_eval() {
 	if (!result)
 	{
 		// 読み込みエラーのとき終了してくれないと困る。
-		std::cout << "Error! : failed to read " << NNUE::kFileName << std::endl;
-		my_exit();
+		std::cout << "Error! " << NNUE::kFileName << " not found or wrong format" << std::endl;
+		//my_exit();
 	}
+	else
+	  std::cout << "info string NNUE " << NNUE::kFileName << " found & loaded" << std::endl;
   }
+  else
+    std::cout << "info string NNUE " << NNUE::kFileName << " not loaded" << std::endl;
 }
 
 // 初期化


### PR DESCRIPTION
Use "nn.bin found & loaded" or "nn.bin not loaded" (file not found, read error, or UCI option SkipLoadingEval true)
Also, print "Error! nn.bin not found or wrong format" and continue...instead of exiting the program (looks like a crash).