### PR TITLE
Fix races in gensfen as detected with thread sanitizer.

### DIFF
--- a/src/learn/multi_think.h
+++ b/src/learn/multi_think.h
@@ -96,10 +96,7 @@ private:
 	std::mutex loop_mutex;
 
 	// Thread end flag.
-	// vector<bool> may not be reflected properly when trying to rewrite from multiple threads...
-	typedef uint8_t Flag;
-	std::vector<Flag> thread_finished;
-
+        std::atomic<uint64_t> threads_finished;
 };
 
 // Mechanism to process task during idle time.

--- a/src/search.h
+++ b/src/search.h
@@ -24,6 +24,7 @@
 #include "misc.h"
 #include "movepick.h"
 #include "types.h"
+#include "uci.h"
 
 class Position;
 
@@ -109,6 +110,17 @@ void init();
 void clear();
 
 } // namespace Search
+
+namespace Tablebases {
+
+extern int MaxCardinality;
+extern int Cardinality;
+extern bool UseRule50;
+extern Depth ProbeDepth;
+
+void init();
+
+}
 
 namespace Learner {
 

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -43,8 +43,6 @@ enum ProbeState {
     ZEROING_BEST_MOVE =  2  // Best move zeroes DTZ (capture or pawn move)
 };
 
-extern int MaxCardinality;
-
 void init(const std::string& paths);
 WDLScore probe_wdl(Position& pos, ProbeState* result);
 int probe_dtz(Position& pos, ProbeState* result);

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -192,6 +192,8 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
           || std::count(limits.searchmoves.begin(), limits.searchmoves.end(), m))
           rootMoves.emplace_back(m);
 
+  Tablebases::init();
+
   if (!rootMoves.empty())
       Tablebases::rank_root_moves(pos, rootMoves);
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -74,6 +74,7 @@ public:
   CapturePieceToHistory captureHistory;
   ContinuationHistory continuationHistory[2][2];
   Score contempt;
+  bool rootInTB;
 };
 
 


### PR DESCRIPTION
RootInTB was an incorrectly shared global, probably leading to wrong scoring

Minor:
 setting TB global state from input by all threads (all threads write same values)
 setting Limits global state by all threads (idem)
 thread counting for finalization

CI can be enabled once races are fixed in the learner, manually goes like:
```
make clean && make -j2 ARCH=x86-64-modern sanitize=thread    optimize=no debug=yes build
../tests/instrumented_learn.sh --sanitizer-thread
```

Needs some review.