### PR TITLE
PRNG seeding for gensfen and learn.

### DIFF
--- a/src/learn/gensfen.cpp
+++ b/src/learn/gensfen.cpp
@@ -355,7 +355,8 @@ namespace Learner
         // It must be 2**N because it will be used as the mask to calculate hash_index.
         static_assert((GENSFEN_HASH_SIZE& (GENSFEN_HASH_SIZE - 1)) == 0);
 
-        MultiThinkGenSfen(int search_depth_min_, int search_depth_max_, SfenWriter& sw_) :
+        MultiThinkGenSfen(int search_depth_min_, int search_depth_max_, SfenWriter& sw_, const std::string& seed) :
+            MultiThink(seed),
             search_depth_min(search_depth_min_),
             search_depth_max(search_depth_max_),
             sfen_writer(sw_)
@@ -1055,6 +1056,7 @@ namespace Learner
         bool random_file_name = false;
 
         std::string sfen_format;
+        std::string seed;
 
         while (true)
         {
@@ -1111,6 +1113,8 @@ namespace Learner
                 is >> detect_draw_by_insufficient_mating_material;
             else if (token == "sfen_format")
                 is >> sfen_format;
+            else if (token == "seed")
+                is >> seed;
             else
                 cout << "Error! : Illegal token " << token << endl;
         }
@@ -1137,7 +1141,7 @@ namespace Learner
         {
             // Give a random number to output_file_name at this point.
             // Do not use std::random_device().  Because it always the same integers on MinGW.
-            PRNG r(std::chrono::system_clock::now().time_since_epoch().count());
+            PRNG r(seed);
             // Just in case, reassign the random numbers.
             for (int i = 0; i < 10; ++i)
                 r.rand(1);
@@ -1182,7 +1186,7 @@ namespace Learner
             SfenWriter sfen_writer(output_file_name, thread_num);
             sfen_writer.set_save_interval(save_every);
 
-            MultiThinkGenSfen multi_think(search_depth_min, search_depth_max, sfen_writer);
+            MultiThinkGenSfen multi_think(search_depth_min, search_depth_max, sfen_writer, seed);
             multi_think.nodes = nodes;
             multi_think.set_loop_max(loop_max);
             multi_think.eval_limit = eval_limit;

--- a/src/learn/multi_think.h
+++ b/src/learn/multi_think.h
@@ -10,6 +10,8 @@
 #include <limits>
 #include <functional>
 #include <mutex>
+#include <string>
+#include <cstdint>
 
 
 // Learning from a game record, when making yourself think and generating a fixed track, etc.
@@ -19,10 +21,11 @@ struct MultiThink
 {
 	static constexpr std::uint64_t LOOP_COUNT_FINISHED = std::numeric_limits<std::uint64_t>::max();
 
-	MultiThink() : prng(std::chrono::system_clock::now().time_since_epoch().count())
-	{
-		loop_count = 0;
-	}
+	MultiThink() : prng{}, loop_count(0) { }
+
+	MultiThink(std::uint64_t seed) : prng(seed), loop_count(0) { }
+
+	MultiThink(const std::string& seed) : prng(seed), loop_count(0) { }
 
 	// Call this function from the master thread, each thread will think,
 	// Return control when the thought ending condition is satisfied.

--- a/src/misc.h
+++ b/src/misc.h
@@ -19,6 +19,7 @@
 #ifndef MISC_H_INCLUDED
 #define MISC_H_INCLUDED
 
+#include <algorithm>
 #include <cassert>
 #include <chrono>
 #include <functional>
@@ -28,6 +29,7 @@
 #include <vector>
 #include <utility>
 #include <cmath>
+#include <cctype>
 
 #include "types.h"
 
@@ -85,6 +87,19 @@ std::ostream& operator<<(std::ostream&, SyncCout);
 /// For further analysis see
 ///   <http://vigna.di.unimi.it/ftp/papers/xorshift.pdf>
 
+static uint64_t string_hash(const std::string& str)
+{
+  uint64_t h = 525201411107845655ull;
+
+  for (auto c : str) {
+    h ^= static_cast<uint64_t>(c);
+    h *= 0x5bd1e9955bd1e995ull;
+    h ^= h >> 47;
+  }
+
+  return h;
+}
+
 class PRNG {
 
   uint64_t s;
@@ -109,6 +124,19 @@ public:
 
   // Return the random seed used internally.
   uint64_t get_seed() const { return s; }
+
+  void set_seed(uint64_t seed) { s = seed; }
+
+  void set_seed(const std::string& str)
+  {
+    if (std::all_of(str.begin(), str.end(), std::isdigit)) {
+      set_seed(std::stoull(str));
+    }
+    else
+    {
+      set_seed(string_hash(str));
+    }
+  }
 };
 
 // Display a random seed. (For debugging)

--- a/src/misc.h
+++ b/src/misc.h
@@ -111,7 +111,9 @@ class PRNG {
   }
 
 public:
+  PRNG() { set_seed_from_time(); }
   PRNG(uint64_t seed) : s(seed) { assert(seed); }
+  PRNG(const std::string& seed) { set_seed(seed); }
 
   template<typename T> T rand() { return T(rand64()); }
 
@@ -127,9 +129,18 @@ public:
 
   void set_seed(uint64_t seed) { s = seed; }
 
+  void set_seed_from_time()
+  {
+      set_seed(std::chrono::system_clock::now().time_since_epoch().count());
+  }
+
   void set_seed(const std::string& str)
   {
-    if (std::all_of(str.begin(), str.end(), std::isdigit)) {
+    if (str.empty())
+    {
+      set_seed_from_time();
+    }
+    else if (std::all_of(str.begin(), str.end(), [](char c) { return std::isdigit(c);} )) {
       set_seed(std::stoull(str));
     }
     else
@@ -196,7 +207,9 @@ int write_memory_to_file(std::string filename, void* ptr, uint64_t size);
 // async version of PRNG
 struct AsyncPRNG
 {
+  AsyncPRNG() : prng() { }
   AsyncPRNG(uint64_t seed) : prng(seed) { assert(seed); }
+  AsyncPRNG(const std::string& seed) : prng(seed) { }
   // [ASYNC] Extract one random number.
   template<typename T> T rand() {
     std::unique_lock<std::mutex> lk(mutex);


### PR DESCRIPTION
This PR extends the ways the PRNG can be seeded. Now it can be seeded from either time, uint64, or string. Empty strings fallback to time. Also allows reseeding an existing PRNG. Strings are converted to uint64 by a murmur64 type hash.

`gensfen` and `learn` commands now support a `seed` option that takes either a string (in which case its hash is used) or a base 10 integer as a prng seed.