### PR TITLE
Fix profile builds for AVX512

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -459,7 +459,7 @@ endif
 ifeq ($(avx512),yes)
 	CXXFLAGS += -DUSE_AVX512
 	ifeq ($(comp),$(filter $(comp),gcc clang mingw msys2))
-		CXXFLAGS += -mavx512vbmi
+		CXXFLAGS += -mavx512bw
 	endif
 endif
 


### PR DESCRIPTION
Tested on Windows gcc/mingw using
make profile-build ARCH=x86-64-avx512  -j
and
make profile-build ARCH=x86-64-avx512  COMP=mingw -j

I don't have access to a suitable Linux machine.