### PR TITLE
Added EnableTranspositionTable UCI option to enable/disable transposition table.

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -28,6 +28,10 @@
 
 TranspositionTable TT; // Our global transposition table
 
+#ifdef EVAL_LEARN
+bool TranspositionTable::enable_transposition_table = true;
+#endif
+
 /// TTEntry::save() populates the TTEntry with a new node's data, possibly
 /// overwriting an old position. Update is not atomic and can be racy.
 
@@ -115,6 +119,13 @@ void TranspositionTable::clear() {
 /// TTEntry t2 if its replace value is greater than that of t2.
 
 TTEntry* TranspositionTable::probe(const Key key, bool& found) const {
+
+#ifdef EVAL_LEARN
+  if (!enable_transposition_table) {
+      found = false;
+      return first_entry(0);
+  }
+#endif
 
   TTEntry* const tte = first_entry(key);
   const uint16_t key16 = (uint16_t)key;  // Use the low 16 bits as key inside the cluster

--- a/src/tt.h
+++ b/src/tt.h
@@ -84,6 +84,10 @@ public:
     return &table[mul_hi64(key, clusterCount)].entry[0];
   }
 
+#ifdef EVAL_LEARN
+  static bool enable_transposition_table;
+#endif
+
 private:
   friend struct TTEntry;
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -44,7 +44,10 @@ void on_use_NNUE(const Option& ) { Eval::init_NNUE(); }
 void on_eval_file(const Option& ) { Eval::init_NNUE(); }
 #ifdef EVAL_LEARN
 void on_prune_at_shallow_depth_on_pv_node(const Option& o) {
-  Search::prune_at_shallow_depth_on_pv_node = o;
+    Search::prune_at_shallow_depth_on_pv_node = o;
+}
+void on_enable_transposition_table(const Option& o) {
+    TranspositionTable::enable_transposition_table = o;
 }
 #endif
 
@@ -102,6 +105,8 @@ void init(OptionsMap& o) {
   o["EvalSaveDir"] << Option("evalsave");
   // Prune at shallow depth on PV nodes. Setting this value to true gains elo in shallow search.
   o["PruneAtShallowDepthOnPvNode"] << Option(false, on_prune_at_shallow_depth_on_pv_node);
+  // Enable transposition table.
+  o["EnableTranspositionTable"] << Option(true, on_enable_transposition_table);
 #endif
 }
 


### PR DESCRIPTION
This pull request adds `EnableTranspositionTable` UCI option to enable/disable transposition table.  

In Discord, noobpwnftw asked if it is better to disable transposition table during training.  This is the option for it.

https://discordapp.com/channels/435943710472011776/737073080081317948/752744087936827502

> again, next issue:
https://github.com/nodchip/Stockfish/blob/e5f05fa2b9f60503e121102ba94390e6974ced1e/src/learn/learner.cpp#L847
During loss test, qsearch is used without clearing previous TT, this is also true for training, for training this is less harmful due to positions being shuffled and unique, however there are chances that they do hit and the progression of net performance cannot be properly measured if previous TT is available, this largely affects loss function due to test samples are usually not as many, this may make training end early due to unable to fulfill loss function which is polluted by early iterations
GitHub
nodchip/Stockfish
UCI chess engine. Contribute to nodchip/Stockfish development by creating an account on GitHub.

> whether this needs fixing, or you'll just go with the flow, I have no opinion, also I will not get my hands on fixing it rather than pointing out the issue and let the experts investigate