### PR TITLE
Add AVX2 and AVX512 to engine info printed at startup

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -149,7 +149,13 @@ const string engine_info(bool to_uci) {
   }
 
   ss << (Is64Bit ? " 64" : "")
+#if defined(USE_AVX512)
+     << (HasPext ? " AVX512 BMI2" : " AVX512")
+#elif defined(USE_AVX2)
+     << (HasPext ? " AVX2 BMI2" : " AVX2")
+#else
      << (HasPext ? " BMI2" : (HasPopCnt ? " POPCNT" : ""))
+#endif
      << (to_uci  ? "\nid author ": " by ")
      << "T. Romstad, M. Costalba, J. Kiiski, G. Linscott, H. Noda, Y. Nasu, M. Isozaki";
 


### PR DESCRIPTION
Helps to identify the type of binary.  More could be added but I don't know how fine grained you want to go with this.