### PR TITLE
Change some learn and gensfen defaults. Add switch for setting recommended UCI options.

### DIFF
--- a/src/docs/gensfen.md
+++ b/src/docs/gensfen.md
@@ -20,44 +20,44 @@ Currently the following options are available:
 
 `nodes` - the number of nodes to use for evaluation of each position. This number is multiplied by the number of PVs of the current search. This does NOT override the `depth` and `depth2` options. If specified then whichever of depth or nodes limit is reached first applies.
 
-`loop` - the number of training data entries to generate. 1 entry == 1 position.
+`loop` - the number of training data entries to generate. 1 entry == 1 position. Default: 8000000000 (8B).
 
-`output_file_name` - the name of the file to output to. If the extension is not present or doesn't match the selected training data format the right extension will be appened.
+`output_file_name` - the name of the file to output to. If the extension is not present or doesn't match the selected training data format the right extension will be appened. Default: generated_kifu
 
-`eval_limit` - evaluations with higher absolute value than this will not be written and will terminate a self-play game. Should not exceed 10000 which is VALUE_KNOWN_WIN, but is only hardcapped at mate in 2 (\~30000).
+`eval_limit` - evaluations with higher absolute value than this will not be written and will terminate a self-play game. Should not exceed 10000 which is VALUE_KNOWN_WIN, but is only hardcapped at mate in 2 (\~30000). Default: 3000
 
-`random_move_minply` - the minimal ply at which a random move may be executed instead of a move chosen by search
+`random_move_minply` - the minimal ply at which a random move may be executed instead of a move chosen by search. Default: 1.
 
-`random_move_maxply` - the maximal ply at which a random move may be executed instead of a move chosen by search
+`random_move_maxply` - the maximal ply at which a random move may be executed instead of a move chosen by search. Default: 24.
 
-`random_move_count` - maximum number of random moves in a single self-play game
+`random_move_count` - maximum number of random moves in a single self-play game. Default: 5.
 
-`random_move_like_apery` - either 0 or 1. If 1 then random king moves will be followed by a random king move from the opponent whenever possible with 50% probability.
+`random_move_like_apery` - either 0 or 1. If 1 then random king moves will be followed by a random king move from the opponent whenever possible with 50% probability. Default: 0.
 
 `random_multi_pv` - the number of PVs used for determining the random move. If not specified then a truly random move will be chosen. If specified then a multiPV search will be performed the random move will be one of the moves chosen by the search.
 
 `random_multi_pv_diff` - Makes the multiPV random move selection consider only moves that are at most `random_multi_pv_diff` worse than the next best move. Default: 30000 (all multiPV moves).
 
-`random_multi_pv_depth` - the depth to use for multiPV search for random move. Defaults to `depth2`.
+`random_multi_pv_depth` - the depth to use for multiPV search for random move. Default: `depth2`.
 
-`write_minply` - minimum ply for which the training data entry will be emitted.
+`write_minply` - minimum ply for which the training data entry will be emitted. Default: 16.
 
-`write_maxply` - maximum ply for which the training data entry will be emitted.
+`write_maxply` - maximum ply for which the training data entry will be emitted. Default: 400.
 
 `save_every` - the number of training data entries per file. If not specified then there will be always one file. If specified there may be more than one file generated (each having at most `save_every` training data entries) and each file will have a unique number attached.
 
 `random_file_name` - if specified then the output filename will be chosen randomly. Overrides `output_file_name`.
 
-`write_out_draw_game_in_training_data_generation` - either 0 or 1. If 1 then training data from drawn games will be emitted too. Default: 0.
+`write_out_draw_game_in_training_data_generation` - either 0 or 1. If 1 then training data from drawn games will be emitted too. Default: 1.
 
 `use_draw_in_training_data_generation` - deprecated, alias for `write_out_draw_game_in_training_data_generation`
 
-`detect_draw_by_consecutive_low_score` - either 0 or 1. If 1 then drawn games will be adjudicated when the score remains 0 for at least 8 plies after ply 80. Default: 0.
+`detect_draw_by_consecutive_low_score` - either 0 or 1. If 1 then drawn games will be adjudicated when the score remains 0 for at least 8 plies after ply 80. Default: 1.
 
 `use_game_draw_adjudication` - deprecated, alias for `detect_draw_by_consecutive_low_score`
 
