### PR TITLE
Add AVX512 support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -87,6 +87,7 @@ endif
 # sse42 = yes/no      --- -msse4.2         --- Use Intel Streaming SIMD Extensions 4.2
 # avx2 = yes/no       --- -mavx2           --- Use Intel Advanced Vector Extensions 2
 # pext = yes/no       --- -DUSE_PEXT       --- Use pext x86_64 asm-instruction
+# avx512 = yes/no     --- -mavx512vbmi     --- Use Intel Advanced Vector Extensions 512
 #
 # Note that Makefile is space sensitive, so when adding new architectures
 # or modifying existing flags, you have to make sure there are no extra spaces
@@ -105,6 +106,7 @@ sse41 = no
 sse42 = no
 avx2 = no
 pext = no
+avx512 = no
 
 ### 2.2 Architecture specific
 ifeq ($(ARCH),general-32)
@@ -181,6 +183,20 @@ ifeq ($(ARCH),x86-64-bmi2)
 	sse42 = yes
 	avx2 = yes
 	pext = yes
+endif
+
+ifeq ($(ARCH),x86-64-avx512)
+	arch = x86_64
+	bits = 64
+	prefetch = yes
+	popcnt = yes
+	sse = yes
+	ssse3 = yes
+	sse41 = yes
+	sse42 = yes
+	avx2 = yes
+	pext = yes
+	avx512 = yes
 endif
 
 ifeq ($(ARCH),armv7)
@@ -407,7 +423,14 @@ endif
 ifeq ($(avx2),yes)
 	CXXFLAGS += -DUSE_AVX2
 	ifeq ($(comp),$(filter $(comp),gcc clang mingw msys2))
-		CXXFLAGS += -mavx2
+	CXXFLAGS += -mavx2
+	endif
+endif
+
+ifeq ($(avx512),yes)
+	CXXFLAGS += -DUSE_AVX512
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw msys2))
+	CXXFLAGS += -mavx512vbmi
 	endif
 endif
 
@@ -493,6 +516,7 @@ help:
 	@echo ""
 	@echo "Supported archs:"
 	@echo ""
+	@echo "x86-64-avx512           > x86 64-bit with avx512 support"
 	@echo "x86-64-bmi2             > x86 64-bit with bmi2 support"
 	@echo "x86-64-avx2             > x86 64-bit with avx2 support"
 	@echo "x86-64-sse42            > x86 64-bit with sse42 support"
@@ -599,6 +623,7 @@ config-sanity:
 	@echo "sse42: '$(sse42)'"
 	@echo "avx2: '$(avx2)'"
 	@echo "pext: '$(pext)'"
+	@echo "avx512: '$(avx512)'"
 	@echo ""
 	@echo "Flags:"
 	@echo "CXX: $(CXX)"
@@ -622,6 +647,7 @@ config-sanity:
 	@test "$(sse42)" = "yes" || test "$(sse42)" = "no"
 	@test "$(avx2)" = "yes" || test "$(avx2)" = "no"
 	@test "$(pext)" = "yes" || test "$(pext)" = "no"
+	@test "$(avx512)" = "yes" || test "$(avx512)" = "no"
 	@test "$(comp)" = "gcc" || test "$(comp)" = "icc" || test "$(comp)" = "mingw" || test "$(comp)" = "clang"
 
 $(EXE): $(OBJS)


### PR DESCRIPTION
Hi @nodchip 

I'm a SF dev and very happy that you started the SFNNUE project.  If I may contribute here is a patch that adds AVX512 support.
I get a 4% speed up over AVX2.

```
Results for 40 tests for each version:

            Base      Test      Diff      
    Mean    1310045   1363423   -53378    
    StDev   36898     46420     49766     

p-value: 0.858
speedup: 0.041
```

I didn't change kMaxSimdWidth from 32 to 64 because the padding is currently written out with the saved nets
and this would break reading existing nets that were saved with 32.  As a result there is a bit of extra code to handle cases that are not multiples of 64.  Once reading/writing the nets can handle different kMaxSimdWidth values this code can be removed.

Regarding the #if defined(\__MINGW32\__) || defined(\__MINGW64\__)
I would have done it in the same style as in the AVX2 section but unfortunately 
_mm512_maddubs_epi16 is declared differently than _mm256_maddubs_epi16 and
MSVC gives errors unless I split the statements completely.  If you like I can do the same
for the AVX2 case for consistency and maybe it is a bit easier to read as well?

I also changed
__m256i sum = mm256_set_epi32(0, 0, 0, 0, 0, 0, 0, biases[i]);
to
__m256i sum = mm256_setzero_si256();
in the AVX2 section because it's a bit more efficient and the biases[i] doesn't benefit from being vectorized.
If you don't like it feel free to ignore that part of course.

Please let me know if there is anything else you need me to do. 
Thanks!  Fisherman

bench: 3909820