### PR TITLE
Increase rule50 and fullmove counters range.

### DIFF
--- a/src/learn/sfen_packer.cpp
+++ b/src/learn/sfen_packer.cpp
@@ -113,43 +113,24 @@ namespace Learner {
   // Huffman coding
   // * is simplified from mini encoding to make conversion easier.
   //
-  // 1 box on the board (other than NO_PIECE) = 2 to 6 bits (+ 1-bit flag + 1-bit forward and backward)
-  // 1 piece of hand piece = 1-5bit (+ 1-bit flag + 1bit ahead and behind)
-  //
-  // empty xxxxx0 + 0 (none)
-  // step xxxx01 + 2 xxxx0 + 2
-  // incense xx0011 + 2 xx001 + 2
-  // Katsura xx1011 + 2 xx101 + 2
-  // silver xx0111 + 2 xx011 + 2
-  // Gold x01111 + 1 x0111 + 1 // Gold is valid and has no flags.
-  // corner 011111 + 2 01111 + 2
-  // Fly 111111 + 2 11111 + 2
-  //
-  // Assuming all pieces are on the board,
-  // Sky 81-40 pieces = 41 boxes = 41bit
-  // Walk 4bit*18 pieces = 72bit
-  // Incense 6bit*4 pieces = 24bit
-  // Katsura 6bit*4 pieces = 24bit
-  // Silver 6bit*4 pieces = 24bit
-  // Gold 6bit* 4 pieces = 24bit
-  // corner 8bit* 2 pieces = 16bit
-  // Fly 8bit* 2 pieces = 16bit
-  // -------
-  // 241bit + 1bit (turn) + 7bit × 2 (King's position after) = 256bit
-  //
-  // When the piece on the board moves to the hand piece, the piece on the board becomes empty, so the box on the board can be expressed with 1 bit,
-  // Since the hand piece can be expressed by 1 bit less than the piece on the board, the total number of bits does not change in the end.
-  // Therefore, in this expression, any aspect can be expressed by this bit number.
-  // It is a hand piece and no flag is required, but if you include this, the bit number of the piece on the board will be -1
-  // Since the total number of bits can be fixed, we will include this as well.
-
   // Huffman Encoding
   //
   // Empty  xxxxxxx0
-  // Pawn   xxxxx001 + 1 bit (Side to move)
-  // Knight xxxxx011 + 1 bit (Side to move)
-  // Bishop xxxxx101 + 1 bit (Side to move)
-  // Rook   xxxxx111 + 1 bit (Side to move)
+  // Pawn   xxxxx001 + 1 bit (Color)
+  // Knight xxxxx011 + 1 bit (Color)
+  // Bishop xxxxx101 + 1 bit (Color)
+  // Rook   xxxxx111 + 1 bit (Color)
+  // Queen   xxxx1001 + 1 bit (Color)
+  //
+  // Worst case:
+  // - 32 empty squares    32 bits
+  // - 30 pieces           150 bits
+  // - 2 kings             12 bits
+  // - castling rights     4 bits
+  // - ep square           7 bits
+  // - rule50              7 bits
+  // - game ply            16 bits
+  // - TOTAL               228 bits < 256 bits
 
   struct HuffmanedPiece
   {
@@ -212,7 +193,18 @@ namespace Learner {
 
     stream.write_n_bit(pos.state()->rule50, 6);
 
-    stream.write_n_bit(1 + (pos.game_ply()-(pos.side_to_move() == BLACK)) / 2, 8);
+    const int fm = 1 + (pos.game_ply()-(pos.side_to_move() == BLACK)) / 2;
+    stream.write_n_bit(fm, 8);
+
+    // Write high bits of half move. This is a fix for the
+    // limited range of half move counter.
+    // This is backwards compatibile.
+    stream.write_n_bit(fm >> 8, 8);
+
+    // Write the highest bit of rule50 at the end. This is a backwards
+    // compatibile fix for rule50 having only 6 bits stored.
+    // This bit is just ignored by the old parsers.
+    stream.write_n_bit(pos.state()->rule50 >> 6, 1);
 
     assert(stream.get_cursor() <= 256);
   }
@@ -355,10 +347,20 @@ namespace Learner {
     }
 
     // Halfmove clock
-    pos.st->rule50 = static_cast<Square>(stream.read_n_bit(6));
+    pos.st->rule50 = stream.read_n_bit(6);
 
     // Fullmove number
-    pos.gamePly = static_cast<Square>(stream.read_n_bit(8));
+    pos.gamePly = stream.read_n_bit(8);
+
+    // Read the highest bit of rule50. This was added as a fix for rule50
+    // counter having only 6 bits stored.
+    // In older entries this will just be a zero bit.
+    pos.gamePly |= stream.read_n_bit(8) << 8;
+
+    // Read the highest bit of rule50. This was added as a fix for rule50
+    // counter having only 6 bits stored.
+    // In older entries this will just be a zero bit.
+    pos.st->rule50 |= stream.read_n_bit(1) << 6;
 
     // Convert from fullmove starting from 1 to gamePly starting from 0,
     // handle also common incorrect FEN with fullmove = 0.


### PR DESCRIPTION
This PR augments the .bin format (and also the .binpack format which relies on the .bin format) with the ability to store rule50 counts up to 127 (up from 63) and full move counts up to 65535 (up from 255). This change keeps the backward compatibility, the fix uses spare bits at the end of the bit stream. These bits are ignored by older versions, and old .bin files have them zeroed so it doesn't affect the value when read by the fixed version.

Fixes #75.