-`detect_draw_by_insufficient_mating_material` - either 0 or 1. If 1 then position with insufficient material will be adjudicated as draws. Default: 0.
+`detect_draw_by_insufficient_mating_material` - either 0 or 1. If 1 then position with insufficient material will be adjudicated as draws. Default: 1.
 
-`sfen_format` - format of the training data to use. Either `bin` or `binpack`. Default: `bin`.
+`sfen_format` - format of the training data to use. Either `bin` or `binpack`. Default: `binpack`.
 
 `seed` - seed for the PRNG. Can be either a number or a string. If it's a string then its hash will be used. If not specified then the current time will be used.

--- a/src/docs/gensfen.md
+++ b/src/docs/gensfen.md
@@ -12,6 +12,8 @@ It is recommended to keep the `EnableTranspositionTable` UCI option at the defau
 
 Currently the following options are available:
 
+`set_recommended_uci_options` - this is a modifier not a parameter, no value follows it. If specified then some UCI options are set to recommended values.
+
 `depth` - minimum depth of evaluation of each position. Default: 3.
 
 `depth2` - maximum depth of evaluation of each position. If not specified then the same as `depth`.

--- a/src/docs/learn.md
+++ b/src/docs/learn.md
@@ -28,11 +28,11 @@ Currently the following options are available:
 
 `lr` - initial learning rate. Default: 1.
 
-`use_draw_games_in_training` - either 0 or 1. If 1 then draws will be used in training too. Default: 0.
+`use_draw_games_in_training` - either 0 or 1. If 1 then draws will be used in training too. Default: 1.
 
 `use_draw_in_training` - deprecated, alias for `use_draw_games_in_training`
 
-`use_draw_games_in_validation` - either 0 or 1. If 1 then draws will be used in validation too. Default: 0.
+`use_draw_games_in_validation` - either 0 or 1. If 1 then draws will be used in validation too. Default: 1.
 
 `use_draw_in_validation` - deprecated, alias for `use_draw_games_in_validation`
 
@@ -44,9 +44,9 @@ Currently the following options are available:
 
 `use_wdl` - either 0 or 1. If 1 then the evaluations will be converted to win/draw/loss percentages prior to learning on them. (Slightly changes the gradient because eval has a different derivative than wdl). Default: 0.
 
-`lambda` - value in range [0..1]. 1 means that only evaluation is used for learning, 0 means that only game result is used. Values inbetween result in interpolation between the two contributions. See `lambda_limit` for when this is applied. Default: 0.33.
+`lambda` - value in range [0..1]. 1 means that only evaluation is used for learning, 0 means that only game result is used. Values inbetween result in interpolation between the two contributions. See `lambda_limit` for when this is applied. Default: 1.0.
 
-`lambda2` - value in range [0..1]. 1 means that only evaluation is used for learning, 0 means that only game result is used. Values inbetween result in interpolation between the two contributions. See `lambda_limit` for when this is applied. Default: 0.33.
+`lambda2` - value in range [0..1]. 1 means that only evaluation is used for learning, 0 means that only game result is used. Values inbetween result in interpolation between the two contributions. See `lambda_limit` for when this is applied. Default: 1.0.
 
 `lambda_limit` - the maximum absolute score value for which `lambda` is used as opposed to `lambda2`. For positions with absolute evaluation higher than `lambda_limit` `lambda2` will be used. Default: 32000 (so always `lambda`).
 
@@ -60,15 +60,15 @@ Currently the following options are available:
 
 `nn_batch_size` - minibatch size used for learning. Should be smaller than batch size. Default: 1000.
 
-`newbob_decay` - learning rate will be multiplied by this factor every time a net is rejected (so in other words it controls LR drops). Default: 1.0 (no LR drops)
+`newbob_decay` - learning rate will be multiplied by this factor every time a net is rejected (so in other words it controls LR drops). Default: 0.5 (no LR drops)
 
-`newbob_num_trials` - determines after how many subsequent rejected nets the training process will be terminated. Default: 2.
+`newbob_num_trials` - determines after how many subsequent rejected nets the training process will be terminated. Default: 4.
 
 `nn_options` - if you're reading this you don't use it. It passes messages directly to the network evaluation. I don't know what it can do either.
 
-`eval_save_interval` - every `eval_save_interval` positions the network will be saved and either accepted or rejected (in which case an LR drop follows). Default: 1000000000 (1B). (generally people use values in 10M-100M range)
+`eval_save_interval` - every `eval_save_interval` positions the network will be saved and either accepted or rejected (in which case an LR drop follows). Default: 100000000 (100M). (generally people use values in 10M-100M range)
 
