### PR TITLE
Default network path in Linux.

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -81,7 +81,11 @@ void init(OptionsMap& o) {
   o["Syzygy50MoveRule"]      << Option(true);
   o["SyzygyProbeLimit"]      << Option(7, 0, 7);
   // Evaluation function file name. When this is changed, it is necessary to reread the evaluation function at the next ucinewgame timing.
+#if defined(__linux__)
+  o["EvalFile"]              << Option("eval/nn.bin", on_eval_file);
+#else
   o["EvalFile"]              << Option("eval\\nn.bin", on_eval_file);
+#endif
   // When the evaluation function is loaded at the ucinewgame timing, it is necessary to convert the new evaluation function.
   // I want to hit the test eval convert command, but there is no new evaluation function
   // It ends abnormally before executing this command.


### PR DESCRIPTION
Not sure how it is with Mac and Android, but for Linux in general `eval\nn.bin` as default path doesn't work.