### PR TITLE
Fix some uninitialized variables with gensfen

### DIFF
--- a/src/learn/gensfen.cpp
+++ b/src/learn/gensfen.cpp
@@ -1159,6 +1159,8 @@ namespace Learner
         // Show if the training data generator uses NNUE.
         Eval::verify_NNUE();
 
+        Threads.main()->ponder = false;
+
         // Create and execute threads as many as Options["Threads"].
         {
             SfenWriter sfen_writer(output_file_name, thread_num);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -2035,6 +2035,8 @@ namespace Learner
       th->completedDepth = 0;
       th->selDepth = 0;
       th->rootDepth = 0;
+      th->nmpMinPly = th->bestMoveChanges = 0;
+      th->ttHitAverage = TtHitAverageWindow * TtHitAverageResolution / 2;
 
 	  // Zero initialization of the number of search nodes
       th->nodes = 0;


### PR DESCRIPTION
fixes valgrind errors as seen with:

```
setoption name Use NNUE value true
isready
gensfen depth 6 loop 10 use_draw_in_training_data_generation 1 eval_limit 32000 output_file_name training_data/training_data.bin use_raw_nnue_eval 0
quit
```

the latter script now runs without valgrind errors on linux