### PR TITLE
Improve AVX512 support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -459,7 +459,7 @@ endif
 ifeq ($(avx512),yes)
 	CXXFLAGS += -DUSE_AVX512
 	ifeq ($(comp),$(filter $(comp),gcc clang mingw msys2))
-		CXXFLAGS += -mavx512bw
+		CXXFLAGS += -mavx512f -mavx512bw -mavx512cd -mavx512dq -mavx512vl
 	endif
 endif
 


### PR DESCRIPTION
- Simplify code and optimize AVX512 implementation.   I also tweaked the USE_AVX2 and USE_SSSE3 sections a little just to keep them all more consistent.

- Enable all lowest common denominator(Skylake) avx512 instructions in the Makefile.
Nice reference here: https://en.wikichip.org/wiki/x86/avx-512

I get another 1% speedup for a total of 5% over AVX2.  This holds when comparing both non PGO and PGO builds.
(PGO is 2% faster than non PGO in both cases.)  Tested on Windows gcc/mingw version 10.1.0 single threaded on Skylake-X.

bench: 3909820