### PR TITLE
Skip eval dampening in Use NNUE = pure case

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -996,6 +996,11 @@ Value Eval::evaluate(const Position& pos) {
 
   if (Eval::useNNUE == UseNNUEMode::Pure) {
       v = NNUE::evaluate(pos);
+
+      // Guarantee evaluation does not hit the tablebase range
+      v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
+
+      return v;
   }
   else if (Eval::useNNUE == UseNNUEMode::False)
       v = Evaluation<NO_TRACE>(pos).value();


### PR DESCRIPTION
This is helpful in both gensfen and training.

We do not need this:
https://github.com/nodchip/Stockfish/blob/6f7a2287079682e5710c10106dd60e3c76abcc3e/src/evaluate.cpp#L1029-L1030

However we do need to clamp evals, otherwise search can be affected by out of range eval scores.

Early versions had this clamp in NNUE code.
https://github.com/nodchip/Stockfish/blob/36092b855a5e2bcfb587a36e2055ea068e4bd8e5/src/eval/nnue/evaluate_nnue.cpp#L152