### PR TITLE
UCI option EvalFile

### DIFF
--- a/src/eval/nnue/evaluate_nnue.cpp
+++ b/src/eval/nnue/evaluate_nnue.cpp
@@ -23,7 +23,7 @@ AlignedPtr<FeatureTransformer> feature_transformer;
 AlignedPtr<Network> network;
 
 // Evaluation function file name
-const char* const kFileName = "nn.bin";
+const char* kFileName = "eval\\nn.bin";
 
 // Get a string that represents the structure of the evaluation function
 std::string GetArchitectureString() {
@@ -243,8 +243,8 @@ void load_eval() {
       return;
   }
 
-  const std::string dir_name = Options["EvalDir"];
-  const std::string file_name = Path::Combine(dir_name, NNUE::kFileName);
+  const std::string file_name = Options["EvalFile"];
+  NNUE::kFileName = file_name.c_str();
 
   std::ifstream stream(file_name, std::ios::binary);
   const bool result = NNUE::ReadParameters(stream);

--- a/src/eval/nnue/evaluate_nnue.cpp
+++ b/src/eval/nnue/evaluate_nnue.cpp
@@ -23,7 +23,7 @@ AlignedPtr<FeatureTransformer> feature_transformer;
 AlignedPtr<Network> network;
 
 // Evaluation function file name
-const char* kFileName = "eval\\nn.bin";
+std::string fileName = "eval\\nn.bin";
 
 // Get a string that represents the structure of the evaluation function
 std::string GetArchitectureString() {
@@ -244,17 +244,17 @@ void load_eval() {
   }
 
   const std::string file_name = Options["EvalFile"];
-  NNUE::kFileName = file_name.c_str();
+  NNUE::fileName = file_name;
 
   std::ifstream stream(file_name, std::ios::binary);
   const bool result = NNUE::ReadParameters(stream);
 
   if (!result)
       // It's a problem if it doesn't finish when there is a read error.
-      std::cout << "Error! " << NNUE::kFileName << " not found or wrong format" << std::endl;
+      std::cout << "Error! " << NNUE::fileName << " not found or wrong format" << std::endl;
 
   else
-      std::cout << "info string NNUE " << NNUE::kFileName << " found & loaded" << std::endl;
+      std::cout << "info string NNUE " << NNUE::fileName << " found & loaded" << std::endl;
 }
 
 // Initialization

--- a/src/eval/nnue/evaluate_nnue.h
+++ b/src/eval/nnue/evaluate_nnue.h
@@ -36,7 +36,7 @@ extern AlignedPtr<FeatureTransformer> feature_transformer;
 extern AlignedPtr<Network> network;
 
 // Evaluation function file name
-extern const char* const kFileName;
+extern const char* kFileName;
 
 // Get a string that represents the structure of the evaluation function
 std::string GetArchitectureString();

--- a/src/eval/nnue/evaluate_nnue.h
+++ b/src/eval/nnue/evaluate_nnue.h
@@ -36,7 +36,7 @@ extern AlignedPtr<FeatureTransformer> feature_transformer;
 extern AlignedPtr<Network> network;
 
 // Evaluation function file name
-extern const char* kFileName;
+extern std::string fileName;
 
 // Get a string that represents the structure of the evaluation function
 std::string GetArchitectureString();

--- a/src/eval/nnue/nnue_test_command.cpp
+++ b/src/eval/nnue/nnue_test_command.cpp
@@ -190,7 +190,7 @@ void TestCommand(Position& pos, std::istream& stream) {
   } else {
     std::cout << "usage:" << std::endl;
     std::cout << " test nnue test_features" << std::endl;
-    std::cout << " test nnue info [path/to/" << kFileName << "...]" << std::endl;
+    std::cout << " test nnue info [path/to/" << fileName << "...]" << std::endl;
   }
 }
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -42,7 +42,7 @@ void on_hash_size(const Option& o) { TT.resize(size_t(o)); }
 void on_logger(const Option& o) { start_logger(o); }
 void on_threads(const Option& o) { Threads.set(size_t(o)); }
 void on_tb_path(const Option& o) { Tablebases::init(o); }
-void on_eval_dir(const Option& o) { load_eval_finished = false; init_nnue(); }
+void on_eval_file(const Option& o) { load_eval_finished = false; init_nnue(); }
 
 
 /// Our case insensitive less() function as required by UCI protocol
@@ -80,12 +80,12 @@ void init(OptionsMap& o) {
   o["SyzygyProbeDepth"]      << Option(1, 1, 100);
   o["Syzygy50MoveRule"]      << Option(true);
   o["SyzygyProbeLimit"]      << Option(7, 0, 7);
-  // Evaluation function folder. When this is changed, it is necessary to reread the evaluation function at the next isready timing.
-  o["EvalDir"]               << Option("eval", on_eval_dir);
-  // When the evaluation function is loaded at the isready timing, it is necessary to convert the new evaluation function.
+  // Evaluation function file name. When this is changed, it is necessary to reread the evaluation function at the next ucinewgame timing.
+  o["EvalFile"]              << Option("eval\\nn.bin", on_eval_file);
+  // When the evaluation function is loaded at the ucinewgame timing, it is necessary to convert the new evaluation function.
   // I want to hit the test eval convert command, but there is no new evaluation function
   // It ends abnormally before executing this command.
-  // Therefore, with this hidden option, you can suppress the loading of the evaluation function when isready,
+  // Therefore, with this hidden option, you can suppress the loading of the evaluation function when ucinewgame,
   // Hit the test eval convert command.
   o["SkipLoadingEval"]       << Option(false);
   // how many moves to use a fixed move


### PR DESCRIPTION
Replace EvalDir with EvalFile
User can now browse filesystem for net (eval\nn.bin is default)
nn.bin no longer const