-`loss_output_interval` - every `loss_output_interval` fitness statistics are displayed. Default: `batchsize`
+`loss_output_interval` - every `loss_output_interval` fitness statistics are displayed. Default: 1000000 (1M)
 
 `validation_set_file_name` - path to the file with training data to be used for validation (loss computation and move accuracy)
 

--- a/src/docs/learn.md
+++ b/src/docs/learn.md
@@ -14,6 +14,8 @@ It is **required** to set the `Use NNUE` UCI option to `pure` as otherwise the f
 
 Currently the following options are available:
 
+`set_recommended_uci_options` - this is a modifier not a parameter, no value follows it. If specified then some UCI options are set to recommended values.
+
 `bat` - the size of a batch in multiples of 10000. This determines how many entries are read and shuffled at once during training. Default: 1000 (meaning batch size of 1000000).
 
 `targetdir` - path to the direction from which training data will be read. All files in this directory are read sequentially. If not specified then only the list of files from positional arguments will be used. If specified then files from the given directory will be used after the explicitly specified files.

--- a/src/learn/gensfen.cpp
+++ b/src/learn/gensfen.cpp
@@ -1014,6 +1014,16 @@ namespace Learner
                 is >> sfen_format;
             else if (token == "seed")
                 is >> seed;
+            else if (token == "set_recommended_uci_options")
+            {
+                UCI::setoption("Contempt", "0");
+                UCI::setoption("Skill Level", "20");
+                UCI::setoption("UCI_Chess960", "false");
+                UCI::setoption("UCI_AnalyseMode", "false");
+                UCI::setoption("UCI_LimitStrength", "false");
+                UCI::setoption("PruneAtShallowDepth", "false");
+                UCI::setoption("EnableTranspositionTable", "true");
+            }
             else
                 cout << "Error! : Illegal token " << token << endl;
         }

--- a/src/learn/gensfen.cpp
+++ b/src/learn/gensfen.cpp
@@ -43,9 +43,9 @@ namespace Learner
         Binpack
     };
 
-    static bool write_out_draw_game_in_training_data_generation = false;
-    static bool detect_draw_by_consecutive_low_score = false;
-    static bool detect_draw_by_insufficient_mating_material = false;
+    static bool write_out_draw_game_in_training_data_generation = true;
+    static bool detect_draw_by_consecutive_low_score = true;
+    static bool detect_draw_by_insufficient_mating_material = true;
 
     static SfenOutputType sfen_output_type = SfenOutputType::Bin;
 
@@ -954,7 +954,7 @@ namespace Learner
         // Add a random number to the end of the file name.
         bool random_file_name = false;
 
-        std::string sfen_format;
+        std::string sfen_format = "binpack";
         std::string seed;
 
         while (true)

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -1745,6 +1745,18 @@ namespace Learner
             else if (option == "dest_score_min_value") is >> dest_score_min_value;
             else if (option == "dest_score_max_value") is >> dest_score_max_value;
             else if (option == "seed") is >> seed;
