### PR TITLE
Fixed a bug that an assertion fails in the trainer.

### DIFF
--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -1988,7 +1988,7 @@ namespace Learner
         Eval::NNUE::SetBatchSize(nn_batch_size);
         Eval::NNUE::SetOptions(nn_options);
         if (newbob_decay != 1.0 && !Options["SkipLoadingEval"]) {
-            // Save the current net to [EvalDir]\original.
+            // Save the current net to [EvalSaveDir]\original.
             Eval::save_eval("original");
 
             // Set the folder above to best_nn_directory so that the trainer can

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -1988,7 +1988,13 @@ namespace Learner
         Eval::NNUE::SetBatchSize(nn_batch_size);
         Eval::NNUE::SetOptions(nn_options);
         if (newbob_decay != 1.0 && !Options["SkipLoadingEval"]) {
-            learn_think.best_nn_directory = std::string(Options["EvalDir"]);
+            // Save the current net to [EvalDir]\original.
+            Eval::save_eval("original");
+
+            // Set the folder above to best_nn_directory so that the trainer can
+            // resotre the network parameters from the original net file.
+            learn_think.best_nn_directory =
+                Path::Combine(Options["EvalSaveDir"], "original");
         }
 
         cout << "init done." << endl;


### PR DESCRIPTION
This pull request changes the trainer to save the original net file to [EvalSaveDir]\original in the beginning of a training, and stores the folder path to `best_nn_directory` so that the trainer can load and restore the network parameters if the loss is not decreased at all.

Fixes #128