### PR TITLE
10% to 15% speedups(depending on platform)

### DIFF
--- a/src/eval/nnue/layers/affine_transform.h
+++ b/src/eval/nnue/layers/affine_transform.h
@@ -79,6 +79,19 @@ class AffineTransform {
   // forward propagation
   const OutputType* Propagate(
       const TransformedFeatureType* transformed_features, char* buffer) const {
+#if (defined(__MINGW32__) || defined(__MINGW64__)) && defined(USE_AVX2)
+// HACK: Use _mm256_loadu_si256() instead of _mm256_load_si256. Because the binary
+//       compiled with g++ in MSYS2 crashes here because the output memory is not aligned
+//       even though alignas is specified.
+#define _mm256_loadAU_si256 _mm256_loadu_si256
+#else
+#define _mm256_loadAU_si256 _mm256_load_si256
+#endif
+#if (defined(__MINGW32__) || defined(__MINGW64__)) && defined(USE_AVX512)
+#define _mm512_loadAU_si512 _mm512_loadu_si512
+#else
+#define _mm512_loadAU_si512 _mm512_load_si512
+#endif
     const auto input = previous_layer_.Propagate(
         transformed_features, buffer + kSelfBufferSize);
     const auto output = reinterpret_cast<OutputType*>(buffer);
@@ -103,72 +116,66 @@ class AffineTransform {
 #if defined(USE_AVX512)
       __m512i sum = _mm512_setzero_si512();
       const auto row = reinterpret_cast<const __m512i*>(&weights_[offset]);
-      for (IndexType j = 0; j < kNumChunks; ++j) {
-#if defined(__MINGW32__) || defined(__MINGW64__)
-          __m512i product = _mm512_maddubs_epi16(_mm512_loadu_si512(&input_vector[j]), _mm512_load_si512(&row[j]));
-#else
-          __m512i product = _mm512_maddubs_epi16(_mm512_load_si512(&input_vector[j]), _mm512_load_si512(&row[j]));
-#endif
+      for (int j = 0; j < (int)kNumChunks - 1; j += 2) {
+          __m512i product0 = _mm512_maddubs_epi16(_mm512_loadAU_si512(&input_vector[j]), _mm512_load_si512(&row[j]));
+          __m512i product1 = _mm512_maddubs_epi16(_mm512_loadAU_si512(&input_vector[j+1]), _mm512_load_si512(&row[j+1]));
+          product0 = _mm512_adds_epi16(product0, product1);
+          product0 = _mm512_madd_epi16(product0, kOnes);
+          sum = _mm512_add_epi32(sum, product0);
+      }
+      if (kNumChunks & 0x1) {
+          __m512i product = _mm512_maddubs_epi16(_mm512_loadAU_si512(&input_vector[kNumChunks-1]), _mm512_load_si512(&row[kNumChunks-1]));
           product = _mm512_madd_epi16(product, kOnes);
           sum = _mm512_add_epi32(sum, product);
       }
-      output[i] = _mm512_reduce_add_epi32(sum) + biases_[i];
       
       // Note: Changing kMaxSimdWidth from 32 to 64 breaks loading existing networks.
       // As a result kPaddedInputDimensions may not be an even multiple of 64(512bit)
       // and we have to do one more 256bit chunk.
-      if (kPaddedInputDimensions != kNumChunks * kSimdWidth * 2)
-      {
-          const auto iv_256  = reinterpret_cast<const __m256i*>(input);
-          const auto row_256 = reinterpret_cast<const __m256i*>(&weights_[offset]);
-          int j = kNumChunks * 2;
-#if defined(__MINGW32__) || defined(__MINGW64__)  // See HACK comment below in AVX2.
-          __m256i sum256 = _mm256_maddubs_epi16(_mm256_loadu_si256(&iv_256[j]), _mm256_load_si256(&row_256[j]));
-#else
-          __m256i sum256 = _mm256_maddubs_epi16(_mm256_load_si256(&iv_256[j]), _mm256_load_si256(&row_256[j]));
-#endif
-          sum256 = _mm256_madd_epi16(sum256, _mm256_set1_epi16(1));
-
-          sum256 = _mm256_hadd_epi32(sum256, sum256);
-          sum256 = _mm256_hadd_epi32(sum256, sum256);
-          const __m128i lo = _mm256_extracti128_si256(sum256, 0);
-          const __m128i hi = _mm256_extracti128_si256(sum256, 1);
-          output[i] += _mm_cvtsi128_si32(lo) + _mm_cvtsi128_si32(hi);
+      if (kPaddedInputDimensions != kNumChunks * kSimdWidth * 2) {
+          const auto iv256  = reinterpret_cast<const __m256i*>(&input_vector[kNumChunks]);
+          const auto row256 = reinterpret_cast<const __m256i*>(&row[kNumChunks]);
+          __m256i product256 = _mm256_maddubs_epi16(_mm256_loadAU_si256(&iv256[0]), _mm256_load_si256(&row256[0]));
+          product256 = _mm256_madd_epi16(product256, _mm256_set1_epi16(1));
+          sum = _mm512_add_epi32(sum, _mm512_zextsi256_si512(product256));
       }
+      output[i] = _mm512_reduce_add_epi32(sum) + biases_[i];
 #elif defined(USE_AVX2)
       __m256i sum = _mm256_setzero_si256();
       const auto row = reinterpret_cast<const __m256i*>(&weights_[offset]);
-      for (IndexType j = 0; j < kNumChunks; ++j) {
-        __m256i product = _mm256_maddubs_epi16(
-#if defined(__MINGW32__) || defined(__MINGW64__)
-          // HACK: Use _mm256_loadu_si256() instead of _mm256_load_si256. Because the binary
-          //       compiled with g++ in MSYS2 crashes here because the output memory is not aligned
-          //       even though alignas is specified.
-          _mm256_loadu_si256
-#else
-          _mm256_load_si256
-#endif
-          (&input_vector[j]), _mm256_load_si256(&row[j]));
-        product = _mm256_madd_epi16(product, kOnes);
-        sum = _mm256_add_epi32(sum, product);
+      for (int j = 0; j < (int)kNumChunks - 1; j += 2) {
+          __m256i product0 = _mm256_maddubs_epi16(_mm256_loadAU_si256(&input_vector[j]), _mm256_load_si256(&row[j]));
+          __m256i product1 = _mm256_maddubs_epi16(_mm256_loadAU_si256(&input_vector[j+1]), _mm256_load_si256(&row[j+1]));
+          product0 = _mm256_adds_epi16(product0, product1);
+          product0 = _mm256_madd_epi16(product0, kOnes);
+          sum = _mm256_add_epi32(sum, product0);
+      }
+      if (kNumChunks & 0x1) {
+          __m256i product = _mm256_maddubs_epi16(_mm256_loadAU_si256(&input_vector[kNumChunks-1]), _mm256_load_si256(&row[kNumChunks-1]));
+          product = _mm256_madd_epi16(product, kOnes);
+          sum = _mm256_add_epi32(sum, product);
       }
       sum = _mm256_hadd_epi32(sum, sum);
       sum = _mm256_hadd_epi32(sum, sum);
-      const __m128i lo = _mm256_extracti128_si256(sum, 0);
-      const __m128i hi = _mm256_extracti128_si256(sum, 1);
-      output[i] = _mm_cvtsi128_si32(lo) + _mm_cvtsi128_si32(hi) + biases_[i];
+      output[i] = _mm256_extract_epi32(sum, 0) + _mm256_extract_epi32(sum, 4) + biases_[i];
 #elif defined(USE_SSSE3)
-      __m128i sum = _mm_cvtsi32_si128(biases_[i]);
+      __m128i sum = _mm_setzero_si128();
       const auto row = reinterpret_cast<const __m128i*>(&weights_[offset]);
-      for (IndexType j = 0; j < kNumChunks; ++j) {
-        __m128i product = _mm_maddubs_epi16(
-            _mm_load_si128(&input_vector[j]), _mm_load_si128(&row[j]));
+      for (int j = 0; j < (int)kNumChunks - 1; j += 2) {
+        __m128i product0 = _mm_maddubs_epi16(_mm_load_si128(&input_vector[j]), _mm_load_si128(&row[j]));
+        __m128i product1 = _mm_maddubs_epi16(_mm_load_si128(&input_vector[j+1]), _mm_load_si128(&row[j+1]));
+        product0 = _mm_adds_epi16(product0, product1);
+        product0 = _mm_madd_epi16(product0, kOnes);
+        sum = _mm_add_epi32(sum, product0);
+      }
+      if (kNumChunks & 0x1) {
+        __m128i product = _mm_maddubs_epi16(_mm_load_si128(&input_vector[kNumChunks-1]), _mm_load_si128(&row[kNumChunks-1]));
         product = _mm_madd_epi16(product, kOnes);
         sum = _mm_add_epi32(sum, product);
       }
       sum = _mm_hadd_epi32(sum, sum);
       sum = _mm_hadd_epi32(sum, sum);
-      output[i] = _mm_cvtsi128_si32(sum);
+      output[i] = _mm_cvtsi128_si32(sum) + biases_[i];
 #elif defined(IS_ARM)
       int32x4_t sum = {biases_[i]};
       const auto row = reinterpret_cast<const int8x8_t*>(&weights_[offset]);

--- a/src/eval/nnue/layers/affine_transform.h
+++ b/src/eval/nnue/layers/affine_transform.h
@@ -118,10 +118,11 @@ class AffineTransform {
       const auto row = reinterpret_cast<const __m512i*>(&weights_[offset]);
       for (int j = 0; j < (int)kNumChunks - 1; j += 2) {
           __m512i product0 = _mm512_maddubs_epi16(_mm512_loadAU_si512(&input_vector[j]), _mm512_load_si512(&row[j]));
-          __m512i product1 = _mm512_maddubs_epi16(_mm512_loadAU_si512(&input_vector[j+1]), _mm512_load_si512(&row[j+1]));
-          product0 = _mm512_adds_epi16(product0, product1);
           product0 = _mm512_madd_epi16(product0, kOnes);
           sum = _mm512_add_epi32(sum, product0);
+          __m512i product1 = _mm512_maddubs_epi16(_mm512_loadAU_si512(&input_vector[j+1]), _mm512_load_si512(&row[j+1]));
+          product1 = _mm512_madd_epi16(product1, kOnes);
+          sum = _mm512_add_epi32(sum, product1);
       }
       if (kNumChunks & 0x1) {
           __m512i product = _mm512_maddubs_epi16(_mm512_loadAU_si512(&input_vector[kNumChunks-1]), _mm512_load_si512(&row[kNumChunks-1]));
@@ -145,10 +146,11 @@ class AffineTransform {
       const auto row = reinterpret_cast<const __m256i*>(&weights_[offset]);
       for (int j = 0; j < (int)kNumChunks - 1; j += 2) {
           __m256i product0 = _mm256_maddubs_epi16(_mm256_loadAU_si256(&input_vector[j]), _mm256_load_si256(&row[j]));
-          __m256i product1 = _mm256_maddubs_epi16(_mm256_loadAU_si256(&input_vector[j+1]), _mm256_load_si256(&row[j+1]));
-          product0 = _mm256_adds_epi16(product0, product1);
           product0 = _mm256_madd_epi16(product0, kOnes);
           sum = _mm256_add_epi32(sum, product0);
+          __m256i product1 = _mm256_maddubs_epi16(_mm256_loadAU_si256(&input_vector[j+1]), _mm256_load_si256(&row[j+1]));
+          product1 = _mm256_madd_epi16(product1, kOnes);
+          sum = _mm256_add_epi32(sum, product1);
       }
       if (kNumChunks & 0x1) {
           __m256i product = _mm256_maddubs_epi16(_mm256_loadAU_si256(&input_vector[kNumChunks-1]), _mm256_load_si256(&row[kNumChunks-1]));
@@ -163,10 +165,11 @@ class AffineTransform {
       const auto row = reinterpret_cast<const __m128i*>(&weights_[offset]);
       for (int j = 0; j < (int)kNumChunks - 1; j += 2) {
         __m128i product0 = _mm_maddubs_epi16(_mm_load_si128(&input_vector[j]), _mm_load_si128(&row[j]));
-        __m128i product1 = _mm_maddubs_epi16(_mm_load_si128(&input_vector[j+1]), _mm_load_si128(&row[j+1]));
-        product0 = _mm_adds_epi16(product0, product1);
         product0 = _mm_madd_epi16(product0, kOnes);
         sum = _mm_add_epi32(sum, product0);
+        __m128i product1 = _mm_maddubs_epi16(_mm_load_si128(&input_vector[j+1]), _mm_load_si128(&row[j+1]));
+        product1 = _mm_madd_epi16(product1, kOnes);
+        sum = _mm_add_epi32(sum, product1);
       }
       if (kNumChunks & 0x1) {
         __m128i product = _mm_maddubs_epi16(_mm_load_si128(&input_vector[kNumChunks-1]), _mm_load_si128(&row[kNumChunks-1]));


### PR DESCRIPTION
Optimize and clean up SSSE3, AVX2, and AVX512 implementations of Propagate().
AVX512 10% faster
AVX2 13% faster
SSSE3 15% faster

This superseeds PR https://github.com/nodchip/Stockfish/pull/62
bench: 3909820

@nodchip I know you are not merging atm but I wanted to let people who compile their own binaries have access to this.
Thanks.

