### PR TITLE
Set the value of prune_at_shallow_depth_on_pv_node on a UCI option callback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-dist: bionic
+dist: focal
 
 matrix:
   include:
@@ -7,9 +7,9 @@ matrix:
       compiler: gcc
       addons:
         apt:
-          packages: ['g++-8', 'g++-8-multilib', 'g++-multilib', 'valgrind', 'expect', 'curl', 'libopenblas-dev']
+          packages: ['g++-multilib', 'valgrind', 'expect', 'curl', 'libopenblas-dev']
       env:
-        - COMPILER=g++-8
+        - COMPILER=g++
         - COMP=gcc
 
 #    - os: linux
@@ -68,18 +68,17 @@ script:
   # TODO avoid _mm_malloc
   # - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make clean && make -j2 ARCH=general-64 build && ../tests/signature.sh $benchref; fi
   # - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make clean && make -j2 ARCH=x86-32 optimize=no debug=yes build && ../tests/signature.sh $benchref; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make clean && make -j2 ARCH=x86-32-sse41-popcnt build && ../tests/signature.sh $benchref; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make clean && make -j2 ARCH=x86-32-sse2 build && ../tests/signature.sh $benchref; fi
+  - make clean && make -j2 ARCH=x86-32-sse41-popcnt build && ../tests/signature.sh $benchref
+  - make clean && make -j2 ARCH=x86-32-sse2 build && ../tests/signature.sh $benchref
   # TODO avoid _mm_malloc
   # - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make clean && make -j2 ARCH=x86-32 build && ../tests/signature.sh $benchref; fi
   # - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make clean && make -j2 ARCH=general-32 build && ../tests/signature.sh $benchref; fi
-  # workaround: exclude a custom version of llvm+clang, which doesn't find llvm-profdata on ubuntu
-  - if [[ "$TRAVIS_OS_NAME" != "linux" || "$COMP" == "gcc" ]]; then make clean && make -j2 ARCH=x86-64-modern profile-build && ../tests/signature.sh $benchref; fi
+  - make clean && make -j2 ARCH=x86-64-modern profile-build && ../tests/signature.sh $benchref
 
   # start some basic learner CI
-  - export CXXFLAGS="-Werror"
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make clean && LDFLAGS="-lstdc++fs" make -j2 ARCH=x86-64-modern learn; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make clean && LDFLAGS="-lstdc++fs" make -j2 ARCH=x86-64-modern profile-learn; fi
+  - make clean && make -j2 ARCH=x86-64-modern learn
+  - make clean && make -j2 ARCH=x86-64-modern profile-learn
+  - make clean && make -j2 ARCH=x86-64-modern debug=yes optimize=no learn
 
   # compile only for some more advanced architectures (might not run in travis)
   - make clean && make -j2 ARCH=x86-64-avx2 build
@@ -98,18 +97,16 @@ script:
   # Valgrind
   #
   - export CXXFLAGS="-O1 -fno-inline"
-  - if [ -x "$(command -v valgrind )" ]; then make clean && make -j2 ARCH=x86-64-modern debug=yes optimize=no build > /dev/null && ../tests/instrumented.sh --valgrind; fi
-  - if [ -x "$(command -v valgrind )" ]; then ../tests/instrumented.sh --valgrind-thread; fi
+  - make clean && make -j2 ARCH=x86-64-modern debug=yes optimize=no build > /dev/null && ../tests/instrumented.sh --valgrind
+  - ../tests/instrumented.sh --valgrind-thread
 
   #
   # Sanitizer
   #
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make clean && make -j2 ARCH=x86-64-modern sanitize=undefined optimize=no debug=yes build > /dev/null && ../tests/instrumented.sh --sanitizer-undefined; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make clean && make -j2 ARCH=x86-64-modern sanitize=thread    optimize=no debug=yes build > /dev/null && ../tests/instrumented.sh --sanitizer-thread; fi
+  - make clean && make -j2 ARCH=x86-64-modern sanitize=undefined optimize=no debug=yes build > /dev/null && ../tests/instrumented.sh --sanitizer-undefined
+  - make clean && make -j2 ARCH=x86-64-modern sanitize=thread    optimize=no debug=yes build > /dev/null && ../tests/instrumented.sh --sanitizer-thread
 
-  #
-  # NNUE testing / TODO should work with debug=yes as well
-  #
+  # NNUE testing
   - export CXXFLAGS="-O1 -fno-inline"
-  - if [ -x "$(command -v valgrind )" ]; then make clean && LDFLAGS="-lstdc++fs"  make -j2 ARCH=x86-64-modern debug=no optimize=no learn > /dev/null && ../tests/instrumented_learn.sh --valgrind; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make clean && LDFLAGS="-lstdc++fs"  make -j2 ARCH=x86-64-modern sanitize=undefined optimize=no debug=no learn > /dev/null && ../tests/instrumented_learn.sh --sanitizer-undefined; fi
+  - make clean && make -j2 ARCH=x86-64-modern debug=no optimize=no learn > /dev/null && ../tests/instrumented_learn.sh --valgrind
+  - make clean && make -j2 ARCH=x86-64-modern sanitize=undefined optimize=no debug=no learn > /dev/null && ../tests/instrumented_learn.sh --sanitizer-undefined

