### PR TITLE
Saving new network in correct path.

### DIFF
--- a/src/eval/nnue/evaluate_nnue.cpp
+++ b/src/eval/nnue/evaluate_nnue.cpp
@@ -23,7 +23,10 @@ AlignedPtr<FeatureTransformer> feature_transformer;
 AlignedPtr<Network> network;
 
 // Evaluation function file name
-std::string fileName = "eval\\nn.bin";
+std::string fileName = "nn.bin";
+
+// Saved evaluation function file name
+std::string savedfileName = "nn.bin";
 
 // Get a string that represents the structure of the evaluation function
 std::string GetArchitectureString() {

--- a/src/eval/nnue/evaluate_nnue.h
+++ b/src/eval/nnue/evaluate_nnue.h
@@ -38,6 +38,9 @@ extern AlignedPtr<Network> network;
 // Evaluation function file name
 extern std::string fileName;
 
+// Saved evaluation function file name
+extern std::string savedfileName;
+
 // Get a string that represents the structure of the evaluation function
 std::string GetArchitectureString();
 

--- a/src/eval/nnue/evaluate_nnue_learner.cpp
+++ b/src/eval/nnue/evaluate_nnue_learner.cpp
@@ -213,7 +213,7 @@ void save_eval(std::string dir_name) {
     NNUE::SendMessages({{"clear_unobserved_feature_weights"}});
   }
 
-  const std::string file_name = NNUE::fileName;
+  const std::string file_name = Path::Combine(eval_dir, NNUE::savedfileName);
   std::ofstream stream(file_name, std::ios::binary);
   const bool result = NNUE::WriteParameters(stream);
   assert(result);


### PR DESCRIPTION
Currently there's a confusion between loaded network files and new network files that are saved after learning in path given by "EvalSaveDir". New network files are written in the path of loaded network files, overwriting them.

This PR corrects the issue, new network files are now saved as "nn.bin" in folder EvalSaveDir, old network is not overwritten.

Tested in both cases:
1) Training with `setoption name SkipLoadingEval value true`,
2) training with `setoption name SkipLoadingEval value false` and `setoption name EvalFile value oldnetwork/nn.bin`