### PR TITLE
Add SSE41 switch.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -389,7 +389,7 @@ endif
 ifeq ($(sse41),yes)
 	CXXFLAGS += -DUSE_SSE41
 	ifeq ($(comp),$(filter $(comp),gcc clang mingw msys2))
-		CXXFLAGS += -msse4
+		CXXFLAGS += -msse4.1
 	endif
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -386,6 +386,13 @@ ifeq ($(avx2),yes)
 	endif
 endif
 
+ifeq ($(sse41),yes)
+	CXXFLAGS += -DUSE_SSE41
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw msys2))
+		CXXFLAGS += -msse4
+	endif
+endif
+
 ### 3.7 pext
 ifeq ($(pext),yes)
 	CXXFLAGS += -DUSE_PEXT


### PR DESCRIPTION
This allows building modern compiles with SSE41 enabled,
which gives a nice speedup on my Bulldozer CPU.

For example:
make nnue ARCH=x86-64-modern sse41=yes -j