+            else if (option == "set_recommended_uci_options")
+            {
+                UCI::setoption("Use NNUE", "pure");
+                UCI::setoption("MultiPV", "1");
+                UCI::setoption("Contempt", "0");
+                UCI::setoption("Skill Level", "20");
+                UCI::setoption("UCI_Chess960", "false");
+                UCI::setoption("UCI_AnalyseMode", "false");
+                UCI::setoption("UCI_LimitStrength", "false");
+                UCI::setoption("PruneAtShallowDepth", "false");
+                UCI::setoption("EnableTranspositionTable", "false");
+            }
             // Otherwise, it's a filename.
             else
                 filenames.push_back(option);

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -77,8 +77,8 @@ T operator -= (std::atomic<T>& x, const T rhs) { return x += -rhs; }
 
 namespace Learner
 {
-    static bool use_draw_games_in_training = false;
-    static bool use_draw_games_in_validation = false;
+    static bool use_draw_games_in_training = true;
+    static bool use_draw_games_in_validation = true;
     static bool skip_duplicated_positions_in_training = true;
 
     static double winning_probability_coefficient = 1.0 / PawnValueEg / 4.0 * std::log(10.0);
@@ -1632,8 +1632,8 @@ namespace Learner
         global_learning_rate = 1.0;
 
         // elmo lambda
-        ELMO_LAMBDA = 0.33;
-        ELMO_LAMBDA2 = 0.33;
+        ELMO_LAMBDA = 1.0;
+        ELMO_LAMBDA2 = 1.0;
         ELMO_LAMBDA_LIMIT = 32000;
 
         // if (gamePly <rand(reduction_gameply)) continue;
@@ -1642,12 +1642,12 @@ namespace Learner
         int reduction_gameply = 1;
 
         uint64_t nn_batch_size = 1000;
-        double newbob_decay = 1.0;
-        int newbob_num_trials = 2;
+        double newbob_decay = 0.5;
+        int newbob_num_trials = 4;
         string nn_options;
 
         uint64_t eval_save_interval = LEARN_EVAL_SAVE_INTERVAL;
-        uint64_t loss_output_interval = 0;
+        uint64_t loss_output_interval = 1'000'000;
 
         string validation_set_file_name;
         string seed;

--- a/src/learn/learn.h
+++ b/src/learn/learn.h
@@ -64,7 +64,7 @@ namespace Learner
     // Needless to say, the longer the saving interval, the shorter the learning time.
     // Folder name is incremented for each save like 0/, 1/, 2/...
     // By default, once every 1 billion phases.
-    constexpr std::size_t LEARN_EVAL_SAVE_INTERVAL = 1000000000ULL;
+    constexpr std::size_t LEARN_EVAL_SAVE_INTERVAL = 100'000'000ULL;
 
     // Reduce the output of rmse during learning to 1 for this number of times.
     // rmse calculation is done in one thread, so it takes some time, so reducing the output is effective.

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -109,7 +109,7 @@ namespace {
   // setoption() is called when engine receives the "setoption" UCI command. The
   // function updates the UCI option ("name") to the given value ("value").
 
-  void setoption(istringstream& is) {
+  void setoption_from_stream(istringstream& is) {
 
     string token, name, value;
 
@@ -123,10 +123,7 @@ namespace {
     while (is >> token)
         value += (value.empty() ? "" : " ") + token;
 
-    if (Options.count(name))
-        Options[name] = value;
-    else
-        sync_cout << "No such option: " << name << sync_endl;
+    UCI::setoption(name, value);
   }
 
 
@@ -195,7 +192,7 @@ namespace {
             else
                trace_eval(pos);
         }
-        else if (token == "setoption")  setoption(is);
+        else if (token == "setoption")  setoption_from_stream(is);
         else if (token == "position")   position(pos, is, states);
         else if (token == "ucinewgame") { Search::clear(); elapsed = now(); } // Search::clear() may take some while
     }
@@ -211,6 +208,14 @@ namespace {
   }
 
 } // namespace
+
+void UCI::setoption(const std::string& name, const std::string& value)
+{
+    if (Options.count(name))
+        Options[name] = value;
+    else
+        sync_cout << "No such option: " << name << sync_endl;
+}
 
 // The win rate model returns the probability (per mille) of winning given an eval
 // and a game-ply. The model fits rather accurately the LTC fishtest statistics.
@@ -318,7 +323,7 @@ void UCI::loop(int argc, char* argv[]) {
                     << "\n"       << Options
                     << "\nuciok"  << sync_endl;
 
-      else if (token == "setoption")  setoption(is);
+      else if (token == "setoption")  setoption_from_stream(is);
       else if (token == "go")         go(pos, is, states);
       else if (token == "position")   position(pos, is, states);
       else if (token == "ucinewgame") Search::clear();

--- a/src/uci.h
+++ b/src/uci.h
@@ -75,6 +75,7 @@ std::string wdl(Value v, int ply);
 int win_rate_model(Value v, int ply);
 double win_rate_model_double(double v, int ply);
 Move to_move(const Position& pos, std::string& str);
+void setoption(const std::string& name, const std::string& value);
 
 } // namespace UCI
 


### PR DESCRIPTION
This introduces a switch in learn and gensfen called `set_recommended_uci_options` which sets the most critical UCI options. There is still some discussion to be had on the exact options and values. For example setting "Contempt" to 0 for gensfen seems logical but I don't know if anyone does it.

This PR also changes the default parameters for learn and gensfen to be more in line with recent experiment results. Now this is even more questionable. For the start I applied moderate changes based on @noobpwnftw 's settings, but I didn't completely copy them. There are some parameters which are either subjective or questionable. The questionable ones are:
- noob sets `eval_limit` to 1000, which seems very low (default here is 3000)
- noob doesn't use draw adjudication (default here is to use draw adjudication)
