### PR TITLE
Remove use of non-existent EvalDir option.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,4 +109,4 @@ script:
   # NNUE testing
   - export CXXFLAGS="-O1 -fno-inline"
   - make clean && make -j2 ARCH=x86-64-modern debug=no optimize=no learn > /dev/null && ../tests/instrumented_learn.sh --valgrind
-  - make clean && make -j2 ARCH=x86-64-modern sanitize=undefined optimize=no debug=no learn > /dev/null && ../tests/instrumented_learn.sh --sanitizer-undefined
+  - make clean && make -j2 ARCH=x86-64-modern sanitize=undefined optimize=no debug=yes learn > /dev/null && ../tests/instrumented_learn.sh --sanitizer-undefined

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -1987,9 +1987,6 @@ namespace Learner
         Eval::NNUE::InitializeTraining(eta1, eta1_epoch, eta2, eta2_epoch, eta3);
         Eval::NNUE::SetBatchSize(nn_batch_size);
         Eval::NNUE::SetOptions(nn_options);
-        if (newbob_decay != 1.0 && !Options["SkipLoadingEval"]) {
-            learn_think.best_nn_directory = std::string(Options["EvalDir"]);
-        }
 
         cout << "init done." << endl;
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -165,7 +165,7 @@ Option::operator double() const {
 }
 
 Option::operator std::string() const {
-  assert(type == "string");
+  assert(type == "check" || type == "spin" || type == "combo" || type == "button" || type == "string");
   return currentValue;
 }
 


### PR DESCRIPTION
additionally allow all options to be converted to string.
Without this, restoring of the options (multi_think.cpp:117) can't work.

fixes https://github.com/nodchip/Stockfish/issues/128

Now gensfen/learn pass with debug=yes in CI