### PR TITLE
Rework loading the net after receiving 'ucinewgame'

### DIFF
--- a/src/eval/nnue/evaluate_nnue.cpp
+++ b/src/eval/nnue/evaluate_nnue.cpp
@@ -233,31 +233,27 @@ void prefetch_evalhash(const Key key) {
 // Save and restore Options with bench command etc., so EvalDir is changed at this time,
 // This function may be called twice to flag that the evaluation function needs to be reloaded.
 void load_eval() {
+
+  if (Options["SkipLoadingEval"])
+  {
+      std::cout << "info string SkipLoadingEval set to true, Net not loaded!" << std::endl;
+      return;
+  }
+
   NNUE::Initialize();
 
-  if (!Options["SkipLoadingEval"])
-  {
-    const std::string dir_name = Options["EvalDir"];
-    const std::string file_name = Path::Combine(dir_name, NNUE::kFileName);
-    //{
-    //  std::ofstream stream(file_name, std::ios::binary);
-    //  NNUE::WriteParameters(stream);
-    //}
-    std::ifstream stream(file_name, std::ios::binary);
-    const bool result = NNUE::ReadParameters(stream);
+  const std::string dir_name = Options["EvalDir"];
+  const std::string file_name = Path::Combine(dir_name, NNUE::kFileName);
 
-//    ASSERT(result);
-	if (!result)
-	{
-		// It's a problem if it doesn't finish when there is a read error.
-		std::cout << "Error! " << NNUE::kFileName << " not found or wrong format" << std::endl;
-		//my_exit();
-	}
-	else
-	  std::cout << "info string NNUE " << NNUE::kFileName << " found & loaded" << std::endl;
-  }
+  std::ifstream stream(file_name, std::ios::binary);
+  const bool result = NNUE::ReadParameters(stream);
+
+  if (!result)
+      // It's a problem if it doesn't finish when there is a read error.
+      std::cout << "Error! " << NNUE::kFileName << " not found or wrong format" << std::endl;
+
   else
-    std::cout << "info string NNUE " << NNUE::kFileName << " not loaded" << std::endl;
+      std::cout << "info string NNUE " << NNUE::kFileName << " found & loaded" << std::endl;
 }
 
 // Initialization

--- a/src/learn/learner.cpp
+++ b/src/learn/learner.cpp
@@ -3092,7 +3092,7 @@ void learn(Position&, istringstream& is)
 	//}
 	if (use_convert_bin)
 	{
-	  	is_ready(true);
+	  	init_nnue(true);
 		cout << "convert_bin.." << endl;
 		convert_bin(filenames,output_file_name, ply_minimum, ply_maximum, interpolate_eval);
 		return;
@@ -3100,7 +3100,7 @@ void learn(Position&, istringstream& is)
 	}
 	if (use_convert_bin_from_pgn_extract)
 	{
-		is_ready(true);
+		init_nnue(true);
 		cout << "convert_bin_from_pgn-extract.." << endl;
 		convert_bin_from_pgn_extract(filenames, output_file_name, pgn_eval_side_to_move);
 		return;
@@ -3166,7 +3166,7 @@ void learn(Position&, istringstream& is)
 	cout << "init.." << endl;
 
 	// Read evaluation function parameters
-	is_ready(true);
+	init_nnue(true);
 
 #if !defined(EVAL_NNUE)
 	cout << "init_grad.." << endl;

--- a/src/learn/multi_think.cpp
+++ b/src/learn/multi_think.cpp
@@ -20,7 +20,7 @@ void MultiThink::go_think()
 	// Read evaluation function, etc.
 	// In the case of the learn command, the value of the evaluation function may be corrected after reading the evaluation function, so
 	// Skip memory corruption check.
-	is_ready(true);
+	init_nnue(true);
 
 	// Call the derived class's init().
 	init();

--- a/src/uci.h
+++ b/src/uci.h
@@ -87,7 +87,7 @@ extern UCI::OptionsMap Options;
 // If skipCorruptCheck == true, skip memory corruption check by check sum when reading the evaluation function a second time.
 // * This function is inconvenient if it is not available in Stockfish, so add it.
 
-void is_ready(bool skipCorruptCheck = false);
+void init_nnue(bool skipCorruptCheck = false);
 
 extern const char* StartFEN;
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -42,7 +42,7 @@ void on_hash_size(const Option& o) { TT.resize(size_t(o)); }
 void on_logger(const Option& o) { start_logger(o); }
 void on_threads(const Option& o) { Threads.set(size_t(o)); }
 void on_tb_path(const Option& o) { Tablebases::init(o); }
-void on_eval_dir(const Option& o) { load_eval_finished = false; }
+void on_eval_dir(const Option& o) { load_eval_finished = false; init_nnue(); }
 
 
 /// Our case insensitive less() function as required by UCI protocol


### PR DESCRIPTION
instead of 'isready' command. This addresses #28 

**Main changes:**

- is_ready() renamed to init_nnue() and simplified, all calls to is_ready() replaced accordingly. There is no need to send empty lines which will at best be simply ignored. TT.resize() is automatically executed after a "setoption name Hash value xxx" anyway, and Search::clear() is done after "ucinewgame".
- The net will now be loaded after "ucinewgame", if necessary, and always after changing `EvalDir`.
- init_nnue() now included in both, the bench command and in the main UCI loop after receiving "ucinewgame" command. This will allow to do profile-builds with the NNUE net loaded.