### PR TITLE
Use the path and filename for restoring parameter files.

### DIFF
--- a/src/eval/nnue/evaluate_nnue_learner.cpp
+++ b/src/eval/nnue/evaluate_nnue_learner.cpp
@@ -110,7 +110,7 @@ void SetOptions(const std::string& options) {
 
 // Reread the evaluation function parameters for learning from the file
 void RestoreParameters(const std::string& dir_name) {
-  const std::string file_name = NNUE::fileName;
+  const std::string file_name = Path::Combine(dir_name, NNUE::savedfileName);
   std::ifstream stream(file_name, std::ios::binary);
   bool result = ReadParameters(stream);
   assert(result);


### PR DESCRIPTION
This fixes #48 