--- a/src/nnue/features/index_list.h
+++ b/src/nnue/features/index_list.h
@@ -50,7 +50,7 @@ namespace Eval::NNUE::Features {
     }
 
    private:
-    T values_[MaxSize];
+    T values_[MaxSize] = {};
     std::size_t size_ = 0;
   };
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -54,6 +54,10 @@ using std::string;
 using Eval::evaluate;
 using namespace Search;
 
+#if defined(EVAL_LEARN)
+bool Search::prune_at_shallow_depth_on_pv_node = false;
+#endif
+
 namespace {
 
   // Different node types, used as a template parameter
@@ -67,8 +71,6 @@ namespace {
   Value futility_margin(Depth d, bool improving) {
     return Value(223 * (d - improving));
   }
-
-  bool training;
 
   // Reductions lookup table, initialized at startup
   int Reductions[MAX_MOVES]; // [depth or moveNumber]
@@ -195,8 +197,6 @@ void Search::init() {
 
   for (int i = 1; i < MAX_MOVES; ++i)
       Reductions[i] = int((22.0 + std::log(Threads.size())) * std::log(i));
-
-  training = Options["Training"];
 }
 
 
@@ -1011,7 +1011,9 @@ moves_loop: // When in check, search starts from here
 
       // Step 12. Pruning at shallow depth (~200 Elo)
       if (  !rootNode
-          && !(training && PvNode)
+#ifdef EVAL_LEARN
+          && !(!prune_at_shallow_depth_on_pv_node && PvNode)
+#endif
           && pos.non_pawn_material(us)
           && bestValue > VALUE_TB_LOSS_IN_MAX_PLY)
       {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1012,7 +1012,7 @@ moves_loop: // When in check, search starts from here
       // Step 12. Pruning at shallow depth (~200 Elo)
       if (  !rootNode
 #ifdef EVAL_LEARN
-          && !(!prune_at_shallow_depth_on_pv_node && PvNode)
+          && (PvNode ? prune_at_shallow_depth_on_pv_node : true)
 #endif
           && pos.non_pawn_material(us)
           && bestValue > VALUE_TB_LOSS_IN_MAX_PLY)

--- a/src/search.h
+++ b/src/search.h
@@ -33,6 +33,10 @@ namespace Search {
 constexpr int CounterMovePruneThreshold = 0;
 
 
+#if defined(EVAL_LEARN)
+extern bool prune_at_shallow_depth_on_pv_node;
+#endif
+
 /// Stack struct keeps track of the information we need to remember from nodes
 /// shallower and deeper in the tree during the search. Each search thread has
 /// its own array of Stack objects, indexed by the current ply.

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -42,6 +42,11 @@ void on_threads(const Option& o) { Threads.set(size_t(o)); }
 void on_tb_path(const Option& o) { Tablebases::init(o); }
 void on_use_NNUE(const Option& ) { Eval::init_NNUE(); }
 void on_eval_file(const Option& ) { Eval::init_NNUE(); }
+#ifdef EVAL_LEARN
+void on_prune_at_shallow_depth_on_pv_node(const Option& o) {
+  Search::prune_at_shallow_depth_on_pv_node = o;
+}
+#endif
 
 /// Our case insensitive less() function as required by UCI protocol
 bool CaseInsensitiveLess::operator() (const string& s1, const string& s2) const {
@@ -69,7 +74,6 @@ void init(OptionsMap& o) {
   o["Move Overhead"]         << Option(10, 0, 5000);
   o["Slow Mover"]            << Option(100, 10, 1000);
   o["nodestime"]             << Option(0, 0, 10000);
-  o["Training"]              << Option(false);
   o["UCI_Chess960"]          << Option(false);
   o["UCI_AnalyseMode"]       << Option(false);
   o["UCI_LimitStrength"]     << Option(false);
@@ -96,6 +100,8 @@ void init(OptionsMap& o) {
   // Evalsave by default. This folder shall be prepared in advance.
   // Automatically create a folder under this folder like "0/", "1/", ... and save the evaluation function file there.
   o["EvalSaveDir"] << Option("evalsave");
+  // Prune at shallow depth on PV nodes. Setting this value to true gains elo in shallow search.
+  o["PruneAtShallowDepthOnPvNode"] << Option(false, on_prune_at_shallow_depth_on_pv_node);
 #endif
 }
 


### PR DESCRIPTION
This pull request contains two changes:
- Changes the option name to prune at shallow depth on PV nodes more descriptive.
   - Training -> PruneAtShallowDepthOnPvNode
- Sets the value of prune_at_shallow_depth_on_pv_node on a UCI option callback.
- Invert true/false of prune_at_shallow_depth_on_pv_node according to the option name.  The default behavior is not changed.

fixes #119