### PR TITLE
Stalemate fix

### DIFF
--- a/src/learn/learner.cpp
+++ b/src/learn/learner.cpp
@@ -504,16 +504,24 @@ void MultiThinkGenSfen::thread_worker(size_t thread_id)
 			}
 
       if (pos.is_draw(ply)) {
-        // Do not write if draw.
-        break;
+#if defined (LEARN_GENSFEN_USE_DRAW_RESULT)
+          flush_psv(0);
+#endif
+          // Do not write if draw.
+          break;
       }
 
 			// 全駒されて詰んでいたりしないか？
-			if (MoveList<LEGAL>(pos).size() == 0)
+			if (MoveList<LEGAL>(pos).size() == 0) // Can be mate or stalemate
 			{
         // (この局面の一つ前の局面までは書き出す)
         // Write the positions other than this position if checkmated.
-        flush_psv(-1);
+                if (pos.checkers()) // Mate
+                    flush_psv(-1);
+#if defined (LEARN_GENSFEN_USE_DRAW_RESULT)
+                else                // Stalemate
+                    flush_psv(0);
+#endif
 				break;
 			}
 
@@ -578,7 +586,7 @@ void MultiThinkGenSfen::thread_worker(size_t thread_id)
         if (pos.is_draw(0)) {
 #if defined	(LEARN_GENSFEN_USE_DRAW_RESULT)
           // 引き分けを書き出すとき
-          flush_psv(is_win);
+          flush_psv(0);
 #endif
           break;
         }

--- a/src/types.h
+++ b/src/types.h
@@ -40,6 +40,7 @@
 
 #include <cassert>
 #include <cctype>
+#include <climits>
 #include <cstdint>
 #include <cstdlib>
 #include <algorithm>


### PR DESCRIPTION
This fixes a possible bug in learner.cpp.

A position with no legal moves for the side-to-move can either be mate (if the side-to-move is in check) or stalemate.
We simply look for checking pieces to know if the side-to-move is being checked or not.

Also re-add an include in types.h which was deleted upstream.