### PR TITLE
Cleanup 2020 10 14

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -26,32 +26,13 @@
 class Position;
 
 namespace Eval {
-  enum struct UseNNUEMode
-  {
-    False,
-    True,
-    Pure
-  };
-
   std::string trace(const Position& pos);
   Value evaluate(const Position& pos);
-
-  extern UseNNUEMode useNNUE;
-  extern std::string eval_file_loaded;
 
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
   #define EvalFileDefaultName   "nn-98a7585c85e9.nnue"
-
-  namespace NNUE {
-
-    Value evaluate(const Position& pos);
-    bool load_eval(std::string name, std::istream& stream);
-    void init();
-    void verify();
-
-  } // namespace NNUE
 
 } // namespace Eval
 

--- a/src/learn/gensfen.cpp
+++ b/src/learn/gensfen.cpp
@@ -3,7 +3,6 @@
 #include "packed_sfen.h"
 #include "multi_think.h"
 #include "sfen_stream.h"
-#include "../syzygy/tbprobe.h"
 
 #include "misc.h"
 #include "position.h"
@@ -73,7 +72,7 @@ namespace Learner
             file_worker_thread.join();
             output_file_stream.reset();
 
-#if defined(_DEBUG)
+#if !defined(NDEBUG)
             {
                 // All buffers should be empty since file_worker_thread
                 // should have written everything before exiting.

--- a/src/learn/gensfen.cpp
+++ b/src/learn/gensfen.cpp
@@ -673,7 +673,7 @@ namespace Learner
             }
             else
             {
-                Learner::search(pos, random_multi_pv_depth, random_multi_pv);
+                Search::search(pos, random_multi_pv_depth, random_multi_pv);
 
                 // Select one from the top N hands of root Moves
                 auto& rm = pos.this_thread()->rootMoves;
@@ -790,7 +790,7 @@ namespace Learner
                 const int depth = search_depth_min + (int)prng.rand(search_depth_max - search_depth_min + 1);
 
                 // Starting search calls init_for_search
-                auto [search_value, search_pv] = search(pos, depth, 1, nodes);
+                auto [search_value, search_pv] = Search::search(pos, depth, 1, nodes);
 
                 // This has to be performed after search because it needs to know
                 // rootMoves which are filled in init_for_search.

--- a/src/learn/gensfen.cpp
+++ b/src/learn/gensfen.cpp
@@ -1000,7 +1000,7 @@ namespace Learner
             << "  detect_draw_by_insufficient_mating_material = " << detect_draw_by_insufficient_mating_material << endl;
 
         // Show if the training data generator uses NNUE.
-        Eval::NNUE::verify();
+        Eval::NNUE::verify_eval_file_loaded();
 
         Threads.main()->ponder = false;
 

--- a/src/learn/gensfen.cpp
+++ b/src/learn/gensfen.cpp
@@ -12,6 +12,7 @@
 
 #include "extra/nnue_data_binpack_format.h"
 
+#include "nnue/evaluate_nnue.h"
 #include "nnue/evaluate_nnue_learner.h"
 
 #include "syzygy/tbprobe.h"

--- a/src/learn/half_float.h
+++ b/src/learn/half_float.h
@@ -11,122 +11,122 @@
 
 namespace HalfFloat
 {
-	// IEEE 754 float 32 format is :
-	//   sign(1bit) + exponent(8bits) + fraction(23bits) = 32bits
-	//
-	// Our float16 format is :
-	//   sign(1bit) + exponent(5bits) + fraction(10bits) = 16bits
-	union float32_converter
-	{
-		int32_t n;
-		float f;
-	};
+    // IEEE 754 float 32 format is :
+    //   sign(1bit) + exponent(8bits) + fraction(23bits) = 32bits
+    //
+    // Our float16 format is :
+    //   sign(1bit) + exponent(5bits) + fraction(10bits) = 16bits
+    union float32_converter
+    {
+        int32_t n;
+        float f;
+    };
 
 
-	// 16-bit float
-	struct float16
-	{
-		// --- constructors
+    // 16-bit float
+    struct float16
+    {
+        // --- constructors
 
-		float16() {}
-		float16(int16_t n) { from_float((float)n);  }
-		float16(int32_t n) { from_float((float)n); }
-		float16(float n) { from_float(n); }
-		float16(double n) { from_float((float)n); }
+        float16() {}
+        float16(int16_t n) { from_float((float)n);  }
+        float16(int32_t n) { from_float((float)n); }
+        float16(float n) { from_float(n); }
+        float16(double n) { from_float((float)n); }
 
-		// build from a float
-		void from_float(float f) { *this = to_float16(f); }
+        // build from a float
+        void from_float(float f) { *this = to_float16(f); }
 
-		// --- implicit converters
+        // --- implicit converters
 
-		operator int32_t() const { return (int32_t)to_float(*this); }
-		operator float() const { return to_float(*this); }
-		operator double() const { return double(to_float(*this)); }
+        operator int32_t() const { return (int32_t)to_float(*this); }
+        operator float() const { return to_float(*this); }
+        operator double() const { return double(to_float(*this)); }
 
-		// --- operators
+        // --- operators
 
-		float16 operator += (float16 rhs) { from_float(to_float(*this) + to_float(rhs)); return *this; }
-		float16 operator -= (float16 rhs) { from_float(to_float(*this) - to_float(rhs)); return *this; }
-		float16 operator *= (float16 rhs) { from_float(to_float(*this) * to_float(rhs)); return *this; }
-		float16 operator /= (float16 rhs) { from_float(to_float(*this) / to_float(rhs)); return *this; }
-		float16 operator + (float16 rhs) const { return float16(*this) += rhs; }
-		float16 operator - (float16 rhs) const { return float16(*this) -= rhs; }
-		float16 operator * (float16 rhs) const { return float16(*this) *= rhs; }
-		float16 operator / (float16 rhs) const { return float16(*this) /= rhs; }
-		float16 operator - () const { return float16(-to_float(*this)); }
-		bool operator == (float16 rhs) const { return this->v_ == rhs.v_; }
-		bool operator != (float16 rhs) const { return !(*this == rhs); }
+        float16 operator += (float16 rhs) { from_float(to_float(*this) + to_float(rhs)); return *this; }
+        float16 operator -= (float16 rhs) { from_float(to_float(*this) - to_float(rhs)); return *this; }
+        float16 operator *= (float16 rhs) { from_float(to_float(*this) * to_float(rhs)); return *this; }
+        float16 operator /= (float16 rhs) { from_float(to_float(*this) / to_float(rhs)); return *this; }
+        float16 operator + (float16 rhs) const { return float16(*this) += rhs; }
+        float16 operator - (float16 rhs) const { return float16(*this) -= rhs; }
+        float16 operator * (float16 rhs) const { return float16(*this) *= rhs; }
+        float16 operator / (float16 rhs) const { return float16(*this) /= rhs; }
+        float16 operator - () const { return float16(-to_float(*this)); }
+        bool operator == (float16 rhs) const { return this->v_ == rhs.v_; }
+        bool operator != (float16 rhs) const { return !(*this == rhs); }
 
-		static void UnitTest() { unit_test(); }
+        static void UnitTest() { unit_test(); }
 
-	private:
+    private:
 
-		// --- entity
+        // --- entity
 
-		uint16_t v_;
+        uint16_t v_;
 
-		// --- conversion between float and float16
+        // --- conversion between float and float16
 
-		static float16 to_float16(float f)
-		{
-			float32_converter c;
-			c.f = f;
-			u32 n = c.n;
+        static float16 to_float16(float f)
+        {
+            float32_converter c;
+            c.f = f;
+            u32 n = c.n;
 
-			// The sign bit is MSB in common.
-			uint16_t sign_bit = (n >> 16) & 0x8000;
+            // The sign bit is MSB in common.
+            uint16_t sign_bit = (n >> 16) & 0x8000;
 
-			// The exponent of IEEE 754's float 32 is biased +127 , so we change this bias into +15 and limited to 5-bit.
-			uint16_t exponent = (((n >> 23) - 127 + 15) & 0x1f) << 10;
+            // The exponent of IEEE 754's float 32 is biased +127 , so we change this bias into +15 and limited to 5-bit.
+            uint16_t exponent = (((n >> 23) - 127 + 15) & 0x1f) << 10;
 
-			// The fraction is limited to 10-bit.
-			uint16_t fraction = (n >> (23-10)) & 0x3ff;
+            // The fraction is limited to 10-bit.
+            uint16_t fraction = (n >> (23-10)) & 0x3ff;
 
-			float16 f_;
-			f_.v_ = sign_bit | exponent | fraction;
+            float16 f_;
+            f_.v_ = sign_bit | exponent | fraction;
 
-			return f_;
-		}
+            return f_;
+        }
 
-		static float to_float(float16 v)
-		{
-			u32 sign_bit = (v.v_ & 0x8000) << 16;
-			u32 exponent = ((((v.v_ >> 10) & 0x1f) - 15 + 127) & 0xff) << 23;
-			u32 fraction = (v.v_ & 0x3ff) << (23 - 10);
+        static float to_float(float16 v)
+        {
+            u32 sign_bit = (v.v_ & 0x8000) << 16;
+            u32 exponent = ((((v.v_ >> 10) & 0x1f) - 15 + 127) & 0xff) << 23;
+            u32 fraction = (v.v_ & 0x3ff) << (23 - 10);
 
-			float32_converter c;
-			c.n = sign_bit | exponent | fraction;
-			return c.f;
-		}
+            float32_converter c;
+            c.n = sign_bit | exponent | fraction;
+            return c.f;
+        }
 
-		// It is not a unit test, but I confirmed that it can be calculated. I'll fix the code later (maybe).
-		static void unit_test()
-		{
-			float16 a, b, c, d;
-			a = 1;
-			std::cout << (float)a << std::endl;
-			b = -118.625;
-			std::cout << (float)b << std::endl;
-			c = 2.5;
-			std::cout << (float)c << std::endl;
-			d = a + c;
-			std::cout << (float)d << std::endl;
+        // It is not a unit test, but I confirmed that it can be calculated. I'll fix the code later (maybe).
+        static void unit_test()
+        {
+            float16 a, b, c, d;
+            a = 1;
+            std::cout << (float)a << std::endl;
+            b = -118.625;
+            std::cout << (float)b << std::endl;
+            c = 2.5;
+            std::cout << (float)c << std::endl;
+            d = a + c;
+            std::cout << (float)d << std::endl;
 
-			c *= 1.5;
-			std::cout << (float)c << std::endl;
+            c *= 1.5;
+            std::cout << (float)c << std::endl;
 
-			b /= 3;
-			std::cout << (float)b << std::endl;
+            b /= 3;
+            std::cout << (float)b << std::endl;
 
-			float f1 = 1.5;
-			a += f1;
-			std::cout << (float)a << std::endl;
+            float f1 = 1.5;
+            a += f1;
+            std::cout << (float)a << std::endl;
 
-			a += f1 * (float)a;
-			std::cout << (float)a << std::endl;
-		}
+            a += f1 * (float)a;
+            std::cout << (float)a << std::endl;
+        }
 
-	};
+    };
 
 }
 

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -903,10 +903,6 @@ namespace Learner
                     << " , learn_entropy = " << learn_sum_entropy / done
                     << endl;
             }
-
-            // Bigger space between progress reports so that they can be more
-            // easly disinguished. Looking for timestamps is hard.
-            cout << endl;
         }
         else
         {

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -768,12 +768,11 @@ namespace Learner
         atomic<int> move_accord_count;
         move_accord_count = 0;
 
-        // Display the value of eval() in the initial stage of Hirate and see the shaking.
         auto th = Threads[thread_id];
         auto& pos = th->rootPos;
         StateInfo si;
         pos.set(StartFEN, false, &si, th);
-        cout << "hirate eval = " << Eval::evaluate(pos) << endl;
+        cout << "startpos eval = " << Eval::evaluate(pos) << endl;
 
         // It's better to parallelize here, but it's a bit
         // troublesome because the search before slave has not finished.

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -824,7 +824,7 @@ namespace Learner
         // The value of evaluate() may be used, but when calculating loss, learn_cross_entropy and
         // Use qsearch() because it is difficult to compare the values.
         // EvalHash has been disabled in advance. (If not, the same value will be returned every time)
-        const auto [_, pv] = qsearch(task_pos);
+        const auto [_, pv] = Search::qsearch(task_pos);
 
         const auto rootColor = task_pos.side_to_move();
 
@@ -962,7 +962,7 @@ namespace Learner
 
                 // Determine if the teacher's move and the score of the shallow search match
                 {
-                    const auto [value, pv] = search(task_pos, 1);
+                    const auto [value, pv] = Search::search(task_pos, 1);
                     if ((uint16_t)pv[0] == ps.move)
                         move_accord_count.fetch_add(1, std::memory_order_relaxed);
                 }
@@ -1186,7 +1186,7 @@ namespace Learner
 				goto RETRY_READ;
 
             // Evaluation value of shallow search (qsearch)
-            const auto [_, pv] = qsearch(pos);
+            const auto [_, pv] = Search::qsearch(pos);
 
             // Evaluation value of deep search
             const auto deep_value = (Value)ps.score;

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -1066,14 +1066,14 @@ namespace Learner
 
             pos.do_move((Move)ps.move, state[ply++]);
 
-			// There is a possibility that all the pieces are blocked and stuck.
-			// Also, the declaration win phase is excluded from
-			// learning because you cannot go to leaf with PV moves.
-			// (shouldn't write out such teacher aspect itself,
-			// but may have written it out with an old generation routine)
-			// Skip the position if there are no legal moves (=checkmated or stalemate).
-			if (MoveList<LEGAL>(pos).size() == 0)
-				goto RETRY_READ;
+            // There is a possibility that all the pieces are blocked and stuck.
+            // Also, the declaration win phase is excluded from
+            // learning because you cannot go to leaf with PV moves.
+            // (shouldn't write out such teacher aspect itself,
+            // but may have written it out with an old generation routine)
+            // Skip the position if there are no legal moves (=checkmated or stalemate).
+            if (MoveList<LEGAL>(pos).size() == 0)
+                goto RETRY_READ;
 
             // Evaluation value of shallow search (qsearch)
             const auto [_, pv] = Search::qsearch(pos);

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -32,6 +32,7 @@
 
 #include "extra/nnue_data_binpack_format.h"
 
+#include "nnue/evaluate_nnue.h"
 #include "nnue/evaluate_nnue_learner.h"
 
 #include "syzygy/tbprobe.h"

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -1486,6 +1486,27 @@ namespace Learner
         std::cout << "..shuffle_on_memory done." << std::endl;
     }
 
+    static void set_learning_search_limits()
+    {
+        // About Search::Limits
+        // Be careful because this member variable is global and affects other threads.
+        auto& limits = Search::Limits;
+
+        limits.startTime = now();
+
+        // Make the search equivalent to the "go infinite" command. (Because it is troublesome if time management is done)
+        limits.infinite = true;
+
+        // Since PV is an obstacle when displayed, erase it.
+        limits.silent = true;
+
+        // If you use this, it will be compared with the accumulated nodes of each thread. Therefore, do not use it.
+        limits.nodes = 0;
+
+        // depth is also processed by the one passed as an argument of Learner::search().
+        limits.depth = 0;
+    }
+
     // Learning from the generated game record
     void learn(Position&, istringstream& is)
     {
@@ -1837,30 +1858,9 @@ namespace Learner
 
         cout << "init.." << endl;
 
-        // Read evaluation function parameters
-        Eval::NNUE::init();
-
         Threads.main()->ponder = false;
 
-        // About Search::Limits
-        // Be careful because this member variable is global and affects other threads.
-        {
-          auto& limits = Search::Limits;
-
-          limits.startTime = now();
-
-          // Make the search equivalent to the "go infinite" command. (Because it is troublesome if time management is done)
-          limits.infinite = true;
-
-          // Since PV is an obstacle when displayed, erase it.
-          limits.silent = true;
-
-          // If you use this, it will be compared with the accumulated nodes of each thread. Therefore, do not use it.
-          limits.nodes = 0;
-
-          // depth is also processed by the one passed as an argument of Learner::search().
-          limits.depth = 0;
-        }
+        set_learning_search_limits();
 
         cout << "init_training.." << endl;
         Eval::NNUE::InitializeTraining(seed);
@@ -1906,6 +1906,8 @@ namespace Learner
         {
             sr.read_validation_set(validation_set_file_name, eval_limit);
         }
+
+        Eval::NNUE::verify_any_net_loaded();
 
         // Calculate rmse once at this point (timing of 0 sfen)
         // sr.calc_rmse();

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -903,6 +903,10 @@ namespace Learner
                     << " , learn_entropy = " << learn_sum_entropy / done
                     << endl;
             }
+
+            // Bigger space between progress reports so that they can be more
+            // easly disinguished. Looking for timestamps is hard.
+            cout << endl;
         }
         else
         {

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -1194,7 +1194,7 @@ namespace Learner
                 {
                     cout << " < best (" << best_loss << "), accepted" << endl;
                     best_loss = latest_loss;
-                    best_nn_directory = Path::Combine((std::string)Options["EvalSaveDir"], dir_name);
+                    best_nn_directory = Path::combine((std::string)Options["EvalSaveDir"], dir_name);
                     trials = newbob_num_trials;
 
                     if (tot >= last_lr_drop + auto_lr_drop)

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -964,7 +964,7 @@ namespace Learner
 
                         // Lock the evaluation function so that it is not used during updating.
                         lock_guard<shared_timed_mutex> write_lock(nn_mutex);
-                        Eval::NNUE::UpdateParameters();
+                        Eval::NNUE::update_parameters();
                     }
 
                     ++epoch;
@@ -998,7 +998,7 @@ namespace Learner
                         // loss calculation
                         calc_loss(thread_id, done);
 
-                        Eval::NNUE::CheckHealth();
+                        Eval::NNUE::check_health();
 
                         // Make a note of how far you have totaled.
                         sr.last_done = sr.total_done;
@@ -1127,7 +1127,7 @@ namespace Learner
                 learn_sum_entropy_win += learn_entropy_win;
                 learn_sum_entropy += learn_entropy;
 
-                Eval::NNUE::AddExample(pos, rootColor, ps, 1.0);
+                Eval::NNUE::add_example(pos, rootColor, ps, 1.0);
 
                 // Since the processing is completed, the counter of the processed number is incremented
                 sr.total_done++;
@@ -1207,13 +1207,13 @@ namespace Learner
                 {
                     cout << " < best (" << best_loss << "), accepted" << endl;
                     best_loss = latest_loss;
-                    best_nn_directory = Path::Combine((std::string)Options["EvalSaveDir"], dir_name);
+                    best_nn_directory = Path::combine((std::string)Options["EvalSaveDir"], dir_name);
                     trials = newbob_num_trials;
                 }
                 else
                 {
                     cout << " >= best (" << best_loss << "), rejected" << endl;
-                    best_nn_directory = Path::Combine((std::string)Options["EvalSaveDir"], dir_name);
+                    best_nn_directory = Path::combine((std::string)Options["EvalSaveDir"], dir_name);
 
                     if (--trials > 0 && !is_final)
                     {
@@ -1714,14 +1714,14 @@ namespace Learner
         // Display learning game file
         if (target_dir != "")
         {
-            string kif_base_dir = Path::Combine(base_dir, target_dir);
+            string kif_base_dir = Path::combine(base_dir, target_dir);
 
             namespace sys = std::filesystem;
             sys::path p(kif_base_dir); // Origin of enumeration
             std::for_each(sys::directory_iterator(p), sys::directory_iterator(),
                 [&](const sys::path& path) {
                     if (sys::is_regular_file(path))
-                        filenames.push_back(Path::Combine(target_dir, path.filename().generic_string()));
+                        filenames.push_back(Path::combine(target_dir, path.filename().generic_string()));
                 });
         }
 
@@ -1815,7 +1815,7 @@ namespace Learner
             // order so I'll reverse it here. I'm sorry.
             for (auto it = filenames.rbegin(); it != filenames.rend(); ++it)
             {
-                sr.filenames.push_back(Path::Combine(base_dir, *it));
+                sr.filenames.push_back(Path::combine(base_dir, *it));
             }
         }
 
@@ -1859,9 +1859,9 @@ namespace Learner
         set_learning_search_limits();
 
         cout << "init_training.." << endl;
-        Eval::NNUE::InitializeTraining(seed);
-        Eval::NNUE::SetBatchSize(nn_batch_size);
-        Eval::NNUE::SetOptions(nn_options);
+        Eval::NNUE::initialize_training(seed);
+        Eval::NNUE::set_batch_size(nn_batch_size);
+        Eval::NNUE::set_options(nn_options);
         if (newbob_decay != 1.0 && !Options["SkipLoadingEval"]) {
             // Save the current net to [EvalSaveDir]\original.
             Eval::NNUE::save_eval("original");
@@ -1869,7 +1869,7 @@ namespace Learner
             // Set the folder above to best_nn_directory so that the trainer can
             // resotre the network parameters from the original net file.
             learn_think.best_nn_directory =
-                Path::Combine(Options["EvalSaveDir"], "original");
+                Path::combine(Options["EvalSaveDir"], "original");
         }
 
         cout << "init done." << endl;
@@ -1923,7 +1923,7 @@ namespace Learner
         // Start learning.
         learn_think.go_think();
 
-        Eval::NNUE::FinalizeNet();
+        Eval::NNUE::finalize_net();
 
         // Save once at the end.
         learn_think.save(true);

--- a/src/learn/multi_think.cpp
+++ b/src/learn/multi_think.cpp
@@ -1,5 +1,7 @@
 ﻿#include "multi_think.h"
 
+#include "nnue/evaluate_nnue.h"
+
 #include "tt.h"
 #include "uci.h"
 #include "types.h"

--- a/src/learn/multi_think.cpp
+++ b/src/learn/multi_think.cpp
@@ -1,103 +1,103 @@
 ﻿#include "multi_think.h"
 
-#include "nnue/evaluate_nnue.h"
-
 #include "tt.h"
 #include "uci.h"
 #include "types.h"
 #include "search.h"
 
+#include "nnue/evaluate_nnue.h"
+
 #include <thread>
 
 void MultiThink::go_think()
 {
-	// Read evaluation function, etc.
-	// In the case of the learn command, the value of the evaluation function may be corrected after reading the evaluation function, so
-	// Skip memory corruption check.
-	Eval::NNUE::init();
+    // Read evaluation function, etc.
+    // In the case of the learn command, the value of the evaluation function may be corrected after reading the evaluation function, so
+    // Skip memory corruption check.
+    Eval::NNUE::init();
 
-	// Call the derived class's init().
-	init();
+    // Call the derived class's init().
+    init();
 
-	// The loop upper limit is set with set_loop_max().
-	loop_count = 0;
-	done_count = 0;
+    // The loop upper limit is set with set_loop_max().
+    loop_count = 0;
+    done_count = 0;
 
-	// Create threads as many as Options["Threads"] and start thinking.
-	std::vector<std::thread> threads;
-	auto thread_num = (size_t)Options["Threads"];
+    // Create threads as many as Options["Threads"] and start thinking.
+    std::vector<std::thread> threads;
+    auto thread_num = (size_t)Options["Threads"];
 
-	// Secure end flag of worker thread
+    // Secure end flag of worker thread
         threads_finished=0;
 
-	// start worker thread
-	for (size_t i = 0; i < thread_num; ++i)
-	{
-		threads.push_back(std::thread([i, this]
-		{
-			// exhaust all processor threads.
-			WinProcGroup::bindThisThread(i);
+    // start worker thread
+    for (size_t i = 0; i < thread_num; ++i)
+    {
+        threads.push_back(std::thread([i, this]
+        {
+            // exhaust all processor threads.
+            WinProcGroup::bindThisThread(i);
 
-			// execute the overridden process
-			this->thread_worker(i);
+            // execute the overridden process
+            this->thread_worker(i);
 
-			// Set the end flag because the thread has ended
-			this->threads_finished++;
-		}));
-	}
+            // Set the end flag because the thread has ended
+            this->threads_finished++;
+        }));
+    }
 
-	// wait for all threads to finish
-	// for (auto& th :threads)
-	// th.join();
-	// If you write like, the thread will rush here while it is still working,
-	// During that time, callback_func() cannot be called and you cannot save.
-	// Therefore, you need to check the end flag yourself.
+    // wait for all threads to finish
+    // for (auto& th :threads)
+    // th.join();
+    // If you write like, the thread will rush here while it is still working,
+    // During that time, callback_func() cannot be called and you cannot save.
+    // Therefore, you need to check the end flag yourself.
 
-	// function to determine if all threads have finished
-	auto threads_done = [&]()
-	{
-		return threads_finished == thread_num;
-	};
+    // function to determine if all threads have finished
+    auto threads_done = [&]()
+    {
+        return threads_finished == thread_num;
+    };
 
-	// Call back if the callback function is set.
-	auto do_a_callback = [&]()
-	{
-		if (callback_func)
-			callback_func();
-	};
+    // Call back if the callback function is set.
+    auto do_a_callback = [&]()
+    {
+        if (callback_func)
+            callback_func();
+    };
 
 
-	for (uint64_t i = 0 ; ; )
-	{
-		// If all threads have finished, exit the loop.
-		if (threads_done())
-			break;
+    for (uint64_t i = 0 ; ; )
+    {
+        // If all threads have finished, exit the loop.
+        if (threads_done())
+            break;
 
-		sleep(1000);
+        sleep(1000);
 
-		// callback_func() is called every callback_seconds.
-		if (++i == callback_seconds)
-		{
-			do_a_callback();
-			// Since I am returning from ↑, I reset the counter, so
-			// no matter how long it takes to save() etc. in do_a_callback()
-			// The next call will take a certain amount of time.
-			i = 0;
-		}
-	}
+        // callback_func() is called every callback_seconds.
+        if (++i == callback_seconds)
+        {
+            do_a_callback();
+            // Since I am returning from ↑, I reset the counter, so
+            // no matter how long it takes to save() etc. in do_a_callback()
+            // The next call will take a certain amount of time.
+            i = 0;
+        }
+    }
 
-	// Last save.
-	std::cout << std::endl << "finalize..";
+    // Last save.
+    std::cout << std::endl << "finalize..";
 
-	// do_a_callback();
-	// → It should be saved by the caller, so I feel that it is not necessary here.
+    // do_a_callback();
+    // → It should be saved by the caller, so I feel that it is not necessary here.
 
-	// It is possible that the exit code of the thread is running but the exit code of the thread is running, so
-	// We need to wait for the end with join().
-	for (auto& th : threads)
-		th.join();
+    // It is possible that the exit code of the thread is running but the exit code of the thread is running, so
+    // We need to wait for the end with join().
+    for (auto& th : threads)
+        th.join();
 
-	// The file writing thread etc. are still running only when all threads are finished
-	// Since the work itself may not have completed, output only that all threads have finished.
-	std::cout << "all threads are joined." << std::endl;
+    // The file writing thread etc. are still running only when all threads are finished
+    // Since the work itself may not have completed, output only that all threads have finished.
+    std::cout << "all threads are joined." << std::endl;
 }

--- a/src/learn/multi_think.cpp
+++ b/src/learn/multi_think.cpp
@@ -11,11 +11,6 @@
 
 void MultiThink::go_think()
 {
-    // Read evaluation function, etc.
-    // In the case of the learn command, the value of the evaluation function may be corrected after reading the evaluation function, so
-    // Skip memory corruption check.
-    Eval::NNUE::init();
-
     // Call the derived class's init().
     init();
 

--- a/src/learn/multi_think.h
+++ b/src/learn/multi_think.h
@@ -19,84 +19,84 @@
 // Derive and use this class.
 struct MultiThink
 {
-	static constexpr std::uint64_t LOOP_COUNT_FINISHED = std::numeric_limits<std::uint64_t>::max();
+    static constexpr std::uint64_t LOOP_COUNT_FINISHED = std::numeric_limits<std::uint64_t>::max();
 
-	MultiThink() : prng{}, loop_count(0) { }
+    MultiThink() : prng{}, loop_count(0) { }
 
-	MultiThink(std::uint64_t seed) : prng(seed), loop_count(0) { }
+    MultiThink(std::uint64_t seed) : prng(seed), loop_count(0) { }
 
-	MultiThink(const std::string& seed) : prng(seed), loop_count(0) { }
+    MultiThink(const std::string& seed) : prng(seed), loop_count(0) { }
 
-	// Call this function from the master thread, each thread will think,
-	// Return control when the thought ending condition is satisfied.
-	// Do something else.
-	// ・It is safe for each thread to call Learner::search(),qsearch()
-	// Separates the substitution table for each thread. (It will be restored after the end.)
-	// ・Book is not thread safe when in on the fly mode, so temporarily change this mode.
-	// Turn it off.
-	// [Requirements]
-	// 1) Override thread_worker()
-	// 2) Set the loop count with set_loop_max()
-	// 3) set a function to be called back periodically (if necessary)
-	// callback_func and callback_interval
-	void go_think();
+    // Call this function from the master thread, each thread will think,
+    // Return control when the thought ending condition is satisfied.
+    // Do something else.
+    // ・It is safe for each thread to call Learner::search(),qsearch()
+    // Separates the substitution table for each thread. (It will be restored after the end.)
+    // ・Book is not thread safe when in on the fly mode, so temporarily change this mode.
+    // Turn it off.
+    // [Requirements]
+    // 1) Override thread_worker()
+    // 2) Set the loop count with set_loop_max()
+    // 3) set a function to be called back periodically (if necessary)
+    // callback_func and callback_interval
+    void go_think();
 
-	// If there is something you want to initialize on the derived class side, override this,
-	// Called when initialization is completed with go_think().
-	// It is better to read the fixed trace at that timing.
-	virtual void init() {}
+    // If there is something you want to initialize on the derived class side, override this,
+    // Called when initialization is completed with go_think().
+    // It is better to read the fixed trace at that timing.
+    virtual void init() {}
 
-	// A thread worker that is called by creating a thread when you go_think()
-	// Override and use this.
-	virtual void thread_worker(size_t thread_id) = 0;
+    // A thread worker that is called by creating a thread when you go_think()
+    // Override and use this.
+    virtual void thread_worker(size_t thread_id) = 0;
 
-	// Called back every callback_seconds [seconds] when go_think().
-	std::function<void()> callback_func;
-	uint64_t callback_seconds = 600;
+    // Called back every callback_seconds [seconds] when go_think().
+    std::function<void()> callback_func;
+    uint64_t callback_seconds = 600;
 
-	// Set the number of times worker processes (calls Search::think()).
-	void set_loop_max(uint64_t loop_max_) { loop_max = loop_max_; }
+    // Set the number of times worker processes (calls Search::think()).
+    void set_loop_max(uint64_t loop_max_) { loop_max = loop_max_; }
 
-	// Get the value set by set_loop_max().
-	uint64_t get_loop_max() const { return loop_max; }
+    // Get the value set by set_loop_max().
+    uint64_t get_loop_max() const { return loop_max; }
 
-	// [ASYNC] Take the value of the loop counter and add the loop counter after taking it out.
-	// If the loop counter has reached loop_max, return UINT64_MAX.
-	// If you want to generate a phase, you must call this function at the time of generating the phase,
-	// Please note that the number of generated phases and the value of the counter will not match.
-	uint64_t get_next_loop_count() {
-		std::unique_lock<std::mutex> lk(loop_mutex);
-		if (loop_count >= loop_max)
-			return LOOP_COUNT_FINISHED;
-		return loop_count++;
-	}
+    // [ASYNC] Take the value of the loop counter and add the loop counter after taking it out.
+    // If the loop counter has reached loop_max, return UINT64_MAX.
+    // If you want to generate a phase, you must call this function at the time of generating the phase,
+    // Please note that the number of generated phases and the value of the counter will not match.
+    uint64_t get_next_loop_count() {
+        std::unique_lock<std::mutex> lk(loop_mutex);
+        if (loop_count >= loop_max)
+            return LOOP_COUNT_FINISHED;
+        return loop_count++;
+    }
 
-	// [ASYNC] For returning the processed number. Each time it is called, it returns a counter that is incremented.
-	uint64_t get_done_count() {
-		std::unique_lock<std::mutex> lk(loop_mutex);
-		return ++done_count;
-	}
+    // [ASYNC] For returning the processed number. Each time it is called, it returns a counter that is incremented.
+    uint64_t get_done_count() {
+        std::unique_lock<std::mutex> lk(loop_mutex);
+        return ++done_count;
+    }
 
-	// Mutex when worker thread accesses I/O
-	std::mutex io_mutex;
+    // Mutex when worker thread accesses I/O
+    std::mutex io_mutex;
 
 protected:
-	// Random number generator body
-	AsyncPRNG prng;
+    // Random number generator body
+    AsyncPRNG prng;
 
 private:
-	// number of times worker processes (calls Search::think())
-	std::atomic<uint64_t> loop_max;
-	// number of times the worker has processed (calls Search::think())
-	std::atomic<uint64_t> loop_count;
-	// To return the number of times it has been processed.
-	std::atomic<uint64_t> done_count;
+    // number of times worker processes (calls Search::think())
+    std::atomic<uint64_t> loop_max;
+    // number of times the worker has processed (calls Search::think())
+    std::atomic<uint64_t> loop_count;
+    // To return the number of times it has been processed.
+    std::atomic<uint64_t> done_count;
 
-	// Mutex when changing the variables in ↑
-	std::mutex loop_mutex;
+    // Mutex when changing the variables in ↑
+    std::mutex loop_mutex;
 
-	// Thread end flag.
-        std::atomic<uint64_t> threads_finished;
+    // Thread end flag.
+    std::atomic<uint64_t> threads_finished;
 };
 
 // Mechanism to process task during idle time.
@@ -105,48 +105,48 @@ private:
 // Convenient to use when you want to write MultiThink thread worker in master-slave method.
 struct TaskDispatcher
 {
-	typedef std::function<void(size_t /* thread_id */)> Task;
+    typedef std::function<void(size_t /* thread_id */)> Task;
 
-	// slave calls this function during idle.
-	void on_idle(size_t thread_id)
-	{
-		Task task;
-		while ((task = get_task_async()) != nullptr)
-			task(thread_id);
+    // slave calls this function during idle.
+    void on_idle(size_t thread_id)
+    {
+        Task task;
+        while ((task = get_task_async()) != nullptr)
+            task(thread_id);
 
-		sleep(1);
-	}
+        sleep(1);
+    }
 
-	// Stack [ASYNC] task.
-	void push_task_async(Task task)
-	{
-		std::unique_lock<std::mutex> lk(task_mutex);
-		tasks.push_back(task);
-	}
+    // Stack [ASYNC] task.
+    void push_task_async(Task task)
+    {
+        std::unique_lock<std::mutex> lk(task_mutex);
+        tasks.push_back(task);
+    }
 
-	// Allocate size array elements for task in advance.
-	void task_reserve(size_t size)
-	{
-		tasks.reserve(size);
-	}
+    // Allocate size array elements for task in advance.
+    void task_reserve(size_t size)
+    {
+        tasks.reserve(size);
+    }
 
 protected:
-	// set of tasks
-	std::vector<Task> tasks;
+    // set of tasks
+    std::vector<Task> tasks;
 
-	// Take out one [ASYNC] task. Called from on_idle().
-	Task get_task_async()
-	{
-		std::unique_lock<std::mutex> lk(task_mutex);
-		if (tasks.size() == 0)
-			return nullptr;
-		Task task = *tasks.rbegin();
-		tasks.pop_back();
-		return task;
-	}
+    // Take out one [ASYNC] task. Called from on_idle().
+    Task get_task_async()
+    {
+        std::unique_lock<std::mutex> lk(task_mutex);
+        if (tasks.size() == 0)
+            return nullptr;
+        Task task = *tasks.rbegin();
+        tasks.pop_back();
+        return task;
+    }
 
-	// a mutex for accessing tasks
-	std::mutex task_mutex;
+    // a mutex for accessing tasks
+    std::mutex task_mutex;
 };
 
 #endif

--- a/src/learn/sfen_packer.cpp
+++ b/src/learn/sfen_packer.cpp
@@ -13,378 +13,374 @@ using namespace std;
 
 namespace Learner {
 
-  // Class that handles bitstream
-  // useful when doing aspect encoding
-  struct BitStream
-  {
-    // Set the memory to store the data in advance.
-    // Assume that memory is cleared to 0.
-    void set_data(std::uint8_t* data_) { data = data_; reset(); }
-
-    // Get the pointer passed in set_data().
-    uint8_t* get_data() const { return data; }
-
-    // Get the cursor.
-    int get_cursor() const { return bit_cursor; }
-
-    // reset the cursor
-    void reset() { bit_cursor = 0; }
-
-    // Write 1bit to the stream.
-    // If b is non-zero, write out 1. If 0, write 0.
-    void write_one_bit(int b)
+    // Class that handles bitstream
+    // useful when doing aspect encoding
+    struct BitStream
     {
-      if (b)
-        data[bit_cursor / 8] |= 1 << (bit_cursor & 7);
+        // Set the memory to store the data in advance.
+        // Assume that memory is cleared to 0.
+        void set_data(std::uint8_t* data_) { data = data_; reset(); }
 
-      ++bit_cursor;
-    }
+        // Get the pointer passed in set_data().
+        uint8_t* get_data() const { return data; }
 
-    // Get 1 bit from the stream.
-    int read_one_bit()
+        // Get the cursor.
+        int get_cursor() const { return bit_cursor; }
+
+        // reset the cursor
+        void reset() { bit_cursor = 0; }
+
+        // Write 1bit to the stream.
+        // If b is non-zero, write out 1. If 0, write 0.
+        void write_one_bit(int b)
+        {
+            if (b)
+                data[bit_cursor / 8] |= 1 << (bit_cursor & 7);
+
+            ++bit_cursor;
+        }
+
+        // Get 1 bit from the stream.
+        int read_one_bit()
+        {
+            int b = (data[bit_cursor / 8] >> (bit_cursor & 7)) & 1;
+            ++bit_cursor;
+
+            return b;
+        }
+
+        // write n bits of data
+        // Data shall be written out from the lower order of d.
+        void write_n_bit(int d, int n)
+        {
+            for (int i = 0; i <n; ++i)
+                write_one_bit(d & (1 << i));
+        }
+
+        // read n bits of data
+        // Reverse conversion of write_n_bit().
+        int read_n_bit(int n)
+        {
+            int result = 0;
+            for (int i = 0; i < n; ++i)
+                result |= read_one_bit() ? (1 << i) : 0;
+
+            return result;
+        }
+
+    private:
+        // Next bit position to read/write.
+        int bit_cursor;
+
+        // data entity
+        std::uint8_t* data;
+    };
+
+    // Class for compressing/decompressing sfen
+    // sfen can be packed to 256bit (32bytes) by Huffman coding.
+    // This is proven by mini. The above is Huffman coding.
+    //
+    // Internal format = 1-bit turn + 7-bit king position *2 + piece on board (Huffman coding) + hand piece (Huffman coding)
+    // Side to move (White = 0, Black = 1) (1bit)
+    // White King Position (6 bits)
+    // Black King Position (6 bits)
+    // Huffman Encoding of the board
+    // Castling availability (1 bit x 4)
+    // En passant square (1 or 1 + 6 bits)
+    // Rule 50 (6 bits)
+    // Game play (8 bits)
+    //
+    // TODO(someone): Rename SFEN to FEN.
+    //
+    struct SfenPacker
     {
-      int b = (data[bit_cursor / 8] >> (bit_cursor & 7)) & 1;
-      ++bit_cursor;
+        void pack(const Position& pos);
 
-      return b;
-    }
+        // sfen packed by pack() (256bit = 32bytes)
+        // Or sfen to decode with unpack()
+        uint8_t *data; // uint8_t[32];
 
-    // write n bits of data
-    // Data shall be written out from the lower order of d.
-    void write_n_bit(int d, int n)
+        BitStream stream;
+
+        // Output the board pieces to stream.
+        void write_board_piece_to_stream(Piece pc);
+
+        // Read one board piece from stream
+        Piece read_board_piece_from_stream();
+    };
+
+
+    // Huffman coding
+    // * is simplified from mini encoding to make conversion easier.
+    //
+    // Huffman Encoding
+    //
+    // Empty  xxxxxxx0
+    // Pawn   xxxxx001 + 1 bit (Color)
+    // Knight xxxxx011 + 1 bit (Color)
+    // Bishop xxxxx101 + 1 bit (Color)
+    // Rook   xxxxx111 + 1 bit (Color)
+    // Queen   xxxx1001 + 1 bit (Color)
+    //
+    // Worst case:
+    // - 32 empty squares    32 bits
+    // - 30 pieces           150 bits
+    // - 2 kings             12 bits
+    // - castling rights     4 bits
+    // - ep square           7 bits
+    // - rule50              7 bits
+    // - game ply            16 bits
+    // - TOTAL               228 bits < 256 bits
+
+    struct HuffmanedPiece
     {
-      for (int i = 0; i <n; ++i)
-        write_one_bit(d & (1 << i));
-    }
+        int code; // how it will be coded
+        int bits; // How many bits do you have
+    };
 
-    // read n bits of data
-    // Reverse conversion of write_n_bit().
-    int read_n_bit(int n)
+    constexpr HuffmanedPiece huffman_table[] =
     {
-      int result = 0;
-      for (int i = 0; i < n; ++i)
-        result |= read_one_bit() ? (1 << i) : 0;
+        {0b0000,1}, // NO_PIECE
+        {0b0001,4}, // PAWN
+        {0b0011,4}, // KNIGHT
+        {0b0101,4}, // BISHOP
+        {0b0111,4}, // ROOK
+        {0b1001,4}, // QUEEN
+    };
 
-      return result;
+    // Pack sfen and store in data[32].
+    void SfenPacker::pack(const Position& pos)
+    {
+        memset(data, 0, 32 /* 256bit */);
+        stream.set_data(data);
+
+        // turn
+        // Side to move.
+        stream.write_one_bit((int)(pos.side_to_move()));
+
+        // 7-bit positions for leading and trailing balls
+        // White king and black king, 6 bits for each.
+        for(auto c: Colors)
+            stream.write_n_bit(pos.king_square(c), 6);
+
+        // Write the pieces on the board other than the kings.
+        for (Rank r = RANK_8; r >= RANK_1; --r)
+        {
+            for (File f = FILE_A; f <= FILE_H; ++f)
+            {
+                Piece pc = pos.piece_on(make_square(f, r));
+                if (type_of(pc) == KING)
+                    continue;
+                write_board_piece_to_stream(pc);
+            }
+        }
+
+        // TODO(someone): Support chess960.
+        stream.write_one_bit(pos.can_castle(WHITE_OO));
+        stream.write_one_bit(pos.can_castle(WHITE_OOO));
+        stream.write_one_bit(pos.can_castle(BLACK_OO));
+        stream.write_one_bit(pos.can_castle(BLACK_OOO));
+
+        if (pos.ep_square() == SQ_NONE) {
+            stream.write_one_bit(0);
+        }
+        else {
+            stream.write_one_bit(1);
+            stream.write_n_bit(static_cast<int>(pos.ep_square()), 6);
+        }
+
+        stream.write_n_bit(pos.state()->rule50, 6);
+
+        const int fm = 1 + (pos.game_ply()-(pos.side_to_move() == BLACK)) / 2;
+        stream.write_n_bit(fm, 8);
+
+        // Write high bits of half move. This is a fix for the
+        // limited range of half move counter.
+        // This is backwards compatibile.
+        stream.write_n_bit(fm >> 8, 8);
+
+        // Write the highest bit of rule50 at the end. This is a backwards
+        // compatibile fix for rule50 having only 6 bits stored.
+        // This bit is just ignored by the old parsers.
+        stream.write_n_bit(pos.state()->rule50 >> 6, 1);
+
+        assert(stream.get_cursor() <= 256);
     }
-
-  private:
-    // Next bit position to read/write.
-    int bit_cursor;
-
-    // data entity
-    std::uint8_t* data;
-  };
-
-  // Class for compressing/decompressing sfen
-  // sfen can be packed to 256bit (32bytes) by Huffman coding.
-  // This is proven by mini. The above is Huffman coding.
-  //
-  // Internal format = 1-bit turn + 7-bit king position *2 + piece on board (Huffman coding) + hand piece (Huffman coding)
-  // Side to move (White = 0, Black = 1) (1bit)
-  // White King Position (6 bits)
-  // Black King Position (6 bits)
-  // Huffman Encoding of the board
-  // Castling availability (1 bit x 4)
-  // En passant square (1 or 1 + 6 bits)
-  // Rule 50 (6 bits)
-  // Game play (8 bits)
-  //
-  // TODO(someone): Rename SFEN to FEN.
-  //
-  struct SfenPacker
-  {
-    void pack(const Position& pos);
-
-    // sfen packed by pack() (256bit = 32bytes)
-    // Or sfen to decode with unpack()
-    uint8_t *data; // uint8_t[32];
-
-    BitStream stream;
 
     // Output the board pieces to stream.
-    void write_board_piece_to_stream(Piece pc);
+    void SfenPacker::write_board_piece_to_stream(Piece pc)
+    {
+        // piece type
+        PieceType pr = type_of(pc);
+        auto c = huffman_table[pr];
+        stream.write_n_bit(c.code, c.bits);
+
+        if (pc == NO_PIECE)
+            return;
+
+        // first and second flag
+        stream.write_one_bit(color_of(pc));
+    }
 
     // Read one board piece from stream
-    Piece read_board_piece_from_stream();
-  };
-
-
-  // Huffman coding
-  // * is simplified from mini encoding to make conversion easier.
-  //
-  // Huffman Encoding
-  //
-  // Empty  xxxxxxx0
-  // Pawn   xxxxx001 + 1 bit (Color)
-  // Knight xxxxx011 + 1 bit (Color)
-  // Bishop xxxxx101 + 1 bit (Color)
-  // Rook   xxxxx111 + 1 bit (Color)
-  // Queen   xxxx1001 + 1 bit (Color)
-  //
-  // Worst case:
-  // - 32 empty squares    32 bits
-  // - 30 pieces           150 bits
-  // - 2 kings             12 bits
-  // - castling rights     4 bits
-  // - ep square           7 bits
-  // - rule50              7 bits
-  // - game ply            16 bits
-  // - TOTAL               228 bits < 256 bits
-
-  struct HuffmanedPiece
-  {
-    int code; // how it will be coded
-    int bits; // How many bits do you have
-  };
-
-  constexpr HuffmanedPiece huffman_table[] =
-  {
-    {0b0000,1}, // NO_PIECE
-    {0b0001,4}, // PAWN
-    {0b0011,4}, // KNIGHT
-    {0b0101,4}, // BISHOP
-    {0b0111,4}, // ROOK
-    {0b1001,4}, // QUEEN
-  };
-
-  // Pack sfen and store in data[32].
-  void SfenPacker::pack(const Position& pos)
-  {
-  // cout << pos;
-
-    memset(data, 0, 32 /* 256bit */);
-    stream.set_data(data);
-
-    // turn
-    // Side to move.
-    stream.write_one_bit((int)(pos.side_to_move()));
-
-    // 7-bit positions for leading and trailing balls
-    // White king and black king, 6 bits for each.
-    for(auto c: Colors)
-      stream.write_n_bit(pos.king_square(c), 6);
-
-    // Write the pieces on the board other than the kings.
-    for (Rank r = RANK_8; r >= RANK_1; --r)
+    Piece SfenPacker::read_board_piece_from_stream()
     {
-      for (File f = FILE_A; f <= FILE_H; ++f)
-      {
-        Piece pc = pos.piece_on(make_square(f, r));
-        if (type_of(pc) == KING)
-          continue;
-        write_board_piece_to_stream(pc);
-      }
-    }
-
-    // TODO(someone): Support chess960.
-    stream.write_one_bit(pos.can_castle(WHITE_OO));
-    stream.write_one_bit(pos.can_castle(WHITE_OOO));
-    stream.write_one_bit(pos.can_castle(BLACK_OO));
-    stream.write_one_bit(pos.can_castle(BLACK_OOO));
-
-    if (pos.ep_square() == SQ_NONE) {
-      stream.write_one_bit(0);
-    }
-    else {
-      stream.write_one_bit(1);
-      stream.write_n_bit(static_cast<int>(pos.ep_square()), 6);
-    }
-
-    stream.write_n_bit(pos.state()->rule50, 6);
-
-    const int fm = 1 + (pos.game_ply()-(pos.side_to_move() == BLACK)) / 2;
-    stream.write_n_bit(fm, 8);
-
-    // Write high bits of half move. This is a fix for the
-    // limited range of half move counter.
-    // This is backwards compatibile.
-    stream.write_n_bit(fm >> 8, 8);
-
-    // Write the highest bit of rule50 at the end. This is a backwards
-    // compatibile fix for rule50 having only 6 bits stored.
-    // This bit is just ignored by the old parsers.
-    stream.write_n_bit(pos.state()->rule50 >> 6, 1);
-
-    assert(stream.get_cursor() <= 256);
-  }
-
-  // Output the board pieces to stream.
-  void SfenPacker::write_board_piece_to_stream(Piece pc)
-  {
-    // piece type
-    PieceType pr = type_of(pc);
-    auto c = huffman_table[pr];
-    stream.write_n_bit(c.code, c.bits);
-
-    if (pc == NO_PIECE)
-      return;
-
-    // first and second flag
-    stream.write_one_bit(color_of(pc));
-  }
-
-  // Read one board piece from stream
-  Piece SfenPacker::read_board_piece_from_stream()
-  {
-    PieceType pr = NO_PIECE_TYPE;
-    int code = 0, bits = 0;
-    while (true)
-    {
-      code |= stream.read_one_bit() << bits;
-      ++bits;
-
-      assert(bits <= 6);
-
-      for (pr = NO_PIECE_TYPE; pr <KING; ++pr)
-        if (huffman_table[pr].code == code
-          && huffman_table[pr].bits == bits)
-          goto Found;
-    }
-  Found:;
-    if (pr == NO_PIECE_TYPE)
-      return NO_PIECE;
-
-    // first and second flag
-    Color c = (Color)stream.read_one_bit();
-
-    return make_piece(c, pr);
-  }
-
-  int set_from_packed_sfen(Position& pos, const PackedSfen& sfen, StateInfo* si, Thread* th)
-  {
-    SfenPacker packer;
-    auto& stream = packer.stream;
-
-    // TODO: separate streams for writing and reading. Here we actually have to
-    // const_cast which is not safe in the long run.
-    stream.set_data(const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(&sfen)));
-
-    pos.clear();
-    std::memset(si, 0, sizeof(StateInfo));
-    std::fill_n(&pos.pieceList[0][0], sizeof(pos.pieceList) / sizeof(Square), SQ_NONE);
-    pos.st = si;
-
-    // Active color
-    pos.sideToMove = (Color)stream.read_one_bit();
-
-    pos.pieceList[W_KING][0] = SQUARE_NB;
-    pos.pieceList[B_KING][0] = SQUARE_NB;
-
-    // First the position of the ball
-    for (auto c : Colors)
-      pos.board[stream.read_n_bit(6)] = make_piece(c, KING);
-
-    // Piece placement
-    for (Rank r = RANK_8; r >= RANK_1; --r)
-    {
-      for (File f = FILE_A; f <= FILE_H; ++f)
-      {
-        auto sq = make_square(f, r);
-
-        // it seems there are already balls
-        Piece pc;
-        if (type_of(pos.board[sq]) != KING)
+        PieceType pr = NO_PIECE_TYPE;
+        int code = 0, bits = 0;
+        while (true)
         {
-          assert(pos.board[sq] == NO_PIECE);
-          pc = packer.read_board_piece_from_stream();
+            code |= stream.read_one_bit() << bits;
+            ++bits;
+
+            assert(bits <= 6);
+
+            for (pr = NO_PIECE_TYPE; pr <KING; ++pr)
+                if (huffman_table[pr].code == code
+                    && huffman_table[pr].bits == bits)
+                    goto Found;
         }
-        else
+    Found:;
+        if (pr == NO_PIECE_TYPE)
+            return NO_PIECE;
+
+        // first and second flag
+        Color c = (Color)stream.read_one_bit();
+
+        return make_piece(c, pr);
+    }
+
+    int set_from_packed_sfen(Position& pos, const PackedSfen& sfen, StateInfo* si, Thread* th)
+    {
+        SfenPacker packer;
+        auto& stream = packer.stream;
+
+        // TODO: separate streams for writing and reading. Here we actually have to
+        // const_cast which is not safe in the long run.
+        stream.set_data(const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(&sfen)));
+
+        pos.clear();
+        std::memset(si, 0, sizeof(StateInfo));
+        std::fill_n(&pos.pieceList[0][0], sizeof(pos.pieceList) / sizeof(Square), SQ_NONE);
+        pos.st = si;
+
+        // Active color
+        pos.sideToMove = (Color)stream.read_one_bit();
+
+        pos.pieceList[W_KING][0] = SQUARE_NB;
+        pos.pieceList[B_KING][0] = SQUARE_NB;
+
+        // First the position of the ball
+        for (auto c : Colors)
+            pos.board[stream.read_n_bit(6)] = make_piece(c, KING);
+
+        // Piece placement
+        for (Rank r = RANK_8; r >= RANK_1; --r)
         {
-          pc = pos.board[sq];
-          // put_piece() will catch ASSERT unless you remove it all.
-          pos.board[sq] = NO_PIECE;
+            for (File f = FILE_A; f <= FILE_H; ++f)
+            {
+                auto sq = make_square(f, r);
+
+                // it seems there are already balls
+                Piece pc;
+                if (type_of(pos.board[sq]) != KING)
+                {
+                    assert(pos.board[sq] == NO_PIECE);
+                    pc = packer.read_board_piece_from_stream();
+                }
+                else
+                {
+                    pc = pos.board[sq];
+                    // put_piece() will catch ASSERT unless you remove it all.
+                    pos.board[sq] = NO_PIECE;
+                }
+
+                // There may be no pieces, so skip in that case.
+                if (pc == NO_PIECE)
+                    continue;
+
+                pos.put_piece(Piece(pc), sq);
+
+                if (stream.get_cursor()> 256)
+                    return 1;
+            }
         }
 
-        // There may be no pieces, so skip in that case.
-        if (pc == NO_PIECE)
-          continue;
+        // Castling availability.
+        // TODO(someone): Support chess960.
+        pos.st->castlingRights = 0;
+        if (stream.read_one_bit()) {
+            Square rsq;
+            for (rsq = relative_square(WHITE, SQ_H1); pos.piece_on(rsq) != W_ROOK; --rsq) {}
+            pos.set_castling_right(WHITE, rsq);
+        }
+        if (stream.read_one_bit()) {
+            Square rsq;
+            for (rsq = relative_square(WHITE, SQ_A1); pos.piece_on(rsq) != W_ROOK; ++rsq) {}
+            pos.set_castling_right(WHITE, rsq);
+        }
+        if (stream.read_one_bit()) {
+            Square rsq;
+            for (rsq = relative_square(BLACK, SQ_H1); pos.piece_on(rsq) != B_ROOK; --rsq) {}
+            pos.set_castling_right(BLACK, rsq);
+        }
+        if (stream.read_one_bit()) {
+            Square rsq;
+            for (rsq = relative_square(BLACK, SQ_A1); pos.piece_on(rsq) != B_ROOK; ++rsq) {}
+            pos.set_castling_right(BLACK, rsq);
+        }
 
-        pos.put_piece(Piece(pc), sq);
+        // En passant square. Ignore if no pawn capture is possible
+        if (stream.read_one_bit()) {
+            Square ep_square = static_cast<Square>(stream.read_n_bit(6));
+            pos.st->epSquare = ep_square;
 
-        if (stream.get_cursor()> 256)
-          return 1;
+            if (!(pos.attackers_to(pos.st->epSquare) & pos.pieces(pos.sideToMove, PAWN))
+                || !(pos.pieces(~pos.sideToMove, PAWN) & (pos.st->epSquare + pawn_push(~pos.sideToMove))))
+                pos.st->epSquare = SQ_NONE;
+        }
+        else {
+            pos.st->epSquare = SQ_NONE;
+        }
 
-        //assert(stream.get_cursor() <= 256);
-      }
+        // Halfmove clock
+        pos.st->rule50 = stream.read_n_bit(6);
+
+        // Fullmove number
+        pos.gamePly = stream.read_n_bit(8);
+
+        // Read the highest bit of rule50. This was added as a fix for rule50
+        // counter having only 6 bits stored.
+        // In older entries this will just be a zero bit.
+        pos.gamePly |= stream.read_n_bit(8) << 8;
+
+        // Read the highest bit of rule50. This was added as a fix for rule50
+        // counter having only 6 bits stored.
+        // In older entries this will just be a zero bit.
+        pos.st->rule50 |= stream.read_n_bit(1) << 6;
+
+        // Convert from fullmove starting from 1 to gamePly starting from 0,
+        // handle also common incorrect FEN with fullmove = 0.
+        pos.gamePly = std::max(2 * (pos.gamePly - 1), 0) + (pos.sideToMove == BLACK);
+
+        assert(stream.get_cursor() <= 256);
+
+        pos.chess960 = false;
+        pos.thisThread = th;
+        pos.set_state(pos.st);
+
+        assert(pos.pos_is_ok());
+
+        return 0;
     }
 
-    // Castling availability.
-    // TODO(someone): Support chess960.
-    pos.st->castlingRights = 0;
-    if (stream.read_one_bit()) {
-      Square rsq;
-      for (rsq = relative_square(WHITE, SQ_H1); pos.piece_on(rsq) != W_ROOK; --rsq) {}
-      pos.set_castling_right(WHITE, rsq);
+    PackedSfen sfen_pack(Position& pos)
+    {
+        PackedSfen sfen;
+
+        SfenPacker sp;
+        sp.data = (uint8_t*)&sfen;
+        sp.pack(pos);
+
+        return sfen;
     }
-    if (stream.read_one_bit()) {
-      Square rsq;
-      for (rsq = relative_square(WHITE, SQ_A1); pos.piece_on(rsq) != W_ROOK; ++rsq) {}
-      pos.set_castling_right(WHITE, rsq);
-    }
-    if (stream.read_one_bit()) {
-      Square rsq;
-      for (rsq = relative_square(BLACK, SQ_H1); pos.piece_on(rsq) != B_ROOK; --rsq) {}
-      pos.set_castling_right(BLACK, rsq);
-    }
-    if (stream.read_one_bit()) {
-      Square rsq;
-      for (rsq = relative_square(BLACK, SQ_A1); pos.piece_on(rsq) != B_ROOK; ++rsq) {}
-      pos.set_castling_right(BLACK, rsq);
-    }
-
-    // En passant square. Ignore if no pawn capture is possible
-    if (stream.read_one_bit()) {
-      Square ep_square = static_cast<Square>(stream.read_n_bit(6));
-      pos.st->epSquare = ep_square;
-
-      if (!(pos.attackers_to(pos.st->epSquare) & pos.pieces(pos.sideToMove, PAWN))
-        || !(pos.pieces(~pos.sideToMove, PAWN) & (pos.st->epSquare + pawn_push(~pos.sideToMove))))
-        pos.st->epSquare = SQ_NONE;
-    }
-    else {
-      pos.st->epSquare = SQ_NONE;
-    }
-
-    // Halfmove clock
-    pos.st->rule50 = stream.read_n_bit(6);
-
-    // Fullmove number
-    pos.gamePly = stream.read_n_bit(8);
-
-    // Read the highest bit of rule50. This was added as a fix for rule50
-    // counter having only 6 bits stored.
-    // In older entries this will just be a zero bit.
-    pos.gamePly |= stream.read_n_bit(8) << 8;
-
-    // Read the highest bit of rule50. This was added as a fix for rule50
-    // counter having only 6 bits stored.
-    // In older entries this will just be a zero bit.
-    pos.st->rule50 |= stream.read_n_bit(1) << 6;
-
-    // Convert from fullmove starting from 1 to gamePly starting from 0,
-    // handle also common incorrect FEN with fullmove = 0.
-    pos.gamePly = std::max(2 * (pos.gamePly - 1), 0) + (pos.sideToMove == BLACK);
-
-    assert(stream.get_cursor() <= 256);
-
-    pos.chess960 = false;
-    pos.thisThread = th;
-    pos.set_state(pos.st);
-
-    assert(pos.pos_is_ok());
-
-    return 0;
-  }
-
-  PackedSfen sfen_pack(Position& pos)
-  {
-    PackedSfen sfen;
-
-    SfenPacker sp;
-    sp.data = (uint8_t*)&sfen;
-    sp.pack(pos);
-
-    return sfen;
-  }
 }

--- a/src/learn/sfen_stream.h
+++ b/src/learn/sfen_stream.h
@@ -1,0 +1,213 @@
+#ifndef _SFEN_STREAM_H_
+#define _SFEN_STREAM_H_
+
+#include "packed_sfen.h"
+
+#include "extra/nnue_data_binpack_format.h"
+
+#include <optional>
+#include <fstream>
+#include <string>
+#include <memory>
+
+namespace Learner {
+
+    enum struct SfenOutputType
+    {
+        Bin,
+        Binpack
+    };
+
+    static bool ends_with(const std::string& lhs, const std::string& end)
+    {
+        if (end.size() > lhs.size()) return false;
+
+        return std::equal(end.rbegin(), end.rend(), lhs.rbegin());
+    }
+
+    static bool has_extension(const std::string& filename, const std::string& extension)
+    {
+        return ends_with(filename, "." + extension);
+    }
+
+    static std::string filename_with_extension(const std::string& filename, const std::string& ext)
+    {
+        if (ends_with(filename, ext))
+        {
+            return filename;
+        }
+        else
+        {
+            return filename + "." + ext;
+        }
+    }
+
+    struct BasicSfenInputStream
+    {
+        virtual std::optional<PackedSfenValue> next() = 0;
+        virtual bool eof() const = 0;
+        virtual ~BasicSfenInputStream() {}
+    };
+
+    struct BinSfenInputStream : BasicSfenInputStream
+    {
+        static constexpr auto openmode = std::ios::in | std::ios::binary;
+        static inline const std::string extension = "bin";
+
+        BinSfenInputStream(std::string filename) :
+            m_stream(filename, openmode),
+            m_eof(!m_stream)
+        {
+        }
+
+        std::optional<PackedSfenValue> next() override
+        {
+            PackedSfenValue e;
+            if(m_stream.read(reinterpret_cast<char*>(&e), sizeof(PackedSfenValue)))
+            {
+                return e;
+            }
+            else
+            {
+                m_eof = true;
+                return std::nullopt;
+            }
+        }
+
+        bool eof() const override
+        {
+            return m_eof;
+        }
+
+        ~BinSfenInputStream() override {}
+
+    private:
+        std::fstream m_stream;
+        bool m_eof;
+    };
+
+    struct BinpackSfenInputStream : BasicSfenInputStream
+    {
+        static constexpr auto openmode = std::ios::in | std::ios::binary;
+        static inline const std::string extension = "binpack";
+
+        BinpackSfenInputStream(std::string filename) :
+            m_stream(filename, openmode),
+            m_eof(!m_stream.hasNext())
+        {
+        }
+
+        std::optional<PackedSfenValue> next() override
+        {
+            static_assert(sizeof(binpack::nodchip::PackedSfenValue) == sizeof(PackedSfenValue));
+
+            if (!m_stream.hasNext())
+            {
+                m_eof = true;
+                return std::nullopt;
+            }
+
+            auto training_data_entry = m_stream.next();
+            auto v = binpack::trainingDataEntryToPackedSfenValue(training_data_entry);
+            PackedSfenValue psv;
+            // same layout, different types. One is from generic library.
+            std::memcpy(&psv, &v, sizeof(PackedSfenValue));
+
+            return psv;
+        }
+
+        bool eof() const override
+        {
+            return m_eof;
+        }
+
+        ~BinpackSfenInputStream() override {}
+
+    private:
+        binpack::CompressedTrainingDataEntryReader m_stream;
+        bool m_eof;
+    };
+
+    struct BasicSfenOutputStream
+    {
+        virtual void write(const PSVector& sfens) = 0;
+        virtual ~BasicSfenOutputStream() {}
+    };
+
+    struct BinSfenOutputStream : BasicSfenOutputStream
+    {
+        static constexpr auto openmode = std::ios::out | std::ios::binary | std::ios::app;
+        static inline const std::string extension = "bin";
+
+        BinSfenOutputStream(std::string filename) :
+            m_stream(filename_with_extension(filename, extension), openmode)
+        {
+        }
+
+        void write(const PSVector& sfens) override
+        {
+            m_stream.write(reinterpret_cast<const char*>(sfens.data()), sizeof(PackedSfenValue) * sfens.size());
+        }
+
+        ~BinSfenOutputStream() override {}
+
+    private:
+        std::fstream m_stream;
+    };
+
+    struct BinpackSfenOutputStream : BasicSfenOutputStream
+    {
+        static constexpr auto openmode = std::ios::out | std::ios::binary | std::ios::app;
+        static inline const std::string extension = "binpack";
+
+        BinpackSfenOutputStream(std::string filename) :
+            m_stream(filename_with_extension(filename, extension), openmode)
+        {
+        }
+
+        void write(const PSVector& sfens) override
+        {
+            static_assert(sizeof(binpack::nodchip::PackedSfenValue) == sizeof(PackedSfenValue));
+
+            for(auto& sfen : sfens)
+            {
+                // The library uses a type that's different but layout-compatibile.
+                binpack::nodchip::PackedSfenValue e;
+                std::memcpy(&e, &sfen, sizeof(binpack::nodchip::PackedSfenValue));
+                m_stream.addTrainingDataEntry(binpack::packedSfenValueToTrainingDataEntry(e));
+            }
+        }
+
+        ~BinpackSfenOutputStream() override {}
+
+    private:
+        binpack::CompressedTrainingDataEntryWriter m_stream;
+    };
+
+    inline std::unique_ptr<BasicSfenInputStream> open_sfen_input_file(const std::string& filename)
+    {
+        if (has_extension(filename, BinSfenInputStream::extension))
+            return std::make_unique<BinSfenInputStream>(filename);
+        else if (has_extension(filename, BinpackSfenInputStream::extension))
+            return std::make_unique<BinpackSfenInputStream>(filename);
+
+        assert(false);
+        return nullptr;
+    }
+
+    inline std::unique_ptr<BasicSfenOutputStream> create_new_sfen_output(const std::string& filename, SfenOutputType sfen_output_type)
+    {
+        switch(sfen_output_type)
+        {
+            case SfenOutputType::Bin:
+                return std::make_unique<BinSfenOutputStream>(filename);
+            case SfenOutputType::Binpack:
+                return std::make_unique<BinpackSfenOutputStream>(filename);
+        }
+
+        assert(false);
+        return nullptr;
+    }
+}
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,8 @@
 
 #include <iostream>
 
+#include "nnue/evaluate_nnue.h"
+
 #include "bitboard.h"
 #include "endgame.h"
 #include "position.h"

--- a/src/misc.h
+++ b/src/misc.h
@@ -30,6 +30,7 @@
 #include <utility>
 #include <cmath>
 #include <cctype>
+#include <sstream>
 
 #include "types.h"
 
@@ -272,6 +273,19 @@ namespace Algo {
         const auto size = buf.size();
         for (uint64_t i = 0; i < size; ++i)
             std::swap(buf[i], buf[prng.rand(size - i) + i]);
+    }
+
+    // split the string
+    inline std::vector<std::string> split(const std::string& input, char delimiter) {
+        std::istringstream stream(input);
+        std::string field;
+        std::vector<std::string> fields;
+
+        while (std::getline(stream, field, delimiter)) {
+            fields.push_back(field);
+        }
+
+        return fields;
     }
 }
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -299,7 +299,7 @@ struct Path
 {
 	// Combine the path name and file name and return it.
 	// If the folder name is not an empty string, append it if there is no'/' or'\\' at the end.
-	static std::string Combine(const std::string& folder, const std::string& filename)
+	static std::string combine(const std::string& folder, const std::string& filename)
 	{
 		if (folder.length() >= 1 && *folder.rbegin() != '/' && *folder.rbegin() != '\\')
 			return folder + "/" + filename;
@@ -308,7 +308,7 @@ struct Path
 	}
 
 	// Get the file name part (excluding the folder name) from the full path expression.
-	static std::string GetFileName(const std::string& path)
+	static std::string get_file_name(const std::string& path)
 	{
 		// I don't know which "\" or "/" is used.
 		auto path_index1 = path.find_last_of("\\") + 1;

--- a/src/nnue/architectures/halfkp-cr-ep_256x2-32-32.h
+++ b/src/nnue/architectures/halfkp-cr-ep_256x2-32-32.h
@@ -1,19 +1,19 @@
 /*
-  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
-  Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
+    Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+    Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
 
-  Stockfish is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+    Stockfish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-  Stockfish is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+    Stockfish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 // Definition of input features and network structure used in NNUE evaluation function
@@ -21,36 +21,36 @@
 #ifndef NNUE_HALFKP_CR_EP_256X2_32_32_H_INCLUDED
 #define NNUE_HALFKP_CR_EP_256X2_32_32_H_INCLUDED
 
-#include "../features/feature_set.h"
-#include "../features/half_kp.h"
-#include "../features/castling_right.h"
-#include "../features/enpassant.h"
+#include "nnue/features/feature_set.h"
+#include "nnue/features/half_kp.h"
+#include "nnue/features/castling_right.h"
+#include "nnue/features/enpassant.h"
 
-#include "../layers/input_slice.h"
-#include "../layers/affine_transform.h"
-#include "../layers/clipped_relu.h"
+#include "nnue/layers/input_slice.h"
+#include "nnue/layers/affine_transform.h"
+#include "nnue/layers/clipped_relu.h"
 
 namespace Eval::NNUE {
 
-// Input features used in evaluation function
-using RawFeatures = Features::FeatureSet<
-    Features::HalfKP<Features::Side::kFriend>, Features::CastlingRight,
-    Features::EnPassant>;
+    // Input features used in evaluation function
+    using RawFeatures = Features::FeatureSet<
+        Features::HalfKP<Features::Side::kFriend>, Features::CastlingRight,
+        Features::EnPassant>;
 
-// Number of input feature dimensions after conversion
-constexpr IndexType kTransformedFeatureDimensions = 256;
+    // Number of input feature dimensions after conversion
+    constexpr IndexType kTransformedFeatureDimensions = 256;
 
-namespace Layers {
+    namespace Layers {
 
-// Define network structure
-using InputLayer = InputSlice<kTransformedFeatureDimensions * 2>;
-using HiddenLayer1 = ClippedReLU<AffineTransform<InputLayer, 32>>;
-using HiddenLayer2 = ClippedReLU<AffineTransform<HiddenLayer1, 32>>;
-using OutputLayer = AffineTransform<HiddenLayer2, 1>;
+        // Define network structure
+        using InputLayer = InputSlice<kTransformedFeatureDimensions * 2>;
+        using HiddenLayer1 = ClippedReLU<AffineTransform<InputLayer, 32>>;
+        using HiddenLayer2 = ClippedReLU<AffineTransform<HiddenLayer1, 32>>;
+        using OutputLayer = AffineTransform<HiddenLayer2, 1>;
 
-}  // namespace Layers
+    }  // namespace Layers
 
-using Network = Layers::OutputLayer;
+    using Network = Layers::OutputLayer;
 
 }  // namespace Eval::NNUE
 

--- a/src/nnue/architectures/halfkp-cr_256x2-32-32.h
+++ b/src/nnue/architectures/halfkp-cr_256x2-32-32.h
@@ -3,34 +3,34 @@
 #ifndef NNUE_HALFKP_CR_256X2_32_32_H_INCLUDED
 #define NNUE_HALFKP_CR_256X2_32_32_H_INCLUDED
 
-#include "../features/feature_set.h"
-#include "../features/half_kp.h"
-#include "../features/castling_right.h"
+#include "nnue/features/feature_set.h"
+#include "nnue/features/half_kp.h"
+#include "nnue/features/castling_right.h"
 
-#include "../layers/input_slice.h"
-#include "../layers/affine_transform.h"
-#include "../layers/clipped_relu.h"
+#include "nnue/layers/input_slice.h"
+#include "nnue/layers/affine_transform.h"
+#include "nnue/layers/clipped_relu.h"
 
 namespace Eval::NNUE {
 
-// Input features used in evaluation function
-using RawFeatures = Features::FeatureSet<
-    Features::HalfKP<Features::Side::kFriend>, Features::CastlingRight>;
+    // Input features used in evaluation function
+    using RawFeatures = Features::FeatureSet<
+        Features::HalfKP<Features::Side::kFriend>, Features::CastlingRight>;
 
-// Number of input feature dimensions after conversion
-constexpr IndexType kTransformedFeatureDimensions = 256;
+    // Number of input feature dimensions after conversion
+    constexpr IndexType kTransformedFeatureDimensions = 256;
 
-namespace Layers {
+    namespace Layers {
 
-// Define network structure
-using InputLayer = InputSlice<kTransformedFeatureDimensions * 2>;
-using HiddenLayer1 = ClippedReLU<AffineTransform<InputLayer, 32>>;
-using HiddenLayer2 = ClippedReLU<AffineTransform<HiddenLayer1, 32>>;
-using OutputLayer = AffineTransform<HiddenLayer2, 1>;
+        // Define network structure
+        using InputLayer = InputSlice<kTransformedFeatureDimensions * 2>;
+        using HiddenLayer1 = ClippedReLU<AffineTransform<InputLayer, 32>>;
+        using HiddenLayer2 = ClippedReLU<AffineTransform<HiddenLayer1, 32>>;
+        using OutputLayer = AffineTransform<HiddenLayer2, 1>;
 
-}  // namespace Layers
+    }  // namespace Layers
 
-using Network = Layers::OutputLayer;
+    using Network = Layers::OutputLayer;
 
 }  // namespace Eval::NNUE
 

--- a/src/nnue/architectures/halfkp_256x2-32-32.h
+++ b/src/nnue/architectures/halfkp_256x2-32-32.h
@@ -1,19 +1,19 @@
 /*
-  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
-  Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
+    Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+    Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
 
-  Stockfish is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+    Stockfish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-  Stockfish is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+    Stockfish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 // Definition of input features and network structure used in NNUE evaluation function
@@ -21,33 +21,33 @@
 #ifndef NNUE_HALFKP_256X2_32_32_H_INCLUDED
 #define NNUE_HALFKP_256X2_32_32_H_INCLUDED
 
-#include "../features/feature_set.h"
-#include "../features/half_kp.h"
+#include "nnue/features/feature_set.h"
+#include "nnue/features/half_kp.h"
 
-#include "../layers/input_slice.h"
-#include "../layers/affine_transform.h"
-#include "../layers/clipped_relu.h"
+#include "nnue/layers/input_slice.h"
+#include "nnue/layers/affine_transform.h"
+#include "nnue/layers/clipped_relu.h"
 
 namespace Eval::NNUE {
 
-// Input features used in evaluation function
-using RawFeatures = Features::FeatureSet<
-    Features::HalfKP<Features::Side::kFriend>>;
+    // Input features used in evaluation function
+    using RawFeatures = Features::FeatureSet<
+        Features::HalfKP<Features::Side::kFriend>>;
 
-// Number of input feature dimensions after conversion
-constexpr IndexType kTransformedFeatureDimensions = 256;
+    // Number of input feature dimensions after conversion
+    constexpr IndexType kTransformedFeatureDimensions = 256;
 
-namespace Layers {
+    namespace Layers {
 
-// Define network structure
-using InputLayer = InputSlice<kTransformedFeatureDimensions * 2>;
-using HiddenLayer1 = ClippedReLU<AffineTransform<InputLayer, 32>>;
-using HiddenLayer2 = ClippedReLU<AffineTransform<HiddenLayer1, 32>>;
-using OutputLayer = AffineTransform<HiddenLayer2, 1>;
+        // Define network structure
+        using InputLayer = InputSlice<kTransformedFeatureDimensions * 2>;
+        using HiddenLayer1 = ClippedReLU<AffineTransform<InputLayer, 32>>;
+        using HiddenLayer2 = ClippedReLU<AffineTransform<HiddenLayer1, 32>>;
+        using OutputLayer = AffineTransform<HiddenLayer2, 1>;
 
-}  // namespace Layers
+    }  // namespace Layers
 
-using Network = Layers::OutputLayer;
+    using Network = Layers::OutputLayer;
 
 }  // namespace Eval::NNUE
 

--- a/src/nnue/architectures/halfkp_384x2-32-32.h
+++ b/src/nnue/architectures/halfkp_384x2-32-32.h
@@ -3,37 +3,33 @@
 #ifndef HALFKP_384X2_32_32_H
 #define HALFKP_384X2_32_32_H
 
-#include "../features/feature_set.h"
-#include "../features/half_kp.h"
+#include "nnue/features/feature_set.h"
+#include "nnue/features/half_kp.h"
 
-#include "../layers/input_slice.h"
-#include "../layers/affine_transform.h"
-#include "../layers/clipped_relu.h"
+#include "nnue/layers/input_slice.h"
+#include "nnue/layers/affine_transform.h"
+#include "nnue/layers/clipped_relu.h"
 
-namespace Eval {
+namespace Eval::NNUE {
 
-namespace NNUE {
+    // Input features used in evaluation function
+    using RawFeatures = Features::FeatureSet<
+        Features::HalfKP<Features::Side::kFriend>>;
 
-// Input features used in evaluation function
-using RawFeatures = Features::FeatureSet<
-    Features::HalfKP<Features::Side::kFriend>>;
+    // Number of input feature dimensions after conversion
+    constexpr IndexType kTransformedFeatureDimensions = 384;
 
-// Number of input feature dimensions after conversion
-constexpr IndexType kTransformedFeatureDimensions = 384;
+    namespace Layers {
 
-namespace Layers {
+        // define network structure
+        using InputLayer = InputSlice<kTransformedFeatureDimensions * 2>;
+        using HiddenLayer1 = ClippedReLU<AffineTransform<InputLayer, 32>>;
+        using HiddenLayer2 = ClippedReLU<AffineTransform<HiddenLayer1, 32>>;
+        using OutputLayer = AffineTransform<HiddenLayer2, 1>;
 
-// define network structure
-using InputLayer = InputSlice<kTransformedFeatureDimensions * 2>;
-using HiddenLayer1 = ClippedReLU<AffineTransform<InputLayer, 32>>;
-using HiddenLayer2 = ClippedReLU<AffineTransform<HiddenLayer1, 32>>;
-using OutputLayer = AffineTransform<HiddenLayer2, 1>;
+    }  // namespace Layers
 
-}  // namespace Layers
+    using Network = Layers::OutputLayer;
 
-using Network = Layers::OutputLayer;
-
-}  // namespace NNUE
-
-}  // namespace Eval
+}  // namespace Eval::NNUE
 #endif // HALFKP_384X2_32_32_H

--- a/src/nnue/architectures/k-p-cr-ep_256x2-32-32.h
+++ b/src/nnue/architectures/k-p-cr-ep_256x2-32-32.h
@@ -3,40 +3,36 @@
 #ifndef K_P_CR_EP_256X2_32_32_H
 #define K_P_CR_EP_256X2_32_32_H
 
-#include "../features/feature_set.h"
-#include "../features/k.h"
-#include "../features/p.h"
-#include "../features/castling_right.h"
-#include "../features/enpassant.h"
+#include "nnue/features/feature_set.h"
+#include "nnue/features/k.h"
+#include "nnue/features/p.h"
+#include "nnue/features/castling_right.h"
+#include "nnue/features/enpassant.h"
 
-#include "../layers/input_slice.h"
-#include "../layers/affine_transform.h"
-#include "../layers/clipped_relu.h"
+#include "nnue/layers/input_slice.h"
+#include "nnue/layers/affine_transform.h"
+#include "nnue/layers/clipped_relu.h"
 
-namespace Eval {
-
-  namespace NNUE {
+namespace Eval::NNUE {
 
     // Input features used in evaluation function
     using RawFeatures = Features::FeatureSet<Features::K, Features::P,
-      Features::CastlingRight, Features::EnPassant>;
+        Features::CastlingRight, Features::EnPassant>;
 
     // Number of input feature dimensions after conversion
     constexpr IndexType kTransformedFeatureDimensions = 256;
 
     namespace Layers {
 
-      // define network structure
-      using InputLayer = InputSlice<kTransformedFeatureDimensions * 2>;
-      using HiddenLayer1 = ClippedReLU<AffineTransform<InputLayer, 32>>;
-      using HiddenLayer2 = ClippedReLU<AffineTransform<HiddenLayer1, 32>>;
-      using OutputLayer = AffineTransform<HiddenLayer2, 1>;
+        // define network structure
+        using InputLayer = InputSlice<kTransformedFeatureDimensions * 2>;
+        using HiddenLayer1 = ClippedReLU<AffineTransform<InputLayer, 32>>;
+        using HiddenLayer2 = ClippedReLU<AffineTransform<HiddenLayer1, 32>>;
+        using OutputLayer = AffineTransform<HiddenLayer2, 1>;
 
     }  // namespace Layers
 
     using Network = Layers::OutputLayer;
 
-  }  // namespace NNUE
-
-}  // namespace Eval
+}  // namespace Eval::NNUE
 #endif // K_P_CR_EP_256X2_32_32_H

--- a/src/nnue/architectures/k-p-cr_256x2-32-32.h
+++ b/src/nnue/architectures/k-p-cr_256x2-32-32.h
@@ -3,39 +3,35 @@
 #ifndef K_P_CR_256X2_32_32_H
 #define K_P_CR_256X2_32_32_H
 
-#include "../features/feature_set.h"
-#include "../features/k.h"
-#include "../features/p.h"
-#include "../features/castling_right.h"
+#include "nnue/features/feature_set.h"
+#include "nnue/features/k.h"
+#include "nnue/features/p.h"
+#include "nnue/features/castling_right.h"
 
-#include "../layers/input_slice.h"
-#include "../layers/affine_transform.h"
-#include "../layers/clipped_relu.h"
+#include "nnue/layers/input_slice.h"
+#include "nnue/layers/affine_transform.h"
+#include "nnue/layers/clipped_relu.h"
 
-namespace Eval {
-
-  namespace NNUE {
+namespace Eval::NNUE {
 
     // Input features used in evaluation function
     using RawFeatures = Features::FeatureSet<Features::K, Features::P,
-      Features::CastlingRight>;
+        Features::CastlingRight>;
 
     // Number of input feature dimensions after conversion
     constexpr IndexType kTransformedFeatureDimensions = 256;
 
     namespace Layers {
 
-      // define network structure
-      using InputLayer = InputSlice<kTransformedFeatureDimensions * 2>;
-      using HiddenLayer1 = ClippedReLU<AffineTransform<InputLayer, 32>>;
-      using HiddenLayer2 = ClippedReLU<AffineTransform<HiddenLayer1, 32>>;
-      using OutputLayer = AffineTransform<HiddenLayer2, 1>;
+        // define network structure
+        using InputLayer = InputSlice<kTransformedFeatureDimensions * 2>;
+        using HiddenLayer1 = ClippedReLU<AffineTransform<InputLayer, 32>>;
+        using HiddenLayer2 = ClippedReLU<AffineTransform<HiddenLayer1, 32>>;
+        using OutputLayer = AffineTransform<HiddenLayer2, 1>;
 
     }  // namespace Layers
 
     using Network = Layers::OutputLayer;
 
-  }  // namespace NNUE
-
-}  // namespace Eval
+}  // namespace Eval::NNUE
 #endif // K_P_CR_256X2_32_32_H

--- a/src/nnue/architectures/k-p_256x2-32-32.h
+++ b/src/nnue/architectures/k-p_256x2-32-32.h
@@ -3,37 +3,33 @@
 #ifndef K_P_256X2_32_32_H
 #define K_P_256X2_32_32_H
 
-#include "../features/feature_set.h"
-#include "../features/k.h"
-#include "../features/p.h"
+#include "nnue/features/feature_set.h"
+#include "nnue/features/k.h"
+#include "nnue/features/p.h"
 
-#include "../layers/input_slice.h"
-#include "../layers/affine_transform.h"
-#include "../layers/clipped_relu.h"
+#include "nnue/layers/input_slice.h"
+#include "nnue/layers/affine_transform.h"
+#include "nnue/layers/clipped_relu.h"
 
-namespace Eval {
+namespace Eval::NNUE {
 
-namespace NNUE {
+    // Input features used in evaluation function
+    using RawFeatures = Features::FeatureSet<Features::K, Features::P>;
 
-// Input features used in evaluation function
-using RawFeatures = Features::FeatureSet<Features::K, Features::P>;
+    // Number of input feature dimensions after conversion
+    constexpr IndexType kTransformedFeatureDimensions = 256;
 
-// Number of input feature dimensions after conversion
-constexpr IndexType kTransformedFeatureDimensions = 256;
+    namespace Layers {
 
-namespace Layers {
+        // define network structure
+        using InputLayer = InputSlice<kTransformedFeatureDimensions * 2>;
+        using HiddenLayer1 = ClippedReLU<AffineTransform<InputLayer, 32>>;
+        using HiddenLayer2 = ClippedReLU<AffineTransform<HiddenLayer1, 32>>;
+        using OutputLayer = AffineTransform<HiddenLayer2, 1>;
 
-// define network structure
-using InputLayer = InputSlice<kTransformedFeatureDimensions * 2>;
-using HiddenLayer1 = ClippedReLU<AffineTransform<InputLayer, 32>>;
-using HiddenLayer2 = ClippedReLU<AffineTransform<HiddenLayer1, 32>>;
-using OutputLayer = AffineTransform<HiddenLayer2, 1>;
+    }  // namespace Layers
 
-}  // namespace Layers
+    using Network = Layers::OutputLayer;
 
-using Network = Layers::OutputLayer;
-
-}  // namespace NNUE
-
-}  // namespace Eval
+}  // namespace Eval::NNUE
 #endif // K_P_256X2_32_32_H

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -235,6 +235,7 @@ namespace Eval::NNUE {
             else
             {
                 sync_cout << "info string ERROR: failed to load eval file " << directory + eval_file << sync_endl;
+                eval_file_loaded.clear();
             }
         }
 
@@ -243,7 +244,7 @@ namespace Eval::NNUE {
   }
 
   /// NNUE::verify() verifies that the last net used was loaded successfully
-  void verify() {
+  void verify_eval_file_loaded() {
 
     std::string eval_file = std::string(Options["EvalFile"]);
 
@@ -269,6 +270,33 @@ namespace Eval::NNUE {
 
     if (useNNUE != UseNNUEMode::False)
         sync_cout << "info string NNUE evaluation using " << eval_file << " enabled" << sync_endl;
+    else
+        sync_cout << "info string classical evaluation enabled" << sync_endl;
+  }
+
+  /// In training we override eval file so this is useful.
+  void verify_any_net_loaded() {
+
+    if (useNNUE != UseNNUEMode::False && eval_file_loaded.empty())
+    {
+        UCI::OptionsMap defaults;
+        UCI::init(defaults);
+
+        std::string msg1 = "If the UCI option \"Use NNUE\" is set to true, network evaluation parameters compatible with the engine must be available.";
+        std::string msg2 = "The option is set to true, but the network file was not loaded successfully.";
+        std::string msg3 = "The UCI option EvalFile might need to specify the full path, including the directory name, to the network file.";
+        std::string msg5 = "The engine will be terminated now.";
+
+        sync_cout << "info string ERROR: " << msg1 << sync_endl;
+        sync_cout << "info string ERROR: " << msg2 << sync_endl;
+        sync_cout << "info string ERROR: " << msg3 << sync_endl;
+        sync_cout << "info string ERROR: " << msg5 << sync_endl;
+
+        std::exit(EXIT_FAILURE);
+    }
+
+    if (useNNUE != UseNNUEMode::False)
+        sync_cout << "info string NNUE evaluation using " << eval_file_loaded << " enabled" << sync_endl;
     else
         sync_cout << "info string classical evaluation enabled" << sync_endl;
   }

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -1,304 +1,337 @@
 /*
-  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
-  Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
+    Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+    Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
 
-  Stockfish is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+    Stockfish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-  Stockfish is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+    Stockfish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 // Code for calculating NNUE evaluation function
+
+#include "evaluate_nnue.h"
+
+#include "position.h"
+#include "misc.h"
+#include "uci.h"
+#include "types.h"
 
 #include <iostream>
 #include <string>
 #include <fstream>
 #include <set>
 
-#include "../position.h"
-#include "../misc.h"
-#include "../uci.h"
-#include "../types.h"
-
-#include "evaluate_nnue.h"
-
 namespace Eval::NNUE {
 
-  const uint32_t kpp_board_index[PIECE_NB][COLOR_NB] = {
-   // convention: W - us, B - them
-   // viewed from other side, W and B are reversed
-      { PS_NONE,     PS_NONE     },
-      { PS_W_PAWN,   PS_B_PAWN   },
-      { PS_W_KNIGHT, PS_B_KNIGHT },
-      { PS_W_BISHOP, PS_B_BISHOP },
-      { PS_W_ROOK,   PS_B_ROOK   },
-      { PS_W_QUEEN,  PS_B_QUEEN  },
-      { PS_W_KING,   PS_B_KING   },
-      { PS_NONE,     PS_NONE     },
-      { PS_NONE,     PS_NONE     },
-      { PS_B_PAWN,   PS_W_PAWN   },
-      { PS_B_KNIGHT, PS_W_KNIGHT },
-      { PS_B_BISHOP, PS_W_BISHOP },
-      { PS_B_ROOK,   PS_W_ROOK   },
-      { PS_B_QUEEN,  PS_W_QUEEN  },
-      { PS_B_KING,   PS_W_KING   },
-      { PS_NONE,     PS_NONE     }
-  };
+    const uint32_t kpp_board_index[PIECE_NB][COLOR_NB] = {
+        // convention: W - us, B - them
+        // viewed from other side, W and B are reversed
+        { PS_NONE,     PS_NONE     },
+        { PS_W_PAWN,   PS_B_PAWN   },
+        { PS_W_KNIGHT, PS_B_KNIGHT },
+        { PS_W_BISHOP, PS_B_BISHOP },
+        { PS_W_ROOK,   PS_B_ROOK   },
+        { PS_W_QUEEN,  PS_B_QUEEN  },
+        { PS_W_KING,   PS_B_KING   },
+        { PS_NONE,     PS_NONE     },
+        { PS_NONE,     PS_NONE     },
+        { PS_B_PAWN,   PS_W_PAWN   },
+        { PS_B_KNIGHT, PS_W_KNIGHT },
+        { PS_B_BISHOP, PS_W_BISHOP },
+        { PS_B_ROOK,   PS_W_ROOK   },
+        { PS_B_QUEEN,  PS_W_QUEEN  },
+        { PS_B_KING,   PS_W_KING   },
+        { PS_NONE,     PS_NONE     }
+    };
 
-  // Input feature converter
-  LargePagePtr<FeatureTransformer> feature_transformer;
+    // Input feature converter
+    LargePagePtr<FeatureTransformer> feature_transformer;
 
-  // Evaluation function
-  AlignedPtr<Network> network;
+    // Evaluation function
+    AlignedPtr<Network> network;
 
-  // Evaluation function file name
-  std::string fileName;
+    // Evaluation function file name
+    std::string fileName;
 
-  // Saved evaluation function file name
-  std::string savedfileName = "nn.bin";
+    // Saved evaluation function file name
+    std::string savedfileName = "nn.bin";
 
-  // Get a string that represents the structure of the evaluation function
-  std::string GetArchitectureString() {
-    return "Features=" + FeatureTransformer::GetStructureString() +
-      ",Network=" + Network::GetStructureString();
-  }
+    UseNNUEMode useNNUE;
+    std::string eval_file_loaded = "None";
 
-  UseNNUEMode useNNUE;
-  std::string eval_file_loaded = "None";
-
-  namespace Detail {
-
-  // Initialize the evaluation function parameters
-  template <typename T>
-  void Initialize(AlignedPtr<T>& pointer) {
-
-    pointer.reset(reinterpret_cast<T*>(std_aligned_alloc(alignof(T), sizeof(T))));
-    std::memset(pointer.get(), 0, sizeof(T));
-  }
-
-  template <typename T>
-  void Initialize(LargePagePtr<T>& pointer) {
-
-    static_assert(alignof(T) <= 4096, "aligned_large_pages_alloc() may fail for such a big alignment requirement of T");
-    pointer.reset(reinterpret_cast<T*>(aligned_large_pages_alloc(sizeof(T))));
-    std::memset(pointer.get(), 0, sizeof(T));
-  }
-
-  // Read evaluation function parameters
-  template <typename T>
-  bool ReadParameters(std::istream& stream, T& reference) {
-
-    std::uint32_t header;
-    header = read_little_endian<std::uint32_t>(stream);
-    if (!stream || header != T::GetHashValue()) return false;
-    return reference.ReadParameters(stream);
-  }
-
-  // write evaluation function parameters
-  template <typename T>
-  bool WriteParameters(std::ostream& stream, const AlignedPtr<T>& pointer) {
-    constexpr std::uint32_t header = T::GetHashValue();
-    stream.write(reinterpret_cast<const char*>(&header), sizeof(header));
-    return pointer->WriteParameters(stream);
-  }
-
-  template <typename T>
-  bool WriteParameters(std::ostream& stream, const LargePagePtr<T>& pointer) {
-    constexpr std::uint32_t header = T::GetHashValue();
-    stream.write(reinterpret_cast<const char*>(&header), sizeof(header));
-    return pointer->WriteParameters(stream);
-  }
-
-  }  // namespace Detail
-
-  // Initialize the evaluation function parameters
-  void Initialize() {
-
-    Detail::Initialize(feature_transformer);
-    Detail::Initialize(network);
-  }
-
-  // Read network header
-  bool ReadHeader(std::istream& stream, std::uint32_t* hash_value, std::string* architecture)
-  {
-    std::uint32_t version, size;
-
-    version     = read_little_endian<std::uint32_t>(stream);
-    *hash_value = read_little_endian<std::uint32_t>(stream);
-    size        = read_little_endian<std::uint32_t>(stream);
-    if (!stream || version != kVersion) return false;
-    architecture->resize(size);
-    stream.read(&(*architecture)[0], size);
-    return !stream.fail();
-  }
-
-  // write the header
-  bool WriteHeader(std::ostream& stream,
-    std::uint32_t hash_value, const std::string& architecture) {
-    stream.write(reinterpret_cast<const char*>(&kVersion), sizeof(kVersion));
-    stream.write(reinterpret_cast<const char*>(&hash_value), sizeof(hash_value));
-    const std::uint32_t size = static_cast<std::uint32_t>(architecture.size());
-    stream.write(reinterpret_cast<const char*>(&size), sizeof(size));
-    stream.write(architecture.data(), size);
-    return !stream.fail();
-  }
-
-  // Read network parameters
-  bool ReadParameters(std::istream& stream) {
-
-    std::uint32_t hash_value;
-    std::string architecture;
-    if (!ReadHeader(stream, &hash_value, &architecture)) return false;
-    if (hash_value != kHashValue) return false;
-    if (!Detail::ReadParameters(stream, *feature_transformer)) return false;
-    if (!Detail::ReadParameters(stream, *network)) return false;
-    return stream && stream.peek() == std::ios::traits_type::eof();
-  }
-  // write evaluation function parameters
-  bool WriteParameters(std::ostream& stream) {
-    if (!WriteHeader(stream, kHashValue, GetArchitectureString())) return false;
-    if (!Detail::WriteParameters(stream, feature_transformer)) return false;
-    if (!Detail::WriteParameters(stream, network)) return false;
-    return !stream.fail();
-  }
-  // Evaluation function. Perform differential calculation.
-  Value evaluate(const Position& pos) {
-
-    alignas(kCacheLineSize) TransformedFeatureType
-        transformed_features[FeatureTransformer::kBufferSize];
-    feature_transformer->Transform(pos, transformed_features);
-    alignas(kCacheLineSize) char buffer[Network::kBufferSize];
-    const auto output = network->Propagate(transformed_features, buffer);
-
-    return static_cast<Value>(output[0] / FV_SCALE);
-  }
-
-  // Load eval, from a file stream or a memory stream
-  bool load_eval(std::string name, std::istream& stream) {
-
-    Initialize();
-
-    if (Options["SkipLoadingEval"])
-    {
-      std::cout << "info string SkipLoadingEval set to true, Net not loaded!" << std::endl;
-      return true;
+    // Get a string that represents the structure of the evaluation function
+    std::string GetArchitectureString() {
+        return "Features=" + FeatureTransformer::GetStructureString() +
+          ",Network=" + Network::GetStructureString();
     }
-    fileName = name;
-    return ReadParameters(stream);
-  }
 
-  static UseNNUEMode nnue_mode_from_option(const UCI::Option& mode)
-  {
-    if (mode == "false")
-      return UseNNUEMode::False;
-    else if (mode == "true")
-      return UseNNUEMode::True;
-    else if (mode == "pure")
-      return UseNNUEMode::Pure;
+    namespace Detail {
 
-    return UseNNUEMode::False;
-  }
+        // Initialize the evaluation function parameters
+        template <typename T>
+        void Initialize(AlignedPtr<T>& pointer) {
 
-  void init() {
+            pointer.reset(reinterpret_cast<T*>(std_aligned_alloc(alignof(T), sizeof(T))));
+            std::memset(pointer.get(), 0, sizeof(T));
+        }
 
-    useNNUE = nnue_mode_from_option(Options["Use NNUE"]);
-    if (useNNUE == UseNNUEMode::False)
-        return;
+        template <typename T>
+        void Initialize(LargePagePtr<T>& pointer) {
 
-    std::string eval_file = std::string(Options["EvalFile"]);
+            static_assert(alignof(T) <= 4096,
+              "aligned_large_pages_alloc() may fail for such a big alignment requirement of T");
 
-    #if defined(DEFAULT_NNUE_DIRECTORY)
-    #define stringify2(x) #x
-    #define stringify(x) stringify2(x)
-    std::vector<std::string> dirs = { "" , CommandLine::binaryDirectory , stringify(DEFAULT_NNUE_DIRECTORY) };
-    #else
-    std::vector<std::string> dirs = { "" , CommandLine::binaryDirectory };
-    #endif
+            pointer.reset(reinterpret_cast<T*>(aligned_large_pages_alloc(sizeof(T))));
+            std::memset(pointer.get(), 0, sizeof(T));
+        }
 
-    for (std::string directory : dirs)
-        if (eval_file_loaded != eval_file)
+        // Read evaluation function parameters
+        template <typename T>
+        bool ReadParameters(std::istream& stream, T& reference) {
+
+            std::uint32_t header;
+            header = read_little_endian<std::uint32_t>(stream);
+            if (!stream || header != T::GetHashValue())
+                return false;
+
+            return reference.ReadParameters(stream);
+        }
+
+        // write evaluation function parameters
+        template <typename T>
+        bool WriteParameters(std::ostream& stream, const AlignedPtr<T>& pointer) {
+            constexpr std::uint32_t header = T::GetHashValue();
+
+            stream.write(reinterpret_cast<const char*>(&header), sizeof(header));
+
+            return pointer->WriteParameters(stream);
+        }
+
+        template <typename T>
+        bool WriteParameters(std::ostream& stream, const LargePagePtr<T>& pointer) {
+            constexpr std::uint32_t header = T::GetHashValue();
+
+            stream.write(reinterpret_cast<const char*>(&header), sizeof(header));
+
+            return pointer->WriteParameters(stream);
+        }
+
+    }  // namespace Detail
+
+    // Initialize the evaluation function parameters
+    void Initialize() {
+
+        Detail::Initialize(feature_transformer);
+        Detail::Initialize(network);
+    }
+
+    // Read network header
+    bool ReadHeader(std::istream& stream, std::uint32_t* hash_value, std::string* architecture)
+    {
+        std::uint32_t version, size;
+
+        version     = read_little_endian<std::uint32_t>(stream);
+        *hash_value = read_little_endian<std::uint32_t>(stream);
+        size        = read_little_endian<std::uint32_t>(stream);
+
+        if (!stream || version != kVersion)
+            return false;
+
+        architecture->resize(size);
+        stream.read(&(*architecture)[0], size);
+        return !stream.fail();
+    }
+
+    // write the header
+    bool WriteHeader(std::ostream& stream,
+        std::uint32_t hash_value, const std::string& architecture) {
+        stream.write(reinterpret_cast<const char*>(&kVersion), sizeof(kVersion));
+        stream.write(reinterpret_cast<const char*>(&hash_value), sizeof(hash_value));
+
+        const std::uint32_t size = static_cast<std::uint32_t>(architecture.size());
+        stream.write(reinterpret_cast<const char*>(&size), sizeof(size));
+        stream.write(architecture.data(), size);
+
+        return !stream.fail();
+    }
+
+    // Read network parameters
+    bool ReadParameters(std::istream& stream) {
+
+        std::uint32_t hash_value;
+        std::string architecture;
+
+        if (!ReadHeader(stream, &hash_value, &architecture))
+            return false;
+
+        if (hash_value != kHashValue)
+            return false;
+
+        if (!Detail::ReadParameters(stream, *feature_transformer))
+            return false;
+
+        if (!Detail::ReadParameters(stream, *network))
+            return false;
+
+        return stream && stream.peek() == std::ios::traits_type::eof();
+    }
+    // write evaluation function parameters
+    bool WriteParameters(std::ostream& stream) {
+        if (!WriteHeader(stream, kHashValue, GetArchitectureString()))
+            return false;
+
+        if (!Detail::WriteParameters(stream, feature_transformer))
+            return false;
+
+        if (!Detail::WriteParameters(stream, network))
+            return false;
+
+        return !stream.fail();
+    }
+    // Evaluation function. Perform differential calculation.
+    Value evaluate(const Position& pos) {
+
+        alignas(kCacheLineSize) TransformedFeatureType
+            transformed_features[FeatureTransformer::kBufferSize];
+
+        feature_transformer->Transform(pos, transformed_features);
+        alignas(kCacheLineSize) char buffer[Network::kBufferSize];
+
+        const auto output = network->Propagate(transformed_features, buffer);
+
+        return static_cast<Value>(output[0] / FV_SCALE);
+    }
+
+    // Load eval, from a file stream or a memory stream
+    bool load_eval(std::string name, std::istream& stream) {
+
+        Initialize();
+
+        if (Options["SkipLoadingEval"])
         {
-            std::ifstream stream(directory + eval_file, std::ios::binary);
-            if (load_eval(eval_file, stream))
+            std::cout << "info string SkipLoadingEval set to true, Net not loaded!" << std::endl;
+            return true;
+        }
+
+        fileName = name;
+        return ReadParameters(stream);
+    }
+
+    static UseNNUEMode nnue_mode_from_option(const UCI::Option& mode)
+    {
+        if (mode == "false")
+            return UseNNUEMode::False;
+        else if (mode == "true")
+            return UseNNUEMode::True;
+        else if (mode == "pure")
+            return UseNNUEMode::Pure;
+
+        return UseNNUEMode::False;
+    }
+
+    void init() {
+
+        useNNUE = nnue_mode_from_option(Options["Use NNUE"]);
+        if (useNNUE == UseNNUEMode::False)
+            return;
+
+        std::string eval_file = std::string(Options["EvalFile"]);
+
+#if defined(DEFAULT_NNUE_DIRECTORY)
+#define stringify2(x) #x
+#define stringify(x) stringify2(x)
+        std::vector<std::string> dirs = { "" , CommandLine::binaryDirectory , stringify(DEFAULT_NNUE_DIRECTORY) };
+#else
+        std::vector<std::string> dirs = { "" , CommandLine::binaryDirectory };
+#endif
+
+        for (std::string directory : dirs)
+        {
+            if (eval_file_loaded != eval_file)
             {
-                sync_cout << "info string Loaded eval file " << directory + eval_file << sync_endl;
-                eval_file_loaded = eval_file;
-            }
-            else
-            {
-                sync_cout << "info string ERROR: failed to load eval file " << directory + eval_file << sync_endl;
-                eval_file_loaded.clear();
+                std::ifstream stream(directory + eval_file, std::ios::binary);
+                if (load_eval(eval_file, stream))
+                {
+                    sync_cout << "info string Loaded eval file " << directory + eval_file << sync_endl;
+                    eval_file_loaded = eval_file;
+                }
+                else
+                {
+                    sync_cout << "info string ERROR: failed to load eval file " << directory + eval_file << sync_endl;
+                    eval_file_loaded.clear();
+                }
             }
         }
 
-    #undef stringify2
-    #undef stringify
-  }
-
-  /// NNUE::verify() verifies that the last net used was loaded successfully
-  void verify_eval_file_loaded() {
-
-    std::string eval_file = std::string(Options["EvalFile"]);
-
-    if (useNNUE != UseNNUEMode::False && eval_file_loaded != eval_file)
-    {
-        UCI::OptionsMap defaults;
-        UCI::init(defaults);
-
-        std::string msg1 = "If the UCI option \"Use NNUE\" is set to true, network evaluation parameters compatible with the engine must be available.";
-        std::string msg2 = "The option is set to true, but the network file " + eval_file + " was not loaded successfully.";
-        std::string msg3 = "The UCI option EvalFile might need to specify the full path, including the directory name, to the network file.";
-        std::string msg4 = "The default net can be downloaded from: https://tests.stockfishchess.org/api/nn/" + std::string(defaults["EvalFile"]);
-        std::string msg5 = "The engine will be terminated now.";
-
-        sync_cout << "info string ERROR: " << msg1 << sync_endl;
-        sync_cout << "info string ERROR: " << msg2 << sync_endl;
-        sync_cout << "info string ERROR: " << msg3 << sync_endl;
-        sync_cout << "info string ERROR: " << msg4 << sync_endl;
-        sync_cout << "info string ERROR: " << msg5 << sync_endl;
-
-        std::exit(EXIT_FAILURE);
+#undef stringify2
+#undef stringify
     }
 
-    if (useNNUE != UseNNUEMode::False)
-        sync_cout << "info string NNUE evaluation using " << eval_file << " enabled" << sync_endl;
-    else
-        sync_cout << "info string classical evaluation enabled" << sync_endl;
-  }
+    /// NNUE::verify() verifies that the last net used was loaded successfully
+    void verify_eval_file_loaded() {
 
-  /// In training we override eval file so this is useful.
-  void verify_any_net_loaded() {
+        std::string eval_file = std::string(Options["EvalFile"]);
 
-    if (useNNUE != UseNNUEMode::False && eval_file_loaded.empty())
-    {
-        UCI::OptionsMap defaults;
-        UCI::init(defaults);
+        if (useNNUE != UseNNUEMode::False && eval_file_loaded != eval_file)
+        {
+            UCI::OptionsMap defaults;
+            UCI::init(defaults);
 
-        std::string msg1 = "If the UCI option \"Use NNUE\" is set to true, network evaluation parameters compatible with the engine must be available.";
-        std::string msg2 = "The option is set to true, but the network file was not loaded successfully.";
-        std::string msg3 = "The UCI option EvalFile might need to specify the full path, including the directory name, to the network file.";
-        std::string msg5 = "The engine will be terminated now.";
+            std::string msg1 = "If the UCI option \"Use NNUE\" is set to true, network evaluation parameters compatible with the engine must be available.";
+            std::string msg2 = "The option is set to true, but the network file " + eval_file + " was not loaded successfully.";
+            std::string msg3 = "The UCI option EvalFile might need to specify the full path, including the directory name, to the network file.";
+            std::string msg4 = "The default net can be downloaded from: https://tests.stockfishchess.org/api/nn/" + std::string(defaults["EvalFile"]);
+            std::string msg5 = "The engine will be terminated now.";
 
-        sync_cout << "info string ERROR: " << msg1 << sync_endl;
-        sync_cout << "info string ERROR: " << msg2 << sync_endl;
-        sync_cout << "info string ERROR: " << msg3 << sync_endl;
-        sync_cout << "info string ERROR: " << msg5 << sync_endl;
+            sync_cout << "info string ERROR: " << msg1 << sync_endl;
+            sync_cout << "info string ERROR: " << msg2 << sync_endl;
+            sync_cout << "info string ERROR: " << msg3 << sync_endl;
+            sync_cout << "info string ERROR: " << msg4 << sync_endl;
+            sync_cout << "info string ERROR: " << msg5 << sync_endl;
 
-        std::exit(EXIT_FAILURE);
+            std::exit(EXIT_FAILURE);
+        }
+
+        if (useNNUE != UseNNUEMode::False)
+            sync_cout << "info string NNUE evaluation using " << eval_file << " enabled" << sync_endl;
+        else
+            sync_cout << "info string classical evaluation enabled" << sync_endl;
     }
 
-    if (useNNUE != UseNNUEMode::False)
-        sync_cout << "info string NNUE evaluation using " << eval_file_loaded << " enabled" << sync_endl;
-    else
-        sync_cout << "info string classical evaluation enabled" << sync_endl;
-  }
+    /// In training we override eval file so this is useful.
+    void verify_any_net_loaded() {
+
+        if (useNNUE != UseNNUEMode::False && eval_file_loaded.empty())
+        {
+            UCI::OptionsMap defaults;
+            UCI::init(defaults);
+
+            std::string msg1 = "If the UCI option \"Use NNUE\" is set to true, network evaluation parameters compatible with the engine must be available.";
+            std::string msg2 = "The option is set to true, but the network file was not loaded successfully.";
+            std::string msg3 = "The UCI option EvalFile might need to specify the full path, including the directory name, to the network file.";
+            std::string msg5 = "The engine will be terminated now.";
+
+            sync_cout << "info string ERROR: " << msg1 << sync_endl;
+            sync_cout << "info string ERROR: " << msg2 << sync_endl;
+            sync_cout << "info string ERROR: " << msg3 << sync_endl;
+            sync_cout << "info string ERROR: " << msg5 << sync_endl;
+
+            std::exit(EXIT_FAILURE);
+        }
+
+        if (useNNUE != UseNNUEMode::False)
+            sync_cout << "info string NNUE evaluation using " << eval_file_loaded << " enabled" << sync_endl;
+        else
+            sync_cout << "info string classical evaluation enabled" << sync_endl;
+    }
 
 } // namespace Eval::NNUE

--- a/src/nnue/evaluate_nnue.h
+++ b/src/nnue/evaluate_nnue.h
@@ -27,6 +27,13 @@
 
 namespace Eval::NNUE {
 
+  enum struct UseNNUEMode
+  {
+    False,
+    True,
+    Pure
+  };
+
   // Hash value of evaluation function structure
   constexpr std::uint32_t kHashValue =
       FeatureTransformer::GetHashValue() ^ Network::GetHashValue();
@@ -66,6 +73,9 @@ namespace Eval::NNUE {
   // Saved evaluation function file name
   extern std::string savedfileName;
 
+  extern UseNNUEMode useNNUE;
+  extern std::string eval_file_loaded;
+
   // Get a string that represents the structure of the evaluation function
   std::string GetArchitectureString();
 
@@ -82,6 +92,11 @@ namespace Eval::NNUE {
 
   // write evaluation function parameters
   bool WriteParameters(std::ostream& stream);
+
+  Value evaluate(const Position& pos);
+  bool load_eval(std::string name, std::istream& stream);
+  void init();
+  void verify();
 
 }  // namespace Eval::NNUE
 

--- a/src/nnue/evaluate_nnue.h
+++ b/src/nnue/evaluate_nnue.h
@@ -96,7 +96,8 @@ namespace Eval::NNUE {
   Value evaluate(const Position& pos);
   bool load_eval(std::string name, std::istream& stream);
   void init();
-  void verify();
+  void verify_eval_file_loaded();
+  void verify_any_net_loaded();
 
 }  // namespace Eval::NNUE
 

--- a/src/nnue/evaluate_nnue.h
+++ b/src/nnue/evaluate_nnue.h
@@ -37,7 +37,7 @@ namespace Eval::NNUE {
 
     // Hash value of evaluation function structure
     constexpr std::uint32_t kHashValue =
-        FeatureTransformer::GetHashValue() ^ Network::GetHashValue();
+        FeatureTransformer::get_hash_value() ^ Network::get_hash_value();
 
     // Deleter for automating release of memory area
     template <typename T>
@@ -79,21 +79,21 @@ namespace Eval::NNUE {
     extern std::string eval_file_loaded;
 
     // Get a string that represents the structure of the evaluation function
-    std::string GetArchitectureString();
+    std::string get_architecture_string();
 
     // read the header
-    bool ReadHeader(std::istream& stream,
+    bool read_header(std::istream& stream,
         std::uint32_t* hash_value, std::string* architecture);
 
     // write the header
-    bool WriteHeader(std::ostream& stream,
+    bool write_header(std::ostream& stream,
         std::uint32_t hash_value, const std::string& architecture);
 
     // read evaluation function parameters
-    bool ReadParameters(std::istream& stream);
+    bool read_parameters(std::istream& stream);
 
     // write evaluation function parameters
-    bool WriteParameters(std::ostream& stream);
+    bool write_parameters(std::ostream& stream);
 
     Value evaluate(const Position& pos);
     bool load_eval(std::string name, std::istream& stream);

--- a/src/nnue/evaluate_nnue.h
+++ b/src/nnue/evaluate_nnue.h
@@ -21,6 +21,8 @@
 
 #include "nnue_feature_transformer.h"
 
+#include "misc.h"
+
 #include <memory>
 
 // header used in NNUE evaluation function

--- a/src/nnue/evaluate_nnue.h
+++ b/src/nnue/evaluate_nnue.h
@@ -1,22 +1,20 @@
 /*
-  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
-  Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
+    Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+    Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
 
-  Stockfish is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+    Stockfish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-  Stockfish is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+    Stockfish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-
-// header used in NNUE evaluation function
 
 #ifndef NNUE_EVALUATE_NNUE_H_INCLUDED
 #define NNUE_EVALUATE_NNUE_H_INCLUDED
@@ -25,79 +23,82 @@
 
 #include <memory>
 
+// header used in NNUE evaluation function
 namespace Eval::NNUE {
 
-  enum struct UseNNUEMode
-  {
-    False,
-    True,
-    Pure
-  };
+    enum struct UseNNUEMode
+    {
+        False,
+        True,
+        Pure
+    };
 
-  // Hash value of evaluation function structure
-  constexpr std::uint32_t kHashValue =
-      FeatureTransformer::GetHashValue() ^ Network::GetHashValue();
+    // Hash value of evaluation function structure
+    constexpr std::uint32_t kHashValue =
+        FeatureTransformer::GetHashValue() ^ Network::GetHashValue();
 
-  // Deleter for automating release of memory area
-  template <typename T>
-  struct AlignedDeleter {
-    void operator()(T* ptr) const {
-      ptr->~T();
-      std_aligned_free(ptr);
-    }
-  };
+    // Deleter for automating release of memory area
+    template <typename T>
+    struct AlignedDeleter {
+        void operator()(T* ptr) const {
+            ptr->~T();
+            std_aligned_free(ptr);
+        }
+    };
 
-  template <typename T>
-  struct LargePageDeleter {
-    void operator()(T* ptr) const {
-      ptr->~T();
-      aligned_large_pages_free(ptr);
-    }
-  };
+    template <typename T>
+    struct LargePageDeleter {
+        void operator()(T* ptr) const {
+            ptr->~T();
+            aligned_large_pages_free(ptr);
+        }
+    };
 
-  template <typename T>
-  using AlignedPtr = std::unique_ptr<T, AlignedDeleter<T>>;
+    template <typename T>
+    using AlignedPtr = std::unique_ptr<T, AlignedDeleter<T>>;
 
-  template <typename T>
-  using LargePagePtr = std::unique_ptr<T, LargePageDeleter<T>>;
+    template <typename T>
+    using LargePagePtr = std::unique_ptr<T, LargePageDeleter<T>>;
 
-  // Input feature converter
-  extern LargePagePtr<FeatureTransformer> feature_transformer;
+    // Input feature converter
+    extern LargePagePtr<FeatureTransformer> feature_transformer;
 
-  // Evaluation function
-  extern AlignedPtr<Network> network;
+    // Evaluation function
+    extern AlignedPtr<Network> network;
 
-  // Evaluation function file name
-  extern std::string fileName;
+    // Evaluation function file name
+    extern std::string fileName;
 
-  // Saved evaluation function file name
-  extern std::string savedfileName;
+    // Saved evaluation function file name
+    extern std::string savedfileName;
 
-  extern UseNNUEMode useNNUE;
-  extern std::string eval_file_loaded;
+    extern UseNNUEMode useNNUE;
 
-  // Get a string that represents the structure of the evaluation function
-  std::string GetArchitectureString();
+    extern std::string eval_file_loaded;
 
-  // read the header
-  bool ReadHeader(std::istream& stream,
-    std::uint32_t* hash_value, std::string* architecture);
+    // Get a string that represents the structure of the evaluation function
+    std::string GetArchitectureString();
 
-  // write the header
-  bool WriteHeader(std::ostream& stream,
-    std::uint32_t hash_value, const std::string& architecture);
+    // read the header
+    bool ReadHeader(std::istream& stream,
+        std::uint32_t* hash_value, std::string* architecture);
 
-  // read evaluation function parameters
-  bool ReadParameters(std::istream& stream);
+    // write the header
+    bool WriteHeader(std::ostream& stream,
+        std::uint32_t hash_value, const std::string& architecture);
 
-  // write evaluation function parameters
-  bool WriteParameters(std::ostream& stream);
+    // read evaluation function parameters
+    bool ReadParameters(std::istream& stream);
 
-  Value evaluate(const Position& pos);
-  bool load_eval(std::string name, std::istream& stream);
-  void init();
-  void verify_eval_file_loaded();
-  void verify_any_net_loaded();
+    // write evaluation function parameters
+    bool WriteParameters(std::ostream& stream);
+
+    Value evaluate(const Position& pos);
+    bool load_eval(std::string name, std::istream& stream);
+    void init();
+
+    void verify_eval_file_loaded();
+    void verify_any_net_loaded();
 
 }  // namespace Eval::NNUE
 

--- a/src/nnue/evaluate_nnue_learner.cpp
+++ b/src/nnue/evaluate_nnue_learner.cpp
@@ -1,18 +1,10 @@
-﻿// Code for learning NNUE evaluation function
-
-#include <random>
+﻿#include <random>
 #include <fstream>
 #include <filesystem>
 
-#include "../learn/learn.h"
-
-#include "../position.h"
-#include "../uci.h"
-#include "../misc.h"
-#include "../thread_win32_osx.h"
-
 #include "evaluate_nnue.h"
 #include "evaluate_nnue_learner.h"
+
 #include "trainer/features/factorizer_feature_set.h"
 #include "trainer/features/factorizer_half_kp.h"
 #include "trainer/trainer_feature_transformer.h"
@@ -21,191 +13,207 @@
 #include "trainer/trainer_clipped_relu.h"
 #include "trainer/trainer_sum.h"
 
+#include "position.h"
+#include "uci.h"
+#include "misc.h"
+#include "thread_win32_osx.h"
+
+#include "learn/learn.h"
+
 // Learning rate scale
 double global_learning_rate;
 
+// Code for learning NNUE evaluation function
 namespace Eval::NNUE {
 
-  namespace {
+    namespace {
 
-    // learning data
-    std::vector<Example> examples;
+        // learning data
+        std::vector<Example> examples;
 
-    // Mutex for exclusive control of examples
-    std::mutex examples_mutex;
+        // Mutex for exclusive control of examples
+        std::mutex examples_mutex;
 
-    // number of samples in mini-batch
-    uint64_t batch_size;
+        // number of samples in mini-batch
+        uint64_t batch_size;
 
-    // random number generator
-    std::mt19937 rng;
+        // random number generator
+        std::mt19937 rng;
 
-    // learner
-    std::shared_ptr<Trainer<Network>> trainer;
+        // learner
+        std::shared_ptr<Trainer<Network>> trainer;
 
-    // Tell the learner options such as hyperparameters
-    void SendMessages(std::vector<Message> messages) {
-      for (auto& message : messages) {
-        trainer->SendMessage(&message);
-        assert(message.num_receivers > 0);
-      }
-    }
-
-  }  // namespace
-
-  // Initialize learning
-  void InitializeTraining(const std::string& seed) {
-    std::cout << "Initializing NN training for "
-              << GetArchitectureString() << std::endl;
-
-    assert(feature_transformer);
-    assert(network);
-    trainer = Trainer<Network>::Create(network.get(), feature_transformer.get());
-    rng.seed(PRNG(seed).rand<uint64_t>());
-
-    if (Options["SkipLoadingEval"]) {
-      trainer->Initialize(rng);
-    }
-  }
-
-  // set the number of samples in the mini-batch
-  void SetBatchSize(uint64_t size) {
-    assert(size > 0);
-    batch_size = size;
-  }
-  
-  // Set options such as hyperparameters
-  void SetOptions(const std::string& options) {
-    std::vector<Message> messages;
-    for (const auto& option : Split(options, ',')) {
-      const auto fields = Split(option, '=');
-      assert(fields.size() == 1 || fields.size() == 2);
-      if (fields.size() == 1) {
-        messages.emplace_back(fields[0]);
-      } else {
-        messages.emplace_back(fields[0], fields[1]);
-      }
-    }
-    SendMessages(std::move(messages));
-  }
-
-  // Reread the evaluation function parameters for learning from the file
-  void RestoreParameters(const std::string& dir_name) {
-    const std::string file_name = Path::Combine(dir_name, NNUE::savedfileName);
-    std::ifstream stream(file_name, std::ios::binary);
-#ifndef NDEBUG
-    bool result =
-#endif
-    ReadParameters(stream);
-#ifndef NDEBUG
-    assert(result);
-#endif
-
-    SendMessages({{"reset"}});
-  }
-
-  void FinalizeNet() {
-    SendMessages({{"clear_unobserved_feature_weights"}});
-  }
-
-  // Add 1 sample of learning data
-  void AddExample(Position& pos, Color rootColor,
-                  const Learner::PackedSfenValue& psv, double weight) {
-    Example example;
-    if (rootColor == pos.side_to_move()) {
-      example.sign = 1;
-    } else {
-      example.sign = -1;
-    }
-    example.psv = psv;
-    example.weight = weight;
-
-    Features::IndexList active_indices[2];
-    for (const auto trigger : kRefreshTriggers) {
-      RawFeatures::AppendActiveIndices(pos, trigger, active_indices);
-    }
-    if (pos.side_to_move() != WHITE) {
-      active_indices[0].swap(active_indices[1]);
-    }
-    for (const auto color : Colors) {
-      std::vector<TrainingFeature> training_features;
-      for (const auto base_index : active_indices[color]) {
-        static_assert(Features::Factorizer<RawFeatures>::GetDimensions() <
-                      (1 << TrainingFeature::kIndexBits), "");
-        Features::Factorizer<RawFeatures>::AppendTrainingFeatures(
-            base_index, &training_features);
-      }
-      std::sort(training_features.begin(), training_features.end());
-
-      auto& unique_features = example.training_features[color];
-      for (const auto& feature : training_features) {
-        if (!unique_features.empty() &&
-            feature.GetIndex() == unique_features.back().GetIndex()) {
-          unique_features.back() += feature;
-        } else {
-          unique_features.push_back(feature);
+        // Tell the learner options such as hyperparameters
+        void SendMessages(std::vector<Message> messages) {
+            for (auto& message : messages) {
+                trainer->SendMessage(&message);
+                assert(message.num_receivers > 0);
+            }
         }
-      }
+
+    }  // namespace
+
+    // Initialize learning
+    void InitializeTraining(const std::string& seed) {
+        std::cout << "Initializing NN training for "
+                  << GetArchitectureString() << std::endl;
+
+        assert(feature_transformer);
+        assert(network);
+        trainer = Trainer<Network>::Create(network.get(), feature_transformer.get());
+        rng.seed(PRNG(seed).rand<uint64_t>());
+
+        if (Options["SkipLoadingEval"]) {
+            trainer->Initialize(rng);
+        }
     }
 
-    std::lock_guard<std::mutex> lock(examples_mutex);
-    examples.push_back(std::move(example));
-  }
-
-  // update the evaluation function parameters
-  void UpdateParameters() {
-    assert(batch_size > 0);
-
-    const auto learning_rate = static_cast<LearnFloatType>(
-        global_learning_rate / batch_size);
-
-    std::lock_guard<std::mutex> lock(examples_mutex);
-    std::shuffle(examples.begin(), examples.end(), rng);
-    while (examples.size() >= batch_size) {
-      std::vector<Example> batch(examples.end() - batch_size, examples.end());
-      examples.resize(examples.size() - batch_size);
-
-      const auto network_output = trainer->Propagate(batch);
-
-      std::vector<LearnFloatType> gradients(batch.size());
-      for (std::size_t b = 0; b < batch.size(); ++b) {
-        const auto shallow = static_cast<Value>(Round<std::int32_t>(
-            batch[b].sign * network_output[b] * kPonanzaConstant));
-        const auto& psv = batch[b].psv;
-        const double gradient = batch[b].sign * Learner::calc_grad(shallow, psv);
-        gradients[b] = static_cast<LearnFloatType>(gradient * batch[b].weight);
-      }
-
-      trainer->Backpropagate(gradients.data(), learning_rate);
+    // set the number of samples in the mini-batch
+    void SetBatchSize(uint64_t size) {
+        assert(size > 0);
+        batch_size = size;
     }
-    SendMessages({{"quantize_parameters"}});
-  }
 
-  // Check if there are any problems with learning
-  void CheckHealth() {
-    SendMessages({{"check_health"}});
-  }
+    // Set options such as hyperparameters
+    void SetOptions(const std::string& options) {
+        std::vector<Message> messages;
+        for (const auto& option : Split(options, ',')) {
+          const auto fields = Split(option, '=');
+          assert(fields.size() == 1 || fields.size() == 2);
 
-  // save merit function parameters to a file
-  void save_eval(std::string dir_name) {
-    auto eval_dir = Path::Combine(Options["EvalSaveDir"], dir_name);
-    std::cout << "save_eval() start. folder = " << eval_dir << std::endl;
+          if (fields.size() == 1) {
+              messages.emplace_back(fields[0]);
+          } else {
+              messages.emplace_back(fields[0], fields[1]);
+          }
+        }
 
-    // mkdir() will fail if this folder already exists, but
-    // Apart from that. If not, I just want you to make it.
-    // Also, assume that the folders up to EvalSaveDir have been dug.
-    std::filesystem::create_directories(eval_dir);
+        SendMessages(std::move(messages));
+    }
 
-    const std::string file_name = Path::Combine(eval_dir, NNUE::savedfileName);
-    std::ofstream stream(file_name, std::ios::binary);
+    // Reread the evaluation function parameters for learning from the file
+    void RestoreParameters(const std::string& dir_name) {
+        const std::string file_name = Path::Combine(dir_name, NNUE::savedfileName);
+        std::ifstream stream(file_name, std::ios::binary);
 #ifndef NDEBUG
-    bool result =
+        bool result =
 #endif
-    WriteParameters(stream);
+        ReadParameters(stream);
 #ifndef NDEBUG
-    assert(result);
+        assert(result);
 #endif
 
-    std::cout << "save_eval() finished. folder = " << eval_dir << std::endl;
-  }
+        SendMessages({{"reset"}});
+    }
+
+    void FinalizeNet() {
+        SendMessages({{"clear_unobserved_feature_weights"}});
+    }
+
+    // Add 1 sample of learning data
+    void AddExample(Position& pos, Color rootColor,
+                    const Learner::PackedSfenValue& psv, double weight) {
+
+        Example example;
+        if (rootColor == pos.side_to_move()) {
+            example.sign = 1;
+        } else {
+            example.sign = -1;
+        }
+
+        example.psv = psv;
+        example.weight = weight;
+
+        Features::IndexList active_indices[2];
+        for (const auto trigger : kRefreshTriggers) {
+            RawFeatures::AppendActiveIndices(pos, trigger, active_indices);
+        }
+
+        if (pos.side_to_move() != WHITE) {
+            active_indices[0].swap(active_indices[1]);
+        }
+
+        for (const auto color : Colors) {
+            std::vector<TrainingFeature> training_features;
+            for (const auto base_index : active_indices[color]) {
+                static_assert(Features::Factorizer<RawFeatures>::GetDimensions() <
+                              (1 << TrainingFeature::kIndexBits), "");
+                Features::Factorizer<RawFeatures>::AppendTrainingFeatures(
+                    base_index, &training_features);
+            }
+
+            std::sort(training_features.begin(), training_features.end());
+
+            auto& unique_features = example.training_features[color];
+            for (const auto& feature : training_features) {
+                if (!unique_features.empty() &&
+                    feature.GetIndex() == unique_features.back().GetIndex()) {
+
+                    unique_features.back() += feature;
+                } else {
+                    unique_features.push_back(feature);
+                }
+            }
+        }
+
+        std::lock_guard<std::mutex> lock(examples_mutex);
+        examples.push_back(std::move(example));
+    }
+
+    // update the evaluation function parameters
+    void UpdateParameters() {
+        assert(batch_size > 0);
+
+        const auto learning_rate = static_cast<LearnFloatType>(
+            global_learning_rate / batch_size);
+
+        std::lock_guard<std::mutex> lock(examples_mutex);
+        std::shuffle(examples.begin(), examples.end(), rng);
+        while (examples.size() >= batch_size) {
+            std::vector<Example> batch(examples.end() - batch_size, examples.end());
+            examples.resize(examples.size() - batch_size);
+
+            const auto network_output = trainer->Propagate(batch);
+
+            std::vector<LearnFloatType> gradients(batch.size());
+            for (std::size_t b = 0; b < batch.size(); ++b) {
+                const auto shallow = static_cast<Value>(Round<std::int32_t>(
+                    batch[b].sign * network_output[b] * kPonanzaConstant));
+                const auto& psv = batch[b].psv;
+                const double gradient = batch[b].sign * Learner::calc_grad(shallow, psv);
+                gradients[b] = static_cast<LearnFloatType>(gradient * batch[b].weight);
+            }
+
+            trainer->Backpropagate(gradients.data(), learning_rate);
+        }
+        SendMessages({{"quantize_parameters"}});
+    }
+
+    // Check if there are any problems with learning
+    void CheckHealth() {
+        SendMessages({{"check_health"}});
+    }
+
+    // save merit function parameters to a file
+    void save_eval(std::string dir_name) {
+        auto eval_dir = Path::Combine(Options["EvalSaveDir"], dir_name);
+        std::cout << "save_eval() start. folder = " << eval_dir << std::endl;
+
+        // mkdir() will fail if this folder already exists, but
+        // Apart from that. If not, I just want you to make it.
+        // Also, assume that the folders up to EvalSaveDir have been dug.
+        std::filesystem::create_directories(eval_dir);
+
+        const std::string file_name = Path::Combine(eval_dir, NNUE::savedfileName);
+        std::ofstream stream(file_name, std::ios::binary);
+#ifndef NDEBUG
+        bool result =
+#endif
+        WriteParameters(stream);
+#ifndef NDEBUG
+        assert(result);
+#endif
+
+        std::cout << "save_eval() finished. folder = " << eval_dir << std::endl;
+    }
 }  // namespace Eval::NNUE

--- a/src/nnue/evaluate_nnue_learner.cpp
+++ b/src/nnue/evaluate_nnue_learner.cpp
@@ -44,9 +44,9 @@ namespace Eval::NNUE {
         std::shared_ptr<Trainer<Network>> trainer;
 
         // Tell the learner options such as hyperparameters
-        void SendMessages(std::vector<Message> messages) {
+        void send_messages(std::vector<Message> messages) {
             for (auto& message : messages) {
-                trainer->SendMessage(&message);
+                trainer->send_message(&message);
                 assert(message.num_receivers > 0);
             }
         }
@@ -54,31 +54,31 @@ namespace Eval::NNUE {
     }  // namespace
 
     // Initialize learning
-    void InitializeTraining(const std::string& seed) {
+    void initialize_training(const std::string& seed) {
         std::cout << "Initializing NN training for "
-                  << GetArchitectureString() << std::endl;
+                  << get_architecture_string() << std::endl;
 
         assert(feature_transformer);
         assert(network);
-        trainer = Trainer<Network>::Create(network.get(), feature_transformer.get());
+        trainer = Trainer<Network>::create(network.get(), feature_transformer.get());
         rng.seed(PRNG(seed).rand<uint64_t>());
 
         if (Options["SkipLoadingEval"]) {
-            trainer->Initialize(rng);
+            trainer->initialize(rng);
         }
     }
 
     // set the number of samples in the mini-batch
-    void SetBatchSize(uint64_t size) {
+    void set_batch_size(uint64_t size) {
         assert(size > 0);
         batch_size = size;
     }
 
     // Set options such as hyperparameters
-    void SetOptions(const std::string& options) {
+    void set_options(const std::string& options) {
         std::vector<Message> messages;
-        for (const auto& option : Split(options, ',')) {
-          const auto fields = Split(option, '=');
+        for (const auto& option : Algo::split(options, ',')) {
+          const auto fields = Algo::split(option, '=');
           assert(fields.size() == 1 || fields.size() == 2);
 
           if (fields.size() == 1) {
@@ -88,30 +88,30 @@ namespace Eval::NNUE {
           }
         }
 
-        SendMessages(std::move(messages));
+        send_messages(std::move(messages));
     }
 
     // Reread the evaluation function parameters for learning from the file
-    void RestoreParameters(const std::string& dir_name) {
-        const std::string file_name = Path::Combine(dir_name, NNUE::savedfileName);
+    void restore_parameters(const std::string& dir_name) {
+        const std::string file_name = Path::combine(dir_name, NNUE::savedfileName);
         std::ifstream stream(file_name, std::ios::binary);
 #ifndef NDEBUG
         bool result =
 #endif
-        ReadParameters(stream);
+        read_parameters(stream);
 #ifndef NDEBUG
         assert(result);
 #endif
 
-        SendMessages({{"reset"}});
+        send_messages({{"reset"}});
     }
 
-    void FinalizeNet() {
-        SendMessages({{"clear_unobserved_feature_weights"}});
+    void finalize_net() {
+        send_messages({{"clear_unobserved_feature_weights"}});
     }
 
     // Add 1 sample of learning data
-    void AddExample(Position& pos, Color rootColor,
+    void add_example(Position& pos, Color rootColor,
                     const Learner::PackedSfenValue& psv, double weight) {
 
         Example example;
@@ -126,7 +126,7 @@ namespace Eval::NNUE {
 
         Features::IndexList active_indices[2];
         for (const auto trigger : kRefreshTriggers) {
-            RawFeatures::AppendActiveIndices(pos, trigger, active_indices);
+            RawFeatures::append_active_indices(pos, trigger, active_indices);
         }
 
         if (pos.side_to_move() != WHITE) {
@@ -136,9 +136,9 @@ namespace Eval::NNUE {
         for (const auto color : Colors) {
             std::vector<TrainingFeature> training_features;
             for (const auto base_index : active_indices[color]) {
-                static_assert(Features::Factorizer<RawFeatures>::GetDimensions() <
+                static_assert(Features::Factorizer<RawFeatures>::get_dimensions() <
                               (1 << TrainingFeature::kIndexBits), "");
-                Features::Factorizer<RawFeatures>::AppendTrainingFeatures(
+                Features::Factorizer<RawFeatures>::append_training_features(
                     base_index, &training_features);
             }
 
@@ -147,7 +147,7 @@ namespace Eval::NNUE {
             auto& unique_features = example.training_features[color];
             for (const auto& feature : training_features) {
                 if (!unique_features.empty() &&
-                    feature.GetIndex() == unique_features.back().GetIndex()) {
+                    feature.get_index() == unique_features.back().get_index()) {
 
                     unique_features.back() += feature;
                 } else {
@@ -161,7 +161,7 @@ namespace Eval::NNUE {
     }
 
     // update the evaluation function parameters
-    void UpdateParameters() {
+    void update_parameters() {
         assert(batch_size > 0);
 
         const auto learning_rate = static_cast<LearnFloatType>(
@@ -173,30 +173,30 @@ namespace Eval::NNUE {
             std::vector<Example> batch(examples.end() - batch_size, examples.end());
             examples.resize(examples.size() - batch_size);
 
-            const auto network_output = trainer->Propagate(batch);
+            const auto network_output = trainer->propagate(batch);
 
             std::vector<LearnFloatType> gradients(batch.size());
             for (std::size_t b = 0; b < batch.size(); ++b) {
-                const auto shallow = static_cast<Value>(Round<std::int32_t>(
+                const auto shallow = static_cast<Value>(round<std::int32_t>(
                     batch[b].sign * network_output[b] * kPonanzaConstant));
                 const auto& psv = batch[b].psv;
                 const double gradient = batch[b].sign * Learner::calc_grad(shallow, psv);
                 gradients[b] = static_cast<LearnFloatType>(gradient * batch[b].weight);
             }
 
-            trainer->Backpropagate(gradients.data(), learning_rate);
+            trainer->backpropagate(gradients.data(), learning_rate);
         }
-        SendMessages({{"quantize_parameters"}});
+        send_messages({{"quantize_parameters"}});
     }
 
     // Check if there are any problems with learning
-    void CheckHealth() {
-        SendMessages({{"check_health"}});
+    void check_health() {
+        send_messages({{"check_health"}});
     }
 
     // save merit function parameters to a file
     void save_eval(std::string dir_name) {
-        auto eval_dir = Path::Combine(Options["EvalSaveDir"], dir_name);
+        auto eval_dir = Path::combine(Options["EvalSaveDir"], dir_name);
         std::cout << "save_eval() start. folder = " << eval_dir << std::endl;
 
         // mkdir() will fail if this folder already exists, but
@@ -204,12 +204,12 @@ namespace Eval::NNUE {
         // Also, assume that the folders up to EvalSaveDir have been dug.
         std::filesystem::create_directories(eval_dir);
 
-        const std::string file_name = Path::Combine(eval_dir, NNUE::savedfileName);
+        const std::string file_name = Path::combine(eval_dir, NNUE::savedfileName);
         std::ofstream stream(file_name, std::ios::binary);
 #ifndef NDEBUG
         bool result =
 #endif
-        WriteParameters(stream);
+        write_parameters(stream);
 #ifndef NDEBUG
         assert(result);
 #endif

--- a/src/nnue/evaluate_nnue_learner.h
+++ b/src/nnue/evaluate_nnue_learner.h
@@ -1,37 +1,36 @@
-﻿// Interface used for learning NNUE evaluation function
-
-#ifndef _EVALUATE_NNUE_LEARNER_H_
+﻿#ifndef _EVALUATE_NNUE_LEARNER_H_
 #define _EVALUATE_NNUE_LEARNER_H_
 
-#include "../learn/learn.h"
+#include "learn/learn.h"
 
+// Interface used for learning NNUE evaluation function
 namespace Eval::NNUE {
 
-  // Initialize learning
-  void InitializeTraining(const std::string& seed);
+    // Initialize learning
+    void InitializeTraining(const std::string& seed);
 
-  // set the number of samples in the mini-batch
-  void SetBatchSize(uint64_t size);
+    // set the number of samples in the mini-batch
+    void SetBatchSize(uint64_t size);
 
-  // Set options such as hyperparameters
-  void SetOptions(const std::string& options);
+    // Set options such as hyperparameters
+    void SetOptions(const std::string& options);
 
-  // Reread the evaluation function parameters for learning from the file
-  void RestoreParameters(const std::string& dir_name);
+    // Reread the evaluation function parameters for learning from the file
+    void RestoreParameters(const std::string& dir_name);
 
-// Add 1 sample of learning data
-  void AddExample(Position& pos, Color rootColor,
-  	const Learner::PackedSfenValue& psv, double weight);
+    // Add 1 sample of learning data
+    void AddExample(Position& pos, Color rootColor,
+    	 const Learner::PackedSfenValue& psv, double weight);
 
-  // update the evaluation function parameters
-  void UpdateParameters();
+    // update the evaluation function parameters
+    void UpdateParameters();
 
-  // Check if there are any problems with learning
-  void CheckHealth();
+    // Check if there are any problems with learning
+    void CheckHealth();
 
-  void FinalizeNet();
+    void FinalizeNet();
 
-  void save_eval(std::string suffix);
+    void save_eval(std::string suffix);
 }  // namespace Eval::NNUE
 
 #endif

--- a/src/nnue/evaluate_nnue_learner.h
+++ b/src/nnue/evaluate_nnue_learner.h
@@ -7,28 +7,31 @@
 namespace Eval::NNUE {
 
     // Initialize learning
-    void InitializeTraining(const std::string& seed);
+    void initialize_training(const std::string& seed);
 
     // set the number of samples in the mini-batch
-    void SetBatchSize(uint64_t size);
+    void set_batch_size(uint64_t size);
 
     // Set options such as hyperparameters
-    void SetOptions(const std::string& options);
+    void set_options(const std::string& options);
 
     // Reread the evaluation function parameters for learning from the file
-    void RestoreParameters(const std::string& dir_name);
+    void restore_parameters(const std::string& dir_name);
 
     // Add 1 sample of learning data
-    void AddExample(Position& pos, Color rootColor,
-    	 const Learner::PackedSfenValue& psv, double weight);
+    void add_example(
+        Position& pos,
+        Color rootColor,
+    	const Learner::PackedSfenValue& psv,
+        double weight);
 
     // update the evaluation function parameters
-    void UpdateParameters();
+    void update_parameters();
 
     // Check if there are any problems with learning
-    void CheckHealth();
+    void check_health();
 
-    void FinalizeNet();
+    void finalize_net();
 
     void save_eval(std::string suffix);
 }  // namespace Eval::NNUE

--- a/src/nnue/features/castling_right.cpp
+++ b/src/nnue/features/castling_right.cpp
@@ -5,8 +5,11 @@
 namespace Eval::NNUE::Features {
 
     // Get a list of indices with a value of 1 among the features
-    void CastlingRight::AppendActiveIndices(
-        const Position& pos, Color perspective, IndexList* active) {
+    void CastlingRight::append_active_indices(
+        const Position& pos,
+        Color perspective,
+        IndexList* active) {
+
         // do nothing if array size is small to avoid compiler warning
         if (RawFeatures::kMaxActiveDimensions < kMaxActiveDimensions) return;
 
@@ -29,9 +32,11 @@ namespace Eval::NNUE::Features {
     }
 
     // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
-    void CastlingRight::AppendChangedIndices(
-        const Position& pos, Color perspective,
-        IndexList* removed, IndexList* /* added */) {
+    void CastlingRight::append_changed_indices(
+        const Position& pos,
+        Color perspective,
+        IndexList* removed,
+        IndexList* /* added */) {
 
         int previous_castling_rights = pos.state()->previous->castlingRights;
         int current_castling_rights = pos.state()->castlingRights;

--- a/src/nnue/features/castling_right.cpp
+++ b/src/nnue/features/castling_right.cpp
@@ -1,60 +1,60 @@
-//Definition of input feature quantity CastlingRight of NNUE evaluation function
-
 #include "castling_right.h"
 #include "index_list.h"
 
+//Definition of input feature quantity CastlingRight of NNUE evaluation function
 namespace Eval::NNUE::Features {
 
-  // Get a list of indices with a value of 1 among the features
-  void CastlingRight::AppendActiveIndices(
-    const Position& pos, Color perspective, IndexList* active) {
-    // do nothing if array size is small to avoid compiler warning
-    if (RawFeatures::kMaxActiveDimensions < kMaxActiveDimensions) return;
+    // Get a list of indices with a value of 1 among the features
+    void CastlingRight::AppendActiveIndices(
+        const Position& pos, Color perspective, IndexList* active) {
+        // do nothing if array size is small to avoid compiler warning
+        if (RawFeatures::kMaxActiveDimensions < kMaxActiveDimensions) return;
 
-    int castling_rights = pos.state()->castlingRights;
-    int relative_castling_rights;
-    if (perspective == WHITE) {
-      relative_castling_rights = castling_rights;
-    }
-    else {
-      // Invert the perspective.
-      relative_castling_rights = ((castling_rights & 3) << 2)
-        & ((castling_rights >> 2) & 3);
-    }
+        int castling_rights = pos.state()->castlingRights;
+        int relative_castling_rights;
+        if (perspective == WHITE) {
+            relative_castling_rights = castling_rights;
+        }
+        else {
+            // Invert the perspective.
+            relative_castling_rights = ((castling_rights & 3) << 2)
+                & ((castling_rights >> 2) & 3);
+        }
 
-    for (Eval::NNUE::IndexType i = 0; i < kDimensions; ++i) {
-      if (relative_castling_rights & (1 << i)) {
-        active->push_back(i);
-      }
-    }
-  }
-
-  // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
-  void CastlingRight::AppendChangedIndices(
-      const Position& pos, Color perspective,
-      IndexList* removed, IndexList* /* added */) {
-    int previous_castling_rights = pos.state()->previous->castlingRights;
-    int current_castling_rights = pos.state()->castlingRights;
-    int relative_previous_castling_rights;
-    int relative_current_castling_rights;
-    if (perspective == WHITE) {
-      relative_previous_castling_rights = previous_castling_rights;
-      relative_current_castling_rights = current_castling_rights;
-    }
-    else {
-      // Invert the perspective.
-      relative_previous_castling_rights = ((previous_castling_rights & 3) << 2)
-        & ((previous_castling_rights >> 2) & 3);
-      relative_current_castling_rights = ((current_castling_rights & 3) << 2)
-        & ((current_castling_rights >> 2) & 3);
+        for (Eval::NNUE::IndexType i = 0; i < kDimensions; ++i) {
+            if (relative_castling_rights & (1 << i)) {
+                active->push_back(i);
+            }
+        }
     }
 
-    for (Eval::NNUE::IndexType i = 0; i < kDimensions; ++i) {
-      if ((relative_previous_castling_rights & (1 << i)) &&
-        (relative_current_castling_rights & (1 << i)) == 0) {
-        removed->push_back(i);
-      }
+    // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
+    void CastlingRight::AppendChangedIndices(
+        const Position& pos, Color perspective,
+        IndexList* removed, IndexList* /* added */) {
+
+        int previous_castling_rights = pos.state()->previous->castlingRights;
+        int current_castling_rights = pos.state()->castlingRights;
+        int relative_previous_castling_rights;
+        int relative_current_castling_rights;
+        if (perspective == WHITE) {
+            relative_previous_castling_rights = previous_castling_rights;
+            relative_current_castling_rights = current_castling_rights;
+        }
+        else {
+            // Invert the perspective.
+            relative_previous_castling_rights = ((previous_castling_rights & 3) << 2)
+                & ((previous_castling_rights >> 2) & 3);
+            relative_current_castling_rights = ((current_castling_rights & 3) << 2)
+                & ((current_castling_rights >> 2) & 3);
+        }
+
+        for (Eval::NNUE::IndexType i = 0; i < kDimensions; ++i) {
+            if ((relative_previous_castling_rights & (1 << i)) &&
+                (relative_current_castling_rights & (1 << i)) == 0) {
+                removed->push_back(i);
+            }
+        }
     }
-  }
 
 }  // namespace Eval::NNUE::Features

--- a/src/nnue/features/castling_right.h
+++ b/src/nnue/features/castling_right.h
@@ -26,12 +26,17 @@ namespace Eval::NNUE::Features {
         static constexpr TriggerEvent kRefreshTrigger = TriggerEvent::kNone;
 
         // Get a list of indices with a value of 1 among the features
-        static void AppendActiveIndices(const Position& pos, Color perspective,
+        static void append_active_indices(
+            const Position& pos,
+            Color perspective,
             IndexList* active);
 
         // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
-        static void AppendChangedIndices(const Position& pos, Color perspective,
-            IndexList* removed, IndexList* added);
+        static void append_changed_indices(
+            const Position& pos,
+            Color perspective,
+            IndexList* removed,
+            IndexList* added);
     };
 
 }  // namespace Eval::NNUE::Features

--- a/src/nnue/features/castling_right.h
+++ b/src/nnue/features/castling_right.h
@@ -1,34 +1,38 @@
-//Definition of input feature quantity CastlingRight of NNUE evaluation function
-
 #ifndef _NNUE_FEATURES_CASTLING_RIGHT_H_
 #define _NNUE_FEATURES_CASTLING_RIGHT_H_
 
-#include "../../evaluate.h"
 #include "features_common.h"
 
+#include "evaluate.h"
+
+//Definition of input feature quantity CastlingRight of NNUE evaluation function
 namespace Eval::NNUE::Features {
 
-  class CastlingRight {
-  public:
-    // feature quantity name
-    static constexpr const char* kName = "CastlingRight";
-    // Hash value embedded in the evaluation function file
-    static constexpr std::uint32_t kHashValue = 0x913968AAu;
-    // number of feature dimensions
-    static constexpr IndexType kDimensions = 4;
-    // The maximum value of the number of indexes whose value is 1 at the same time among the feature values
-    static constexpr IndexType kMaxActiveDimensions = 4;
-    // Timing of full calculation instead of difference calculation
-    static constexpr TriggerEvent kRefreshTrigger = TriggerEvent::kNone;
+    class CastlingRight {
+    public:
+        // feature quantity name
+        static constexpr const char* kName = "CastlingRight";
 
-    // Get a list of indices with a value of 1 among the features
-    static void AppendActiveIndices(const Position& pos, Color perspective,
-      IndexList* active);
+        // Hash value embedded in the evaluation function file
+        static constexpr std::uint32_t kHashValue = 0x913968AAu;
 
-    // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
-    static void AppendChangedIndices(const Position& pos, Color perspective,
-      IndexList* removed, IndexList* added);
-  };
+        // number of feature dimensions
+        static constexpr IndexType kDimensions = 4;
+
+        // The maximum value of the number of indexes whose value is 1 at the same time among the feature values
+        static constexpr IndexType kMaxActiveDimensions = 4;
+
+        // Timing of full calculation instead of difference calculation
+        static constexpr TriggerEvent kRefreshTrigger = TriggerEvent::kNone;
+
+        // Get a list of indices with a value of 1 among the features
+        static void AppendActiveIndices(const Position& pos, Color perspective,
+            IndexList* active);
+
+        // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
+        static void AppendChangedIndices(const Position& pos, Color perspective,
+            IndexList* removed, IndexList* added);
+    };
 
 }  // namespace Eval::NNUE::Features
 

--- a/src/nnue/features/enpassant.cpp
+++ b/src/nnue/features/enpassant.cpp
@@ -5,8 +5,10 @@
 namespace Eval::NNUE::Features {
 
     // Get a list of indices with a value of 1 among the features
-    void EnPassant::AppendActiveIndices(
-        const Position& pos, Color /* perspective */, IndexList* active) {
+    void EnPassant::append_active_indices(
+        const Position& pos,
+        Color /* perspective */,
+        IndexList* active) {
 
         // do nothing if array size is small to avoid compiler warning
         if (RawFeatures::kMaxActiveDimensions < kMaxActiveDimensions)
@@ -21,9 +23,11 @@ namespace Eval::NNUE::Features {
     }
 
     // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
-    void EnPassant::AppendChangedIndices(
-        const Position& pos, Color /* perspective */,
-        IndexList* removed, IndexList* added) {
+    void EnPassant::append_changed_indices(
+        const Position& pos,
+        Color /* perspective */,
+        IndexList* removed,
+        IndexList* added) {
 
         auto previous_epSquare = pos.state()->previous->epSquare;
         auto epSquare = pos.state()->epSquare;

--- a/src/nnue/features/enpassant.cpp
+++ b/src/nnue/features/enpassant.cpp
@@ -1,42 +1,45 @@
-//Definition of input feature quantity EnPassant of NNUE evaluation function
-
 #include "enpassant.h"
 #include "index_list.h"
 
+//Definition of input feature quantity EnPassant of NNUE evaluation function
 namespace Eval::NNUE::Features {
 
-  // Get a list of indices with a value of 1 among the features
-  void EnPassant::AppendActiveIndices(
-    const Position& pos, Color /* perspective */, IndexList* active) {
-    // do nothing if array size is small to avoid compiler warning
-    if (RawFeatures::kMaxActiveDimensions < kMaxActiveDimensions) return;
+    // Get a list of indices with a value of 1 among the features
+    void EnPassant::AppendActiveIndices(
+        const Position& pos, Color /* perspective */, IndexList* active) {
 
-    auto epSquare = pos.state()->epSquare;
-    if (epSquare == SQ_NONE) {
-      return;
+        // do nothing if array size is small to avoid compiler warning
+        if (RawFeatures::kMaxActiveDimensions < kMaxActiveDimensions)
+            return;
+
+        auto epSquare = pos.state()->epSquare;
+        if (epSquare == SQ_NONE)
+            return;
+
+        auto file = file_of(epSquare);
+        active->push_back(file);
     }
-    auto file = file_of(epSquare);
-    active->push_back(file);
-  }
 
-  // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
-  void EnPassant::AppendChangedIndices(
-      const Position& pos, Color /* perspective */,
-      IndexList* removed, IndexList* added) {
+    // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
+    void EnPassant::AppendChangedIndices(
+        const Position& pos, Color /* perspective */,
+        IndexList* removed, IndexList* added) {
 
-    auto previous_epSquare = pos.state()->previous->epSquare;
-    auto epSquare = pos.state()->epSquare;
+        auto previous_epSquare = pos.state()->previous->epSquare;
+        auto epSquare = pos.state()->epSquare;
 
-    if (previous_epSquare != SQ_NONE) {
-      if (epSquare != SQ_NONE && file_of(epSquare) == file_of(previous_epSquare))
-        return;
-      auto file = file_of(previous_epSquare);
-      removed->push_back(file);
+        if (previous_epSquare != SQ_NONE) {
+            if (epSquare != SQ_NONE && file_of(epSquare) == file_of(previous_epSquare))
+                return;
+
+            auto file = file_of(previous_epSquare);
+            removed->push_back(file);
+        }
+
+        if (epSquare != SQ_NONE) {
+            auto file = file_of(epSquare);
+            added->push_back(file);
+        }
     }
-    if (epSquare != SQ_NONE) {
-      auto file = file_of(epSquare);
-      added->push_back(file);
-    }
-  }
 
 }  // namespace Eval::NNUE::Features

--- a/src/nnue/features/enpassant.h
+++ b/src/nnue/features/enpassant.h
@@ -22,12 +22,17 @@ namespace Eval::NNUE::Features {
         static constexpr TriggerEvent kRefreshTrigger = TriggerEvent::kNone;
 
         // Get a list of indices with a value of 1 among the features
-        static void AppendActiveIndices(const Position& pos, Color perspective,
+        static void append_active_indices(
+            const Position& pos,
+            Color perspective,
             IndexList* active);
 
         // Get a list of indices whose values have changed from the previous one in the feature quantity
-        static void AppendChangedIndices(const Position& pos, Color perspective,
-            IndexList* removed, IndexList* added);
+        static void append_changed_indices(
+            const Position& pos,
+            Color perspective,
+            IndexList* removed,
+            IndexList* added);
     };
 
 }  // namespace Eval::NNUE::Features

--- a/src/nnue/features/enpassant.h
+++ b/src/nnue/features/enpassant.h
@@ -1,34 +1,34 @@
-//Definition of input feature quantity EnPassant of NNUE evaluation function
-
 #ifndef _NNUE_FEATURES_ENPASSANT_H_
 #define _NNUE_FEATURES_ENPASSANT_H_
 
-#include "../../evaluate.h"
 #include "features_common.h"
 
+#include "evaluate.h"
+
+//Definition of input feature quantity EnPassant of NNUE evaluation function
 namespace Eval::NNUE::Features {
 
-  class EnPassant {
-  public:
-    // feature quantity name
-    static constexpr const char* kName = "EnPassant";
-    // Hash value embedded in the evaluation function file
-    static constexpr std::uint32_t kHashValue = 0x02924F91u;
-    // number of feature dimensions
-    static constexpr IndexType kDimensions = 8;
-    // The maximum value of the number of indexes whose value is 1 at the same time among the feature values
-    static constexpr IndexType kMaxActiveDimensions = 1;
-    // Timing of full calculation instead of difference calculation
-    static constexpr TriggerEvent kRefreshTrigger = TriggerEvent::kNone;
+    class EnPassant {
+    public:
+        // feature quantity name
+        static constexpr const char* kName = "EnPassant";
+        // Hash value embedded in the evaluation function file
+        static constexpr std::uint32_t kHashValue = 0x02924F91u;
+        // number of feature dimensions
+        static constexpr IndexType kDimensions = 8;
+        // The maximum value of the number of indexes whose value is 1 at the same time among the feature values
+        static constexpr IndexType kMaxActiveDimensions = 1;
+        // Timing of full calculation instead of difference calculation
+        static constexpr TriggerEvent kRefreshTrigger = TriggerEvent::kNone;
 
-    // Get a list of indices with a value of 1 among the features
-    static void AppendActiveIndices(const Position& pos, Color perspective,
-      IndexList* active);
+        // Get a list of indices with a value of 1 among the features
+        static void AppendActiveIndices(const Position& pos, Color perspective,
+            IndexList* active);
 
-    // Get a list of indices whose values have changed from the previous one in the feature quantity
-    static void AppendChangedIndices(const Position& pos, Color perspective,
-      IndexList* removed, IndexList* added);
-  };
+        // Get a list of indices whose values have changed from the previous one in the feature quantity
+        static void AppendChangedIndices(const Position& pos, Color perspective,
+            IndexList* removed, IndexList* added);
+    };
 
 }  // namespace Eval::NNUE::Features
 

--- a/src/nnue/features/feature_set.h
+++ b/src/nnue/features/feature_set.h
@@ -1,19 +1,19 @@
 /*
-  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
-  Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
+    Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+    Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
 
-  Stockfish is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+    Stockfish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-  Stockfish is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+    Stockfish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 // A class template that represents the input feature set of the NNUE evaluation function
@@ -22,238 +22,266 @@
 #define NNUE_FEATURE_SET_H_INCLUDED
 
 #include "features_common.h"
+
 #include <array>
 
 namespace Eval::NNUE::Features {
 
-  // Class template that represents a list of values
-  template <typename T, T... Values>
-  struct CompileTimeList;
+    // Class template that represents a list of values
+    template <typename T, T... Values>
+    struct CompileTimeList;
 
-  template <typename T, T First, T... Remaining>
-  struct CompileTimeList<T, First, Remaining...> {
-    static constexpr bool Contains(T value) {
-      return value == First || CompileTimeList<T, Remaining...>::Contains(value);
-    }
-    static constexpr std::array<T, sizeof...(Remaining) + 1>
-        kValues = {{First, Remaining...}};
-  };
-
-  template <typename T, T First, T... Remaining>
-  constexpr std::array<T, sizeof...(Remaining) + 1>
-    CompileTimeList<T, First, Remaining...>::kValues;
-  template <typename T>
-  struct CompileTimeList<T> {
-    static constexpr bool Contains(T /*value*/) {
-      return false;
-    }
-    static constexpr std::array<T, 0> kValues = { {} };
-  };
-
-  // Class template that adds to the beginning of the list
-  template <typename T, typename ListType, T Value>
-  struct AppendToList;
-  template <typename T, T... Values, T AnotherValue>
-  struct AppendToList<T, CompileTimeList<T, Values...>, AnotherValue> {
-    using Result = CompileTimeList<T, AnotherValue, Values...>;
-  };
-
-  // Class template for adding to a sorted, unique list
-  template <typename T, typename ListType, T Value>
-  struct InsertToSet;
-  template <typename T, T First, T... Remaining, T AnotherValue>
-  struct InsertToSet<T, CompileTimeList<T, First, Remaining...>, AnotherValue> {
-    using Result = std::conditional_t<
-      CompileTimeList<T, First, Remaining...>::Contains(AnotherValue),
-      CompileTimeList<T, First, Remaining...>,
-      std::conditional_t<(AnotherValue < First),
-      CompileTimeList<T, AnotherValue, First, Remaining...>,
-      typename AppendToList<T, typename InsertToSet<
-      T, CompileTimeList<T, Remaining...>, AnotherValue>::Result,
-      First>::Result>>;
-  };
-  template <typename T, T Value>
-  struct InsertToSet<T, CompileTimeList<T>, Value> {
-    using Result = CompileTimeList<T, Value>;
-  };
-
-  // Base class of feature set
-  template <typename Derived>
-  class FeatureSetBase {
-
-   public:
-    // Get a list of indices for active features
-    template <typename IndexListType>
-    static void AppendActiveIndices(
-        const Position& pos, TriggerEvent trigger, IndexListType active[2]) {
-
-      for (Color perspective : { WHITE, BLACK }) {
-        Derived::CollectActiveIndices(
-            pos, trigger, perspective, &active[perspective]);
-      }
-    }
-
-    // Get a list of indices for recently changed features
-    template <typename PositionType, typename IndexListType>
-    static void AppendChangedIndices(
-        const PositionType& pos, TriggerEvent trigger,
-        IndexListType removed[2], IndexListType added[2], bool reset[2]) {
-
-      const auto& dp = pos.state()->dirtyPiece;
-
-      for (Color perspective : { WHITE, BLACK }) {
-        switch (trigger) {
-          case TriggerEvent::kNone:
-            break;
-          case TriggerEvent::kFriendKingMoved:
-            if (dp.dirty_num == 0) continue;
-            reset[perspective] = dp.piece[0] == make_piece(perspective, KING);
-            break;
-          case TriggerEvent::kEnemyKingMoved:
-            if (dp.dirty_num == 0) continue;
-            reset[perspective] = dp.piece[0] == make_piece(~perspective, KING);
-            break;
-          case TriggerEvent::kAnyKingMoved:
-            if (dp.dirty_num == 0) continue;
-            reset[perspective] = type_of(dp.piece[0]) == KING;
-            break;
-          case TriggerEvent::kAnyPieceMoved:
-            reset[perspective] = true;
-            break;
-          default:
-            assert(false);
-            break;
+    template <typename T, T First, T... Remaining>
+    struct CompileTimeList<T, First, Remaining...> {
+        static constexpr bool Contains(T value) {
+            return value == First || CompileTimeList<T, Remaining...>::Contains(value);
         }
-        if (reset[perspective]) {
-          Derived::CollectActiveIndices(
-              pos, trigger, perspective, &added[perspective]);
-        } else {
-          Derived::CollectChangedIndices(
-              pos, trigger, perspective,
-              &removed[perspective], &added[perspective]);
+
+        static constexpr std::array<T, sizeof...(Remaining) + 1>
+            kValues = {{First, Remaining...}};
+    };
+
+    template <typename T, T First, T... Remaining>
+    constexpr std::array<T, sizeof...(Remaining) + 1>
+        CompileTimeList<T, First, Remaining...>::kValues;
+
+    template <typename T>
+    struct CompileTimeList<T> {
+        static constexpr bool Contains(T /*value*/) {
+            return false;
         }
-      }
-    }
-  };
+        static constexpr std::array<T, 0> kValues = { {} };
+    };
 
-  // Class template that represents the feature set
-  // do internal processing in reverse order of template arguments in order to linearize the amount of calculation at runtime
-  template <typename FirstFeatureType, typename... RemainingFeatureTypes>
-  class FeatureSet<FirstFeatureType, RemainingFeatureTypes...> :
-    public FeatureSetBase<
-    FeatureSet<FirstFeatureType, RemainingFeatureTypes...>> {
-  private:
-    using Head = FirstFeatureType;
-    using Tail = FeatureSet<RemainingFeatureTypes...>;
+    // Class template that adds to the beginning of the list
+    template <typename T, typename ListType, T Value>
+    struct AppendToList;
 
-  public:
-    // Hash value embedded in the evaluation function file
-    static constexpr std::uint32_t kHashValue =
-      Head::kHashValue ^ (Tail::kHashValue << 1) ^ (Tail::kHashValue >> 31);
-    // number of feature dimensions
-    static constexpr IndexType kDimensions =
-      Head::kDimensions + Tail::kDimensions;
-    // The maximum value of the number of indexes whose value is 1 at the same time among the feature values
-    static constexpr IndexType kMaxActiveDimensions =
-      Head::kMaxActiveDimensions + Tail::kMaxActiveDimensions;
-    // List of timings to perform all calculations instead of difference calculation
-    using SortedTriggerSet = typename InsertToSet<TriggerEvent,
-      typename Tail::SortedTriggerSet, Head::kRefreshTrigger>::Result;
-    static constexpr auto kRefreshTriggers = SortedTriggerSet::kValues;
+    template <typename T, T... Values, T AnotherValue>
+    struct AppendToList<T, CompileTimeList<T, Values...>, AnotherValue> {
+        using Result = CompileTimeList<T, AnotherValue, Values...>;
+    };
 
-    // Get the feature quantity name
-    static std::string GetName() {
-      return std::string(Head::kName) + "+" + Tail::GetName();
-    }
+    // Class template for adding to a sorted, unique list
+    template <typename T, typename ListType, T Value>
+    struct InsertToSet;
 
-  private:
-    // Get a list of indices with a value of 1 among the features
-    template <typename IndexListType>
-    static void CollectActiveIndices(
-      const Position& pos, const TriggerEvent trigger, const Color perspective,
-      IndexListType* const active) {
-      Tail::CollectActiveIndices(pos, trigger, perspective, active);
-      if (Head::kRefreshTrigger == trigger) {
-        const auto start = active->size();
-        Head::AppendActiveIndices(pos, perspective, active);
-        for (auto i = start; i < active->size(); ++i) {
-          (*active)[i] += Tail::kDimensions;
+    template <typename T, T First, T... Remaining, T AnotherValue>
+    struct InsertToSet<T, CompileTimeList<T, First, Remaining...>, AnotherValue> {
+        using Result =
+            std::conditional_t<
+                CompileTimeList<T, First, Remaining...>::Contains(AnotherValue),
+                CompileTimeList<T, First, Remaining...>,
+                std::conditional_t<
+                    (AnotherValue < First),
+                    CompileTimeList<T, AnotherValue, First, Remaining...>,
+                    typename AppendToList<T, typename InsertToSet<
+                        T, CompileTimeList<T, Remaining...>, AnotherValue>::Result,
+                        First
+                    >::Result
+                >
+            >;
+    };
+
+    template <typename T, T Value>
+    struct InsertToSet<T, CompileTimeList<T>, Value> {
+        using Result = CompileTimeList<T, Value>;
+    };
+
+    // Base class of feature set
+    template <typename Derived>
+    class FeatureSetBase {
+
+       public:
+        // Get a list of indices for active features
+        template <typename IndexListType>
+        static void AppendActiveIndices(
+            const Position& pos, TriggerEvent trigger, IndexListType active[2]) {
+
+            for (Color perspective : { WHITE, BLACK }) {
+                Derived::CollectActiveIndices(
+                    pos, trigger, perspective, &active[perspective]);
+            }
         }
-      }
-    }
 
-    // Get a list of indices whose values have changed from the previous one in the feature quantity
-    template <typename IndexListType>
-    static void CollectChangedIndices(
-      const Position& pos, const TriggerEvent trigger, const Color perspective,
-      IndexListType* const removed, IndexListType* const added) {
-      Tail::CollectChangedIndices(pos, trigger, perspective, removed, added);
-      if (Head::kRefreshTrigger == trigger) {
-        const auto start_removed = removed->size();
-        const auto start_added = added->size();
-        Head::AppendChangedIndices(pos, perspective, removed, added);
-        for (auto i = start_removed; i < removed->size(); ++i) {
-          (*removed)[i] += Tail::kDimensions;
+        // Get a list of indices for recently changed features
+        template <typename PositionType, typename IndexListType>
+        static void AppendChangedIndices(
+            const PositionType& pos, TriggerEvent trigger,
+            IndexListType removed[2], IndexListType added[2], bool reset[2]) {
+
+            const auto& dp = pos.state()->dirtyPiece;
+
+            for (Color perspective : { WHITE, BLACK }) {
+                switch (trigger) {
+                    case TriggerEvent::kNone:
+                        break;
+                    case TriggerEvent::kFriendKingMoved:
+                        if (dp.dirty_num == 0) continue;
+                        reset[perspective] = dp.piece[0] == make_piece(perspective, KING);
+                        break;
+                    case TriggerEvent::kEnemyKingMoved:
+                        if (dp.dirty_num == 0) continue;
+                        reset[perspective] = dp.piece[0] == make_piece(~perspective, KING);
+                        break;
+                    case TriggerEvent::kAnyKingMoved:
+                        if (dp.dirty_num == 0) continue;
+                        reset[perspective] = type_of(dp.piece[0]) == KING;
+                        break;
+                    case TriggerEvent::kAnyPieceMoved:
+                        reset[perspective] = true;
+                        break;
+                    default:
+                        assert(false);
+                        break;
+                }
+
+                if (reset[perspective]) {
+                    Derived::CollectActiveIndices(
+                        pos, trigger, perspective, &added[perspective]);
+                } else {
+                    Derived::CollectChangedIndices(
+                        pos, trigger, perspective,
+                        &removed[perspective], &added[perspective]);
+                }
+            }
         }
-        for (auto i = start_added; i < added->size(); ++i) {
-          (*added)[i] += Tail::kDimensions;
+    };
+
+    // Class template that represents the feature set
+    // do internal processing in reverse order of template arguments in order to linearize the amount of calculation at runtime
+    template <typename FirstFeatureType, typename... RemainingFeatureTypes>
+    class FeatureSet<FirstFeatureType, RemainingFeatureTypes...> :
+      public FeatureSetBase<
+          FeatureSet<FirstFeatureType, RemainingFeatureTypes...>
+      > {
+
+    private:
+        using Head = FirstFeatureType;
+        using Tail = FeatureSet<RemainingFeatureTypes...>;
+
+    public:
+        // Hash value embedded in the evaluation function file
+        static constexpr std::uint32_t kHashValue =
+            Head::kHashValue ^ (Tail::kHashValue << 1) ^ (Tail::kHashValue >> 31);
+
+        // number of feature dimensions
+        static constexpr IndexType kDimensions =
+            Head::kDimensions + Tail::kDimensions;
+
+        // The maximum value of the number of indexes whose value is 1 at the same time among the feature values
+        static constexpr IndexType kMaxActiveDimensions =
+            Head::kMaxActiveDimensions + Tail::kMaxActiveDimensions;
+
+        // List of timings to perform all calculations instead of difference calculation
+        using SortedTriggerSet = typename InsertToSet<TriggerEvent,
+            typename Tail::SortedTriggerSet, Head::kRefreshTrigger>::Result;
+
+        static constexpr auto kRefreshTriggers = SortedTriggerSet::kValues;
+
+        // Get the feature quantity name
+        static std::string GetName() {
+            return std::string(Head::kName) + "+" + Tail::GetName();
         }
-      }
-    }
 
-    // Make the base class and the class template that recursively uses itself a friend
-    friend class FeatureSetBase<FeatureSet>;
-    template <typename... FeatureTypes>
-    friend class FeatureSet;
-  };
+    private:
+        // Get a list of indices with a value of 1 among the features
+        template <typename IndexListType>
+        static void CollectActiveIndices(
+            const Position& pos, const TriggerEvent trigger, const Color perspective,
+            IndexListType* const active) {
+            Tail::CollectActiveIndices(pos, trigger, perspective, active);
+            if (Head::kRefreshTrigger == trigger) {
+                const auto start = active->size();
+                Head::AppendActiveIndices(pos, perspective, active);
 
-  // Class template that represents the feature set
-  template <typename FeatureType>
-  class FeatureSet<FeatureType> : public FeatureSetBase<FeatureSet<FeatureType>> {
+                for (auto i = start; i < active->size(); ++i) {
+                    (*active)[i] += Tail::kDimensions;
+                }
+            }
+        }
 
-   public:
-    // Hash value embedded in the evaluation file
-    static constexpr std::uint32_t kHashValue = FeatureType::kHashValue;
-    // Number of feature dimensions
-    static constexpr IndexType kDimensions = FeatureType::kDimensions;
-    // Maximum number of simultaneously active features
-    static constexpr IndexType kMaxActiveDimensions =
-        FeatureType::kMaxActiveDimensions;
-    // Trigger for full calculation instead of difference calculation
-    using SortedTriggerSet =
-        CompileTimeList<TriggerEvent, FeatureType::kRefreshTrigger>;
-    static constexpr auto kRefreshTriggers = SortedTriggerSet::kValues;
+        // Get a list of indices whose values have changed from the previous one in the feature quantity
+        template <typename IndexListType>
+        static void CollectChangedIndices(
+            const Position& pos, const TriggerEvent trigger, const Color perspective,
+            IndexListType* const removed, IndexListType* const added) {
+            Tail::CollectChangedIndices(pos, trigger, perspective, removed, added);
+            if (Head::kRefreshTrigger == trigger) {
+                const auto start_removed = removed->size();
+                const auto start_added = added->size();
+                Head::AppendChangedIndices(pos, perspective, removed, added);
 
-    // Get the feature quantity name
-    static std::string GetName() {
-      return FeatureType::kName;
-    }
+                for (auto i = start_removed; i < removed->size(); ++i) {
+                    (*removed)[i] += Tail::kDimensions;
+                }
 
-   private:
-    // Get a list of indices for active features
-    static void CollectActiveIndices(
-        const Position& pos, const TriggerEvent trigger, const Color perspective,
-        IndexList* const active) {
-      if (FeatureType::kRefreshTrigger == trigger) {
-        FeatureType::AppendActiveIndices(pos, perspective, active);
-      }
-    }
+                for (auto i = start_added; i < added->size(); ++i) {
+                    (*added)[i] += Tail::kDimensions;
+                }
+            }
+        }
 
-    // Get a list of indices for recently changed features
-    static void CollectChangedIndices(
-        const Position& pos, const TriggerEvent trigger, const Color perspective,
-        IndexList* const removed, IndexList* const added) {
+        // Make the base class and the class template that recursively uses itself a friend
+        friend class FeatureSetBase<FeatureSet>;
 
-      if (FeatureType::kRefreshTrigger == trigger) {
-        FeatureType::AppendChangedIndices(pos, perspective, removed, added);
-      }
-    }
+        template <typename... FeatureTypes>
+        friend class FeatureSet;
+    };
 
-    // Make the base class and the class template that recursively uses itself a friend
-    friend class FeatureSetBase<FeatureSet>;
-    template <typename... FeatureTypes>
-    friend class FeatureSet;
-  };
+    // Class template that represents the feature set
+    template <typename FeatureType>
+    class FeatureSet<FeatureType> : public FeatureSetBase<FeatureSet<FeatureType>> {
+
+    public:
+        // Hash value embedded in the evaluation file
+        static constexpr std::uint32_t kHashValue = FeatureType::kHashValue;
+
+        // Number of feature dimensions
+        static constexpr IndexType kDimensions = FeatureType::kDimensions;
+
+        // Maximum number of simultaneously active features
+        static constexpr IndexType kMaxActiveDimensions =
+            FeatureType::kMaxActiveDimensions;
+
+        // Trigger for full calculation instead of difference calculation
+        using SortedTriggerSet =
+            CompileTimeList<TriggerEvent, FeatureType::kRefreshTrigger>;
+
+        static constexpr auto kRefreshTriggers = SortedTriggerSet::kValues;
+
+        // Get the feature quantity name
+        static std::string GetName() {
+            return FeatureType::kName;
+        }
+
+    private:
+        // Get a list of indices for active features
+        static void CollectActiveIndices(
+            const Position& pos, const TriggerEvent trigger, const Color perspective,
+            IndexList* const active) {
+
+            if (FeatureType::kRefreshTrigger == trigger) {
+              FeatureType::AppendActiveIndices(pos, perspective, active);
+            }
+        }
+
+        // Get a list of indices for recently changed features
+        static void CollectChangedIndices(
+            const Position& pos, const TriggerEvent trigger, const Color perspective,
+            IndexList* const removed, IndexList* const added) {
+
+            if (FeatureType::kRefreshTrigger == trigger) {
+              FeatureType::AppendChangedIndices(pos, perspective, removed, added);
+            }
+        }
+
+        // Make the base class and the class template that recursively uses itself a friend
+        friend class FeatureSetBase<FeatureSet>;
+
+        template <typename... FeatureTypes>
+        friend class FeatureSet;
+    };
 
 }  // namespace Eval::NNUE::Features
 

--- a/src/nnue/features/features_common.h
+++ b/src/nnue/features/features_common.h
@@ -1,19 +1,19 @@
 /*
-  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
-  Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
+    Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+    Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
 
-  Stockfish is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+    Stockfish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-  Stockfish is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+    Stockfish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Common header of input features of NNUE evaluation function
@@ -21,29 +21,30 @@
 #ifndef NNUE_FEATURES_COMMON_H_INCLUDED
 #define NNUE_FEATURES_COMMON_H_INCLUDED
 
-#include "../../evaluate.h"
-#include "../nnue_common.h"
+#include "evaluate.h"
+
+#include "nnue/nnue_common.h"
 
 namespace Eval::NNUE::Features {
 
-  class IndexList;
+    class IndexList;
 
-  template <typename... FeatureTypes>
-  class FeatureSet;
+    template <typename... FeatureTypes>
+    class FeatureSet;
 
-  // Trigger to perform full calculations instead of difference only
-  enum class TriggerEvent {
-    kNone, // Calculate the difference whenever possible
-    kFriendKingMoved, // calculate full evaluation when own king moves
-    kEnemyKingMoved, // calculate full evaluation when opponent king moves
-    kAnyKingMoved, // calculate full evaluation when any king moves
-    kAnyPieceMoved, // always calculate full evaluation
-  };
+    // Trigger to perform full calculations instead of difference only
+    enum class TriggerEvent {
+        kNone, // Calculate the difference whenever possible
+        kFriendKingMoved, // calculate full evaluation when own king moves
+        kEnemyKingMoved, // calculate full evaluation when opponent king moves
+        kAnyKingMoved, // calculate full evaluation when any king moves
+        kAnyPieceMoved, // always calculate full evaluation
+    };
 
-  enum class Side {
-    kFriend, // side to move
-    kEnemy, // opponent
-  };
+    enum class Side {
+        kFriend, // side to move
+        kEnemy, // opponent
+    };
 
 }  // namespace Eval::NNUE::Features
 

--- a/src/nnue/features/half_kp.cpp
+++ b/src/nnue/features/half_kp.cpp
@@ -1,19 +1,19 @@
 /*
-  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
-  Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
+    Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+    Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
 
-  Stockfish is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+    Stockfish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-  Stockfish is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+    Stockfish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Definition of input features HalfKP of NNUE evaluation function
@@ -23,51 +23,59 @@
 
 namespace Eval::NNUE::Features {
 
-  // Orient a square according to perspective (flip rank for black)
-  inline Square orient(Color perspective, Square s) {
-    return Square(int(s) ^ (bool(perspective) * SQ_A8));
-  }
-
-  // Find the index of the feature quantity from the king position and PieceSquare
-  template <Side AssociatedKing>
-  inline IndexType HalfKP<AssociatedKing>::MakeIndex(
-      Color perspective, Square s, Piece pc, Square ksq) {
-
-    return IndexType(orient(perspective, s) + kpp_board_index[pc][perspective] + PS_END * ksq);
-  }
-
-  // Get a list of indices for active features
-  template <Side AssociatedKing>
-  void HalfKP<AssociatedKing>::AppendActiveIndices(
-      const Position& pos, Color perspective, IndexList* active) {
-
-    Square ksq = orient(perspective, pos.square<KING>(AssociatedKing == Side::kFriend ? perspective : ~perspective));
-    Bitboard bb = pos.pieces() & ~pos.pieces(KING);
-    while (bb) {
-      Square s = pop_lsb(&bb);
-      active->push_back(MakeIndex(perspective, s, pos.piece_on(s), ksq));
+    // Orient a square according to perspective (flip rank for black)
+    inline Square orient(Color perspective, Square s) {
+        return Square(int(s) ^ (bool(perspective) * SQ_A8));
     }
-  }
 
-  // Get a list of indices for recently changed features
-  template <Side AssociatedKing>
-  void HalfKP<AssociatedKing>::AppendChangedIndices(
-      const Position& pos, Color perspective,
-      IndexList* removed, IndexList* added) {
+    // Find the index of the feature quantity from the king position and PieceSquare
+    template <Side AssociatedKing>
+    inline IndexType HalfKP<AssociatedKing>::MakeIndex(
+        Color perspective, Square s, Piece pc, Square ksq) {
 
-    Square ksq = orient(perspective, pos.square<KING>(AssociatedKing == Side::kFriend ? perspective : ~perspective));
-    const auto& dp = pos.state()->dirtyPiece;
-    for (int i = 0; i < dp.dirty_num; ++i) {
-      Piece pc = dp.piece[i];
-      if (type_of(pc) == KING) continue;
-      if (dp.from[i] != SQ_NONE)
-        removed->push_back(MakeIndex(perspective, dp.from[i], pc, ksq));
-      if (dp.to[i] != SQ_NONE)
-        added->push_back(MakeIndex(perspective, dp.to[i], pc, ksq));
+        return IndexType(orient(perspective, s) + kpp_board_index[pc][perspective] + PS_END * ksq);
     }
-  }
 
-  template class HalfKP<Side::kFriend>;
-  template class HalfKP<Side::kEnemy>;
+    // Get a list of indices for active features
+    template <Side AssociatedKing>
+    void HalfKP<AssociatedKing>::AppendActiveIndices(
+        const Position& pos, Color perspective, IndexList* active) {
+
+        Square ksq = orient(perspective, pos.square<KING>(AssociatedKing == Side::kFriend ? perspective : ~perspective));
+        Bitboard bb = pos.pieces() & ~pos.pieces(KING);
+        while (bb) {
+            Square s = pop_lsb(&bb);
+            active->push_back(MakeIndex(perspective, s, pos.piece_on(s), ksq));
+        }
+    }
+
+    // Get a list of indices for recently changed features
+    template <Side AssociatedKing>
+    void HalfKP<AssociatedKing>::AppendChangedIndices(
+        const Position& pos, Color perspective,
+        IndexList* removed, IndexList* added) {
+
+        Square ksq = orient(
+            perspective,
+            pos.square<KING>(
+                AssociatedKing == Side::kFriend ? perspective : ~perspective));
+
+        const auto& dp = pos.state()->dirtyPiece;
+        for (int i = 0; i < dp.dirty_num; ++i) {
+            Piece pc = dp.piece[i];
+
+            if (type_of(pc) == KING)
+                continue;
+
+            if (dp.from[i] != SQ_NONE)
+                removed->push_back(MakeIndex(perspective, dp.from[i], pc, ksq));
+
+            if (dp.to[i] != SQ_NONE)
+                added->push_back(MakeIndex(perspective, dp.to[i], pc, ksq));
+        }
+    }
+
+    template class HalfKP<Side::kFriend>;
+    template class HalfKP<Side::kEnemy>;
 
 }  // namespace Eval::NNUE::Features

--- a/src/nnue/features/half_kp.cpp
+++ b/src/nnue/features/half_kp.cpp
@@ -30,30 +30,41 @@ namespace Eval::NNUE::Features {
 
     // Find the index of the feature quantity from the king position and PieceSquare
     template <Side AssociatedKing>
-    inline IndexType HalfKP<AssociatedKing>::MakeIndex(
-        Color perspective, Square s, Piece pc, Square ksq) {
+    inline IndexType HalfKP<AssociatedKing>::make_index(
+        Color perspective,
+        Square s,
+        Piece pc,
+        Square ksq) {
 
         return IndexType(orient(perspective, s) + kpp_board_index[pc][perspective] + PS_END * ksq);
     }
 
     // Get a list of indices for active features
     template <Side AssociatedKing>
-    void HalfKP<AssociatedKing>::AppendActiveIndices(
-        const Position& pos, Color perspective, IndexList* active) {
+    void HalfKP<AssociatedKing>::append_active_indices(
+        const Position& pos,
+        Color perspective,
+        IndexList* active) {
 
-        Square ksq = orient(perspective, pos.square<KING>(AssociatedKing == Side::kFriend ? perspective : ~perspective));
+        Square ksq = orient(
+            perspective,
+            pos.square<KING>(
+                AssociatedKing == Side::kFriend ? perspective : ~perspective));
+
         Bitboard bb = pos.pieces() & ~pos.pieces(KING);
         while (bb) {
             Square s = pop_lsb(&bb);
-            active->push_back(MakeIndex(perspective, s, pos.piece_on(s), ksq));
+            active->push_back(make_index(perspective, s, pos.piece_on(s), ksq));
         }
     }
 
     // Get a list of indices for recently changed features
     template <Side AssociatedKing>
-    void HalfKP<AssociatedKing>::AppendChangedIndices(
-        const Position& pos, Color perspective,
-        IndexList* removed, IndexList* added) {
+    void HalfKP<AssociatedKing>::append_changed_indices(
+        const Position& pos,
+        Color perspective,
+        IndexList* removed,
+        IndexList* added) {
 
         Square ksq = orient(
             perspective,
@@ -68,10 +79,10 @@ namespace Eval::NNUE::Features {
                 continue;
 
             if (dp.from[i] != SQ_NONE)
-                removed->push_back(MakeIndex(perspective, dp.from[i], pc, ksq));
+                removed->push_back(make_index(perspective, dp.from[i], pc, ksq));
 
             if (dp.to[i] != SQ_NONE)
-                added->push_back(MakeIndex(perspective, dp.to[i], pc, ksq));
+                added->push_back(make_index(perspective, dp.to[i], pc, ksq));
         }
     }
 

--- a/src/nnue/features/half_kp.h
+++ b/src/nnue/features/half_kp.h
@@ -53,16 +53,21 @@ namespace Eval::NNUE::Features {
             TriggerEvent::kFriendKingMoved : TriggerEvent::kEnemyKingMoved;
 
         // Get a list of indices for active features
-        static void AppendActiveIndices(const Position& pos, Color perspective,
-                                        IndexList* active);
+        static void append_active_indices(
+            const Position& pos,
+            Color perspective,
+            IndexList* active);
 
         // Get a list of indices for recently changed features
-        static void AppendChangedIndices(const Position& pos, Color perspective,
-                                         IndexList* removed, IndexList* added);
+        static void append_changed_indices(
+            const Position& pos,
+            Color perspective,
+            IndexList* removed,
+            IndexList* added);
 
     private:
         // Index of a feature for a given king position and another piece on some square
-        static IndexType MakeIndex(Color perspective, Square s, Piece pc, Square sq_k);
+        static IndexType make_index(Color perspective, Square s, Piece pc, Square sq_k);
     };
 
 }  // namespace Eval::NNUE::Features

--- a/src/nnue/features/half_kp.h
+++ b/src/nnue/features/half_kp.h
@@ -1,65 +1,69 @@
 /*
-  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
-  Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
+    Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+    Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
 
-  Stockfish is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+    Stockfish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-  Stockfish is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+    Stockfish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-
-//Definition of input features HalfKP of NNUE evaluation function
 
 #ifndef NNUE_FEATURES_HALF_KP_H_INCLUDED
 #define NNUE_FEATURES_HALF_KP_H_INCLUDED
 
-#include "../../evaluate.h"
 #include "features_common.h"
 
+#include "evaluate.h"
+
+//Definition of input features HalfKP of NNUE evaluation function
 namespace Eval::NNUE::Features {
 
-  // Feature HalfKP: Combination of the position of own king
-  // and the position of pieces other than kings
-  template <Side AssociatedKing>
-  class HalfKP {
+    // Feature HalfKP: Combination of the position of own king
+    // and the position of pieces other than kings
+    template <Side AssociatedKing>
+    class HalfKP {
 
-   public:
-    // Feature name
-    static constexpr const char* kName = (AssociatedKing == Side::kFriend) ?
-        "HalfKP(Friend)" : "HalfKP(Enemy)";
-    // Hash value embedded in the evaluation file
-    static constexpr std::uint32_t kHashValue =
-        0x5D69D5B9u ^ (AssociatedKing == Side::kFriend);
-    // Number of feature dimensions
-    static constexpr IndexType kDimensions =
-        static_cast<IndexType>(SQUARE_NB) * static_cast<IndexType>(PS_END);
-    // Maximum number of simultaneously active features
-    static constexpr IndexType kMaxActiveDimensions = 30; // Kings don't count
-    // Trigger for full calculation instead of difference calculation
-    static constexpr TriggerEvent kRefreshTrigger =
-        (AssociatedKing == Side::kFriend) ?
-        TriggerEvent::kFriendKingMoved : TriggerEvent::kEnemyKingMoved;
+    public:
+        // Feature name
+        static constexpr const char* kName = (AssociatedKing == Side::kFriend) ?
+            "HalfKP(Friend)" : "HalfKP(Enemy)";
 
-    // Get a list of indices for active features
-    static void AppendActiveIndices(const Position& pos, Color perspective,
-                                    IndexList* active);
+        // Hash value embedded in the evaluation file
+        static constexpr std::uint32_t kHashValue =
+            0x5D69D5B9u ^ (AssociatedKing == Side::kFriend);
 
-    // Get a list of indices for recently changed features
-    static void AppendChangedIndices(const Position& pos, Color perspective,
-                                     IndexList* removed, IndexList* added);
+        // Number of feature dimensions
+        static constexpr IndexType kDimensions =
+            static_cast<IndexType>(SQUARE_NB) * static_cast<IndexType>(PS_END);
 
-   private:
-    // Index of a feature for a given king position and another piece on some square
-    static IndexType MakeIndex(Color perspective, Square s, Piece pc, Square sq_k);
-  };
+        // Maximum number of simultaneously active features
+        static constexpr IndexType kMaxActiveDimensions = 30; // Kings don't count
+
+        // Trigger for full calculation instead of difference calculation
+        static constexpr TriggerEvent kRefreshTrigger =
+            (AssociatedKing == Side::kFriend) ?
+            TriggerEvent::kFriendKingMoved : TriggerEvent::kEnemyKingMoved;
+
+        // Get a list of indices for active features
+        static void AppendActiveIndices(const Position& pos, Color perspective,
+                                        IndexList* active);
+
+        // Get a list of indices for recently changed features
+        static void AppendChangedIndices(const Position& pos, Color perspective,
+                                         IndexList* removed, IndexList* added);
+
+    private:
+        // Index of a feature for a given king position and another piece on some square
+        static IndexType MakeIndex(Color perspective, Square s, Piece pc, Square sq_k);
+    };
 
 }  // namespace Eval::NNUE::Features
 

--- a/src/nnue/features/half_relative_kp.cpp
+++ b/src/nnue/features/half_relative_kp.cpp
@@ -11,16 +11,21 @@ namespace Eval::NNUE::Features {
 
     // Find the index of the feature quantity from the ball position and PieceSquare
     template <Side AssociatedKing>
-    inline IndexType HalfRelativeKP<AssociatedKing>::MakeIndex(
-        Color perspective, Square s, Piece pc, Square sq_k) {
+    inline IndexType HalfRelativeKP<AssociatedKing>::make_index(
+        Color perspective,
+        Square s,
+        Piece pc,
+        Square sq_k) {
+
         const IndexType p = IndexType(orient(perspective, s) + kpp_board_index[pc][perspective]);
-        return MakeIndex(sq_k, p);
+        return make_index(sq_k, p);
     }
 
     // Find the index of the feature quantity from the ball position and PieceSquare
     template <Side AssociatedKing>
-    inline IndexType HalfRelativeKP<AssociatedKing>::MakeIndex(
-        Square sq_k, IndexType p) {
+    inline IndexType HalfRelativeKP<AssociatedKing>::make_index(
+        Square sq_k,
+        IndexType p) {
 
         constexpr IndexType W = kBoardWidth;
         constexpr IndexType H = kBoardHeight;
@@ -33,8 +38,10 @@ namespace Eval::NNUE::Features {
 
     // Get a list of indices with a value of 1 among the features
     template <Side AssociatedKing>
-    void HalfRelativeKP<AssociatedKing>::AppendActiveIndices(
-        const Position& pos, Color perspective, IndexList* active) {
+    void HalfRelativeKP<AssociatedKing>::append_active_indices(
+        const Position& pos,
+        Color perspective,
+        IndexList* active) {
 
         Square ksq = orient(
             perspective,
@@ -44,15 +51,17 @@ namespace Eval::NNUE::Features {
         Bitboard bb = pos.pieces() & ~pos.pieces(KING);
         while (bb) {
             Square s = pop_lsb(&bb);
-            active->push_back(MakeIndex(perspective, s, pos.piece_on(s), ksq));
+            active->push_back(make_index(perspective, s, pos.piece_on(s), ksq));
         }
     }
 
     // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
     template <Side AssociatedKing>
-    void HalfRelativeKP<AssociatedKing>::AppendChangedIndices(
-        const Position& pos, Color perspective,
-        IndexList* removed, IndexList* added) {
+    void HalfRelativeKP<AssociatedKing>::append_changed_indices(
+        const Position& pos,
+        Color perspective,
+        IndexList* removed,
+        IndexList* added) {
 
         Square ksq = orient(
             perspective,
@@ -67,10 +76,10 @@ namespace Eval::NNUE::Features {
                 continue;
 
             if (dp.from[i] != SQ_NONE)
-                removed->push_back(MakeIndex(perspective, dp.from[i], pc, ksq));
+                removed->push_back(make_index(perspective, dp.from[i], pc, ksq));
 
             if (dp.to[i] != SQ_NONE)
-                added->push_back(MakeIndex(perspective, dp.to[i], pc, ksq));
+                added->push_back(make_index(perspective, dp.to[i], pc, ksq));
         }
     }
 

--- a/src/nnue/features/half_relative_kp.cpp
+++ b/src/nnue/features/half_relative_kp.cpp
@@ -1,74 +1,80 @@
-﻿//Definition of input features HalfRelativeKP of NNUE evaluation function
-
-#include "half_relative_kp.h"
+﻿#include "half_relative_kp.h"
 #include "index_list.h"
 
-namespace Eval {
+//Definition of input features HalfRelativeKP of NNUE evaluation function
+namespace Eval::NNUE::Features {
 
-namespace NNUE {
+    // Orient a square according to perspective (flip rank for black)
+    inline Square orient(Color perspective, Square s) {
+        return Square(int(s) ^ (bool(perspective) * SQ_A8));
+    }
 
-namespace Features {
+    // Find the index of the feature quantity from the ball position and PieceSquare
+    template <Side AssociatedKing>
+    inline IndexType HalfRelativeKP<AssociatedKing>::MakeIndex(
+        Color perspective, Square s, Piece pc, Square sq_k) {
+        const IndexType p = IndexType(orient(perspective, s) + kpp_board_index[pc][perspective]);
+        return MakeIndex(sq_k, p);
+    }
 
-// Orient a square according to perspective (flip rank for black)
-inline Square orient(Color perspective, Square s) {
-  return Square(int(s) ^ (bool(perspective) * SQ_A8));
-}
+    // Find the index of the feature quantity from the ball position and PieceSquare
+    template <Side AssociatedKing>
+    inline IndexType HalfRelativeKP<AssociatedKing>::MakeIndex(
+        Square sq_k, IndexType p) {
 
-// Find the index of the feature quantity from the ball position and PieceSquare
-template <Side AssociatedKing>
-inline IndexType HalfRelativeKP<AssociatedKing>::MakeIndex(
-  Color perspective, Square s, Piece pc, Square sq_k) {
-  const IndexType p = IndexType(orient(perspective, s) + kpp_board_index[pc][perspective]);
-  return MakeIndex(sq_k, p);
-}
+        constexpr IndexType W = kBoardWidth;
+        constexpr IndexType H = kBoardHeight;
+        const IndexType piece_index = (p - PS_W_PAWN) / SQUARE_NB;
+        const Square sq_p = static_cast<Square>((p - PS_W_PAWN) % SQUARE_NB);
+        const IndexType relative_file = file_of(sq_p) - file_of(sq_k) + (W / 2);
+        const IndexType relative_rank = rank_of(sq_p) - rank_of(sq_k) + (H / 2);
+        return H * W * piece_index + H * relative_file + relative_rank;
+    }
 
-// Find the index of the feature quantity from the ball position and PieceSquare
-template <Side AssociatedKing>
-inline IndexType HalfRelativeKP<AssociatedKing>::MakeIndex(
-    Square sq_k, IndexType p) {
-  constexpr IndexType W = kBoardWidth;
-  constexpr IndexType H = kBoardHeight;
-  const IndexType piece_index = (p - PS_W_PAWN) / SQUARE_NB;
-  const Square sq_p = static_cast<Square>((p - PS_W_PAWN) % SQUARE_NB);
-  const IndexType relative_file = file_of(sq_p) - file_of(sq_k) + (W / 2);
-  const IndexType relative_rank = rank_of(sq_p) - rank_of(sq_k) + (H / 2);
-  return H * W * piece_index + H * relative_file + relative_rank;
-}
+    // Get a list of indices with a value of 1 among the features
+    template <Side AssociatedKing>
+    void HalfRelativeKP<AssociatedKing>::AppendActiveIndices(
+        const Position& pos, Color perspective, IndexList* active) {
 
-// Get a list of indices with a value of 1 among the features
-template <Side AssociatedKing>
-void HalfRelativeKP<AssociatedKing>::AppendActiveIndices(
-    const Position& pos, Color perspective, IndexList* active) {
-  Square ksq = orient(perspective, pos.square<KING>(AssociatedKing == Side::kFriend ? perspective : ~perspective));
-  Bitboard bb = pos.pieces() & ~pos.pieces(KING);
-  while (bb) {
-    Square s = pop_lsb(&bb);
-    active->push_back(MakeIndex(perspective, s, pos.piece_on(s), ksq));
-  }
-}
+        Square ksq = orient(
+            perspective,
+            pos.square<KING>(
+                AssociatedKing == Side::kFriend ? perspective : ~perspective));
 
-// Get a list of indices whose values ​​have changed from the previous one in the feature quantity
-template <Side AssociatedKing>
-void HalfRelativeKP<AssociatedKing>::AppendChangedIndices(
-    const Position& pos, Color perspective,
-    IndexList* removed, IndexList* added) {
-  Square ksq = orient(perspective, pos.square<KING>(AssociatedKing == Side::kFriend ? perspective : ~perspective));
-  const auto& dp = pos.state()->dirtyPiece;
-  for (int i = 0; i < dp.dirty_num; ++i) {
-    Piece pc = dp.piece[i];
-    if (type_of(pc) == KING) continue;
-    if (dp.from[i] != SQ_NONE)
-      removed->push_back(MakeIndex(perspective, dp.from[i], pc, ksq));
-    if (dp.to[i] != SQ_NONE)
-      added->push_back(MakeIndex(perspective, dp.to[i], pc, ksq));
-  }
-}
+        Bitboard bb = pos.pieces() & ~pos.pieces(KING);
+        while (bb) {
+            Square s = pop_lsb(&bb);
+            active->push_back(MakeIndex(perspective, s, pos.piece_on(s), ksq));
+        }
+    }
 
-template class HalfRelativeKP<Side::kFriend>;
-template class HalfRelativeKP<Side::kEnemy>;
+    // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
+    template <Side AssociatedKing>
+    void HalfRelativeKP<AssociatedKing>::AppendChangedIndices(
+        const Position& pos, Color perspective,
+        IndexList* removed, IndexList* added) {
 
-}  // namespace Features
+        Square ksq = orient(
+            perspective,
+            pos.square<KING>(
+                AssociatedKing == Side::kFriend ? perspective : ~perspective));
 
-}  // namespace NNUE
+        const auto& dp = pos.state()->dirtyPiece;
+        for (int i = 0; i < dp.dirty_num; ++i) {
+            Piece pc = dp.piece[i];
 
-}  // namespace Eval
+            if (type_of(pc) == KING)
+                continue;
+
+            if (dp.from[i] != SQ_NONE)
+                removed->push_back(MakeIndex(perspective, dp.from[i], pc, ksq));
+
+            if (dp.to[i] != SQ_NONE)
+                added->push_back(MakeIndex(perspective, dp.to[i], pc, ksq));
+        }
+    }
+
+    template class HalfRelativeKP<Side::kFriend>;
+    template class HalfRelativeKP<Side::kEnemy>;
+
+}  // namespace Eval::NNUE::Features

--- a/src/nnue/features/half_relative_kp.h
+++ b/src/nnue/features/half_relative_kp.h
@@ -42,18 +42,23 @@ namespace Eval::NNUE::Features {
             TriggerEvent::kFriendKingMoved : TriggerEvent::kEnemyKingMoved;
 
         // Get a list of indices with a value of 1 among the features
-        static void AppendActiveIndices(const Position& pos, Color perspective,
-                                        IndexList* active);
+        static void append_active_indices(
+            const Position& pos,
+            Color perspective,
+            IndexList* active);
 
         // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
-        static void AppendChangedIndices(const Position& pos, Color perspective,
-                                         IndexList* removed, IndexList* added);
+        static void append_changed_indices(
+            const Position& pos,
+            Color perspective,
+            IndexList* removed,
+            IndexList* added);
 
         // Find the index of the feature quantity from the ball position and PieceSquare
-        static IndexType MakeIndex(Square s, IndexType p);
+        static IndexType make_index(Square s, IndexType p);
 
         // Find the index of the feature quantity from the ball position and PieceSquare
-        static IndexType MakeIndex(Color perspective, Square s, Piece pc, Square sq_k);
+        static IndexType make_index(Color perspective, Square s, Piece pc, Square sq_k);
     };
 
 }  // namespace Eval::NNUE::Features

--- a/src/nnue/features/half_relative_kp.h
+++ b/src/nnue/features/half_relative_kp.h
@@ -1,61 +1,61 @@
-﻿//Definition of input features HalfRelativeKP of NNUE evaluation function
-
-#ifndef _NNUE_FEATURES_HALF_RELATIVE_KP_H_
+﻿#ifndef _NNUE_FEATURES_HALF_RELATIVE_KP_H_
 #define _NNUE_FEATURES_HALF_RELATIVE_KP_H_
 
-#include "../../evaluate.h"
 #include "features_common.h"
 
-namespace Eval {
+#include "evaluate.h"
 
-namespace NNUE {
+//Definition of input features HalfRelativeKP of NNUE evaluation function
+namespace Eval::NNUE::Features {
 
-namespace Features {
+    // Feature HalfRelativeKP: Relative position of each piece other than the ball based on own ball or enemy ball
+    template <Side AssociatedKing>
+    class HalfRelativeKP {
+    public:
+        // feature quantity name
+        static constexpr const char* kName = (AssociatedKing == Side::kFriend) ?
+            "HalfRelativeKP(Friend)" : "HalfRelativeKP(Enemy)";
 
-// Feature HalfRelativeKP: Relative position of each piece other than the ball based on own ball or enemy ball
-template <Side AssociatedKing>
-class HalfRelativeKP {
- public:
-  // feature quantity name
-  static constexpr const char* kName = (AssociatedKing == Side::kFriend) ?
-      "HalfRelativeKP(Friend)" : "HalfRelativeKP(Enemy)";
-  // Hash value embedded in the evaluation function file
-  static constexpr std::uint32_t kHashValue =
-      0xF9180919u ^ (AssociatedKing == Side::kFriend);
-  // Piece type excluding balls
-  static constexpr IndexType kNumPieceKinds = 5 * 2;
-  // width of the virtual board with the ball in the center
-  static constexpr IndexType kBoardWidth = FILE_NB * 2 - 1;
-  // height of a virtual board with balls in the center
-  static constexpr IndexType kBoardHeight = RANK_NB * 2 - 1;
-  // number of feature dimensions
-  static constexpr IndexType kDimensions =
-      kNumPieceKinds * kBoardHeight * kBoardWidth;
-  // The maximum value of the number of indexes whose value is 1 at the same time among the feature values
-  static constexpr IndexType kMaxActiveDimensions = 30; // Kings don't count
-  // Timing of full calculation instead of difference calculation
-  static constexpr TriggerEvent kRefreshTrigger =
-      (AssociatedKing == Side::kFriend) ?
-      TriggerEvent::kFriendKingMoved : TriggerEvent::kEnemyKingMoved;
+        // Hash value embedded in the evaluation function file
+        static constexpr std::uint32_t kHashValue =
+            0xF9180919u ^ (AssociatedKing == Side::kFriend);
 
-  // Get a list of indices with a value of 1 among the features
-  static void AppendActiveIndices(const Position& pos, Color perspective,
-                                  IndexList* active);
+        // Piece type excluding balls
+        static constexpr IndexType kNumPieceKinds = 5 * 2;
 
-  // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
-  static void AppendChangedIndices(const Position& pos, Color perspective,
-                                   IndexList* removed, IndexList* added);
+        // width of the virtual board with the ball in the center
+        static constexpr IndexType kBoardWidth = FILE_NB * 2 - 1;
 
-  // Find the index of the feature quantity from the ball position and PieceSquare
-  static IndexType MakeIndex(Square s, IndexType p);
-  // Find the index of the feature quantity from the ball position and PieceSquare
-  static IndexType MakeIndex(Color perspective, Square s, Piece pc, Square sq_k);
-};
+        // height of a virtual board with balls in the center
+        static constexpr IndexType kBoardHeight = RANK_NB * 2 - 1;
 
-}  // namespace Features
+        // number of feature dimensions
+        static constexpr IndexType kDimensions =
+            kNumPieceKinds * kBoardHeight * kBoardWidth;
 
-}  // namespace NNUE
+        // The maximum value of the number of indexes whose value is 1 at the same time among the feature values
+        static constexpr IndexType kMaxActiveDimensions = 30; // Kings don't count
 
-}  // namespace Eval
+        // Timing of full calculation instead of difference calculation
+        static constexpr TriggerEvent kRefreshTrigger =
+            (AssociatedKing == Side::kFriend) ?
+            TriggerEvent::kFriendKingMoved : TriggerEvent::kEnemyKingMoved;
+
+        // Get a list of indices with a value of 1 among the features
+        static void AppendActiveIndices(const Position& pos, Color perspective,
+                                        IndexList* active);
+
+        // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
+        static void AppendChangedIndices(const Position& pos, Color perspective,
+                                         IndexList* removed, IndexList* added);
+
+        // Find the index of the feature quantity from the ball position and PieceSquare
+        static IndexType MakeIndex(Square s, IndexType p);
+
+        // Find the index of the feature quantity from the ball position and PieceSquare
+        static IndexType MakeIndex(Color perspective, Square s, Piece pc, Square sq_k);
+    };
+
+}  // namespace Eval::NNUE::Features
 
 #endif

--- a/src/nnue/features/index_list.h
+++ b/src/nnue/features/index_list.h
@@ -1,19 +1,19 @@
 /*
-  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
-  Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
+    Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+    Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
 
-  Stockfish is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+    Stockfish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-  Stockfish is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+    Stockfish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 // Definition of index list of input features
@@ -21,43 +21,43 @@
 #ifndef NNUE_FEATURES_INDEX_LIST_H_INCLUDED
 #define NNUE_FEATURES_INDEX_LIST_H_INCLUDED
 
-#include "../../position.h"
-#include "../nnue_architecture.h"
+#include "position.h"
+
+#include "nnue/nnue_architecture.h"
 
 namespace Eval::NNUE::Features {
 
-  // Class template used for feature index list
-  template <typename T, std::size_t MaxSize>
-  class ValueList {
+    // Class template used for feature index list
+    template <typename T, std::size_t MaxSize>
+    class ValueList {
 
-   public:
-    std::size_t size() const { return size_; }
-    void resize(std::size_t size) { size_ = size; }
-    void push_back(const T& value) { values_[size_++] = value; }
-    T& operator[](std::size_t index) { return values_[index]; }
-    T* begin() { return values_; }
-    T* end() { return values_ + size_; }
-    const T& operator[](std::size_t index) const { return values_[index]; }
-    const T* begin() const { return values_; }
-    const T* end() const { return values_ + size_; }
+    public:
+        std::size_t size() const { return size_; }
+        void resize(std::size_t size) { size_ = size; }
+        void push_back(const T& value) { values_[size_++] = value; }
+        T& operator[](std::size_t index) { return values_[index]; }
+        T* begin() { return values_; }
+        T* end() { return values_ + size_; }
+        const T& operator[](std::size_t index) const { return values_[index]; }
+        const T* begin() const { return values_; }
+        const T* end() const { return values_ + size_; }
 
-    void swap(ValueList& other) {
-      const std::size_t max_size = std::max(size_, other.size_);
-      for (std::size_t i = 0; i < max_size; ++i) {
-        std::swap(values_[i], other.values_[i]);
-      }
-      std::swap(size_, other.size_);
-    }
+        void swap(ValueList& other) {
+            const std::size_t max_size = std::max(size_, other.size_);
+            for (std::size_t i = 0; i < max_size; ++i) {
+                std::swap(values_[i], other.values_[i]);
+            }
+            std::swap(size_, other.size_);
+        }
 
-   private:
-    T values_[MaxSize] = {};
-    std::size_t size_ = 0;
-  };
+    private:
+        T values_[MaxSize] = {};
+        std::size_t size_ = 0;
+    };
 
-  //Type of feature index list
-  class IndexList
-      : public ValueList<IndexType, RawFeatures::kMaxActiveDimensions> {
-  };
+    //Type of feature index list
+    class IndexList : public ValueList<IndexType, RawFeatures::kMaxActiveDimensions> {
+    };
 
 }  // namespace Eval::NNUE::Features
 

--- a/src/nnue/features/k.cpp
+++ b/src/nnue/features/k.cpp
@@ -1,46 +1,39 @@
-﻿//Definition of input feature quantity K of NNUE evaluation function
-
-#include "k.h"
+﻿#include "k.h"
 #include "index_list.h"
 
-namespace Eval {
+//Definition of input feature quantity K of NNUE evaluation function
+namespace Eval::NNUE::Features {
 
-namespace NNUE {
+    // Orient a square according to perspective (flip rank for black)
+    inline Square orient(Color perspective, Square s) {
+        return Square(int(s) ^ (bool(perspective) * SQ_A8));
+    }
 
-namespace Features {
+    // Index of a feature for a given king position.
+    IndexType K::MakeIndex(Color perspective, Square s, Color king_color) {
+        return IndexType(orient(perspective, s) + bool(perspective ^ king_color) * 64);
+    }
 
-// Orient a square according to perspective (flip rank for black)
-inline Square orient(Color perspective, Square s) {
-  return Square(int(s) ^ (bool(perspective) * SQ_A8));
-}
+    // Get a list of indices with a value of 1 among the features
+    void K::AppendActiveIndices(
+        const Position& pos, Color perspective, IndexList* active) {
 
-// Index of a feature for a given king position.
-IndexType K::MakeIndex(Color perspective, Square s, Color king_color) {
-  return IndexType(orient(perspective, s) + bool(perspective ^ king_color) * 64);
-}
+        for (auto color : Colors) {
+          active->push_back(MakeIndex(perspective, pos.square<KING>(color), color));
+        }
+    }
 
-// Get a list of indices with a value of 1 among the features
-void K::AppendActiveIndices(
-    const Position& pos, Color perspective, IndexList* active) {
-  for (auto color : Colors) {
-    active->push_back(MakeIndex(perspective, pos.square<KING>(color), color));
-  }
-}
+    // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
+    void K::AppendChangedIndices(
+        const Position& pos, Color perspective,
+        IndexList* removed, IndexList* added) {
 
-// Get a list of indices whose values ​​have changed from the previous one in the feature quantity
-void K::AppendChangedIndices(
-    const Position& pos, Color perspective,
-    IndexList* removed, IndexList* added) {
-  const auto& dp = pos.state()->dirtyPiece;
-  if (type_of(dp.piece[0]) == KING)
-  {
-    removed->push_back(MakeIndex(perspective, dp.from[0], color_of(dp.piece[0])));
-    added->push_back(MakeIndex(perspective, dp.to[0], color_of(dp.piece[0])));
-  }
-}
+        const auto& dp = pos.state()->dirtyPiece;
+        if (type_of(dp.piece[0]) == KING)
+        {
+            removed->push_back(MakeIndex(perspective, dp.from[0], color_of(dp.piece[0])));
+            added->push_back(MakeIndex(perspective, dp.to[0], color_of(dp.piece[0])));
+        }
+    }
 
-}  // namespace Features
-
-}  // namespace NNUE
-
-}  // namespace Eval
+}  // namespace Eval::NNUE::Features

--- a/src/nnue/features/k.cpp
+++ b/src/nnue/features/k.cpp
@@ -10,29 +10,33 @@ namespace Eval::NNUE::Features {
     }
 
     // Index of a feature for a given king position.
-    IndexType K::MakeIndex(Color perspective, Square s, Color king_color) {
+    IndexType K::make_index(Color perspective, Square s, Color king_color) {
         return IndexType(orient(perspective, s) + bool(perspective ^ king_color) * 64);
     }
 
     // Get a list of indices with a value of 1 among the features
-    void K::AppendActiveIndices(
-        const Position& pos, Color perspective, IndexList* active) {
+    void K::append_active_indices(
+        const Position& pos,
+        Color perspective,
+        IndexList* active) {
 
         for (auto color : Colors) {
-          active->push_back(MakeIndex(perspective, pos.square<KING>(color), color));
+          active->push_back(make_index(perspective, pos.square<KING>(color), color));
         }
     }
 
     // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
-    void K::AppendChangedIndices(
-        const Position& pos, Color perspective,
-        IndexList* removed, IndexList* added) {
+    void K::append_changed_indices(
+        const Position& pos,
+        Color perspective,
+        IndexList* removed,
+        IndexList* added) {
 
         const auto& dp = pos.state()->dirtyPiece;
         if (type_of(dp.piece[0]) == KING)
         {
-            removed->push_back(MakeIndex(perspective, dp.from[0], color_of(dp.piece[0])));
-            added->push_back(MakeIndex(perspective, dp.to[0], color_of(dp.piece[0])));
+            removed->push_back(make_index(perspective, dp.from[0], color_of(dp.piece[0])));
+            added->push_back(make_index(perspective, dp.to[0], color_of(dp.piece[0])));
         }
     }
 

--- a/src/nnue/features/k.h
+++ b/src/nnue/features/k.h
@@ -8,36 +8,41 @@
 //Definition of input feature quantity K of NNUE evaluation function
 namespace Eval::NNUE::Features {
 
-  // Feature K: Ball position
-  class K {
-  public:
-      // feature quantity name
-      static constexpr const char* kName = "K";
+    // Feature K: Ball position
+    class K {
+    public:
+        // feature quantity name
+        static constexpr const char* kName = "K";
 
-      // Hash value embedded in the evaluation function file
-      static constexpr std::uint32_t kHashValue = 0xD3CEE169u;
+        // Hash value embedded in the evaluation function file
+        static constexpr std::uint32_t kHashValue = 0xD3CEE169u;
 
-      // number of feature dimensions
-      static constexpr IndexType kDimensions = SQUARE_NB * 2;
+        // number of feature dimensions
+        static constexpr IndexType kDimensions = SQUARE_NB * 2;
 
-      // The maximum value of the number of indexes whose value is 1 at the same time among the feature values
-      static constexpr IndexType kMaxActiveDimensions = 2;
+        // The maximum value of the number of indexes whose value is 1 at the same time among the feature values
+        static constexpr IndexType kMaxActiveDimensions = 2;
 
-      // Timing of full calculation instead of difference calculation
-      static constexpr TriggerEvent kRefreshTrigger = TriggerEvent::kNone;
+        // Timing of full calculation instead of difference calculation
+        static constexpr TriggerEvent kRefreshTrigger = TriggerEvent::kNone;
 
-      // Get a list of indices with a value of 1 among the features
-      static void AppendActiveIndices(const Position& pos, Color perspective,
-                                      IndexList* active);
+        // Get a list of indices with a value of 1 among the features
+        static void append_active_indices(
+            const Position& pos,
+            Color perspective,
+            IndexList* active);
 
-      // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
-      static void AppendChangedIndices(const Position& pos, Color perspective,
-                                       IndexList* removed, IndexList* added);
+        // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
+        static void append_changed_indices(
+            const Position& pos,
+            Color perspective,
+            IndexList* removed,
+            IndexList* added);
 
-  private:
-      // Index of a feature for a given king position.
-      static IndexType MakeIndex(Color perspective, Square s, Color king_color);
-  };
+    private:
+        // Index of a feature for a given king position.
+        static IndexType make_index(Color perspective, Square s, Color king_color);
+    };
 
 }  // namespace Eval::NNUE::Features
 

--- a/src/nnue/features/k.h
+++ b/src/nnue/features/k.h
@@ -1,48 +1,44 @@
-﻿//Definition of input feature quantity K of NNUE evaluation function
-
-#ifndef _NNUE_FEATURES_K_H_
+﻿#ifndef _NNUE_FEATURES_K_H_
 #define _NNUE_FEATURES_K_H_
 
-#include "../../evaluate.h"
 #include "features_common.h"
 
-namespace Eval {
+#include "evaluate.h"
 
-namespace NNUE {
+//Definition of input feature quantity K of NNUE evaluation function
+namespace Eval::NNUE::Features {
 
-namespace Features {
+  // Feature K: Ball position
+  class K {
+  public:
+      // feature quantity name
+      static constexpr const char* kName = "K";
 
-// Feature K: Ball position
-class K {
- public:
-  // feature quantity name
-  static constexpr const char* kName = "K";
-  // Hash value embedded in the evaluation function file
-  static constexpr std::uint32_t kHashValue = 0xD3CEE169u;
-  // number of feature dimensions
-  static constexpr IndexType kDimensions = SQUARE_NB * 2;
-  // The maximum value of the number of indexes whose value is 1 at the same time among the feature values
-  static constexpr IndexType kMaxActiveDimensions = 2;
-  // Timing of full calculation instead of difference calculation
-  static constexpr TriggerEvent kRefreshTrigger = TriggerEvent::kNone;
+      // Hash value embedded in the evaluation function file
+      static constexpr std::uint32_t kHashValue = 0xD3CEE169u;
 
-  // Get a list of indices with a value of 1 among the features
-  static void AppendActiveIndices(const Position& pos, Color perspective,
-                                  IndexList* active);
+      // number of feature dimensions
+      static constexpr IndexType kDimensions = SQUARE_NB * 2;
 
-  // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
-  static void AppendChangedIndices(const Position& pos, Color perspective,
-                                   IndexList* removed, IndexList* added);
+      // The maximum value of the number of indexes whose value is 1 at the same time among the feature values
+      static constexpr IndexType kMaxActiveDimensions = 2;
 
-private:
-  // Index of a feature for a given king position.
-  static IndexType MakeIndex(Color perspective, Square s, Color king_color);
-};
+      // Timing of full calculation instead of difference calculation
+      static constexpr TriggerEvent kRefreshTrigger = TriggerEvent::kNone;
 
-}  // namespace Features
+      // Get a list of indices with a value of 1 among the features
+      static void AppendActiveIndices(const Position& pos, Color perspective,
+                                      IndexList* active);
 
-}  // namespace NNUE
+      // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
+      static void AppendChangedIndices(const Position& pos, Color perspective,
+                                       IndexList* removed, IndexList* added);
 
-}  // namespace Eval
+  private:
+      // Index of a feature for a given king position.
+      static IndexType MakeIndex(Color perspective, Square s, Color king_color);
+  };
+
+}  // namespace Eval::NNUE::Features
 
 #endif

--- a/src/nnue/features/p.cpp
+++ b/src/nnue/features/p.cpp
@@ -10,26 +10,30 @@ namespace Eval::NNUE::Features {
     }
 
     // Find the index of the feature quantity from the king position and PieceSquare
-    inline IndexType P::MakeIndex(
+    inline IndexType P::make_index(
         Color perspective, Square s, Piece pc) {
         return IndexType(orient(perspective, s) + kpp_board_index[pc][perspective]);
     }
 
     // Get a list of indices with a value of 1 among the features
-    void P::AppendActiveIndices(
-        const Position& pos, Color perspective, IndexList* active) {
+    void P::append_active_indices(
+        const Position& pos,
+        Color perspective,
+        IndexList* active) {
 
         Bitboard bb = pos.pieces() & ~pos.pieces(KING);
         while (bb) {
             Square s = pop_lsb(&bb);
-            active->push_back(MakeIndex(perspective, s, pos.piece_on(s)));
+            active->push_back(make_index(perspective, s, pos.piece_on(s)));
         }
     }
 
     // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
-    void P::AppendChangedIndices(
-        const Position& pos, Color perspective,
-        IndexList* removed, IndexList* added) {
+    void P::append_changed_indices(
+        const Position& pos,
+        Color perspective,
+        IndexList* removed,
+        IndexList* added) {
 
         const auto& dp = pos.state()->dirtyPiece;
         for (int i = 0; i < dp.dirty_num; ++i) {
@@ -39,10 +43,10 @@ namespace Eval::NNUE::Features {
               continue;
 
             if (dp.from[i] != SQ_NONE)
-              removed->push_back(MakeIndex(perspective, dp.from[i], pc));
+              removed->push_back(make_index(perspective, dp.from[i], pc));
 
             if (dp.to[i] != SQ_NONE)
-              added->push_back(MakeIndex(perspective, dp.to[i], pc));
+              added->push_back(make_index(perspective, dp.to[i], pc));
         }
     }
 

--- a/src/nnue/features/p.cpp
+++ b/src/nnue/features/p.cpp
@@ -1,52 +1,49 @@
-﻿//Definition of input feature P of NNUE evaluation function
-
-#include "p.h"
+﻿#include "p.h"
 #include "index_list.h"
 
-namespace Eval {
+//Definition of input feature P of NNUE evaluation function
+namespace Eval::NNUE::Features {
 
-namespace NNUE {
+    // Orient a square according to perspective (flip rank for black)
+    inline Square orient(Color perspective, Square s) {
+        return Square(int(s) ^ (bool(perspective) * SQ_A8));
+    }
 
-namespace Features {
+    // Find the index of the feature quantity from the king position and PieceSquare
+    inline IndexType P::MakeIndex(
+        Color perspective, Square s, Piece pc) {
+        return IndexType(orient(perspective, s) + kpp_board_index[pc][perspective]);
+    }
 
-// Orient a square according to perspective (flip rank for black)
-inline Square orient(Color perspective, Square s) {
-  return Square(int(s) ^ (bool(perspective) * SQ_A8));
-}
+    // Get a list of indices with a value of 1 among the features
+    void P::AppendActiveIndices(
+        const Position& pos, Color perspective, IndexList* active) {
 
-// Find the index of the feature quantity from the king position and PieceSquare
-inline IndexType P::MakeIndex(
-  Color perspective, Square s, Piece pc) {
-  return IndexType(orient(perspective, s) + kpp_board_index[pc][perspective]);
-}
+        Bitboard bb = pos.pieces() & ~pos.pieces(KING);
+        while (bb) {
+            Square s = pop_lsb(&bb);
+            active->push_back(MakeIndex(perspective, s, pos.piece_on(s)));
+        }
+    }
 
-// Get a list of indices with a value of 1 among the features
-void P::AppendActiveIndices(
-    const Position& pos, Color perspective, IndexList* active) {
-  Bitboard bb = pos.pieces() & ~pos.pieces(KING);
-  while (bb) {
-    Square s = pop_lsb(&bb);
-    active->push_back(MakeIndex(perspective, s, pos.piece_on(s)));
-  }
-}
+    // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
+    void P::AppendChangedIndices(
+        const Position& pos, Color perspective,
+        IndexList* removed, IndexList* added) {
 
-// Get a list of indices whose values ​​have changed from the previous one in the feature quantity
-void P::AppendChangedIndices(
-    const Position& pos, Color perspective,
-    IndexList* removed, IndexList* added) {
-  const auto& dp = pos.state()->dirtyPiece;
-  for (int i = 0; i < dp.dirty_num; ++i) {
-    Piece pc = dp.piece[i];
-    if (type_of(pc) == KING) continue;
-    if (dp.from[i] != SQ_NONE)
-      removed->push_back(MakeIndex(perspective, dp.from[i], pc));
-    if (dp.to[i] != SQ_NONE)
-      added->push_back(MakeIndex(perspective, dp.to[i], pc));
-  }
-}
+        const auto& dp = pos.state()->dirtyPiece;
+        for (int i = 0; i < dp.dirty_num; ++i) {
+            Piece pc = dp.piece[i];
 
-}  // namespace Features
+            if (type_of(pc) == KING)
+              continue;
 
-}  // namespace NNUE
+            if (dp.from[i] != SQ_NONE)
+              removed->push_back(MakeIndex(perspective, dp.from[i], pc));
 
-}  // namespace Eval
+            if (dp.to[i] != SQ_NONE)
+              added->push_back(MakeIndex(perspective, dp.to[i], pc));
+        }
+    }
+
+}  // namespace Eval::NNUE::Features

--- a/src/nnue/features/p.h
+++ b/src/nnue/features/p.h
@@ -8,36 +8,41 @@
 //Definition of input feature P of NNUE evaluation function
 namespace Eval::NNUE::Features {
 
-  // Feature P: PieceSquare of pieces other than balls
-  class P {
-  public:
-      // feature quantity name
-      static constexpr const char* kName = "P";
+    // Feature P: PieceSquare of pieces other than balls
+    class P {
+    public:
+        // feature quantity name
+        static constexpr const char* kName = "P";
 
-      // Hash value embedded in the evaluation function file
-      static constexpr std::uint32_t kHashValue = 0x764CFB4Bu;
+        // Hash value embedded in the evaluation function file
+        static constexpr std::uint32_t kHashValue = 0x764CFB4Bu;
 
-      // number of feature dimensions
-      static constexpr IndexType kDimensions = PS_END;
+        // number of feature dimensions
+        static constexpr IndexType kDimensions = PS_END;
 
-      // The maximum value of the number of indexes whose value is 1 at the same time among the feature values
-      static constexpr IndexType kMaxActiveDimensions = 30; // Kings don't count
+        // The maximum value of the number of indexes whose value is 1 at the same time among the feature values
+        static constexpr IndexType kMaxActiveDimensions = 30; // Kings don't count
 
-      // Timing of full calculation instead of difference calculation
-      static constexpr TriggerEvent kRefreshTrigger = TriggerEvent::kNone;
+        // Timing of full calculation instead of difference calculation
+        static constexpr TriggerEvent kRefreshTrigger = TriggerEvent::kNone;
 
-      // Get a list of indices with a value of 1 among the features
-      static void AppendActiveIndices(const Position& pos, Color perspective,
-                                      IndexList* active);
+        // Get a list of indices with a value of 1 among the features
+        static void append_active_indices(
+            const Position& pos,
+            Color perspective,
+            IndexList* active);
 
-      // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
-      static void AppendChangedIndices(const Position& pos, Color perspective,
-                                       IndexList* removed, IndexList* added);
+        // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
+        static void append_changed_indices(
+            const Position& pos,
+            Color perspective,
+            IndexList* removed,
+            IndexList* added);
 
-  private:
-      // Index of a feature for a given piece on some square
-      static IndexType MakeIndex(Color perspective, Square s, Piece pc);
-  };
+    private:
+        // Index of a feature for a given piece on some square
+        static IndexType make_index(Color perspective, Square s, Piece pc);
+    };
 
 }  // namespace Eval::NNUE::Features
 

--- a/src/nnue/features/p.h
+++ b/src/nnue/features/p.h
@@ -1,48 +1,44 @@
-﻿//Definition of input feature P of NNUE evaluation function
-
-#ifndef _NNUE_FEATURES_P_H_
+﻿#ifndef _NNUE_FEATURES_P_H_
 #define _NNUE_FEATURES_P_H_
 
-#include "../../evaluate.h"
 #include "features_common.h"
 
-namespace Eval {
+#include "evaluate.h"
 
-namespace NNUE {
+//Definition of input feature P of NNUE evaluation function
+namespace Eval::NNUE::Features {
 
-namespace Features {
+  // Feature P: PieceSquare of pieces other than balls
+  class P {
+  public:
+      // feature quantity name
+      static constexpr const char* kName = "P";
 
-// Feature P: PieceSquare of pieces other than balls
-class P {
- public:
-  // feature quantity name
-  static constexpr const char* kName = "P";
-  // Hash value embedded in the evaluation function file
-  static constexpr std::uint32_t kHashValue = 0x764CFB4Bu;
-  // number of feature dimensions
-  static constexpr IndexType kDimensions = PS_END;
-  // The maximum value of the number of indexes whose value is 1 at the same time among the feature values
-  static constexpr IndexType kMaxActiveDimensions = 30; // Kings don't count
-  // Timing of full calculation instead of difference calculation
-  static constexpr TriggerEvent kRefreshTrigger = TriggerEvent::kNone;
+      // Hash value embedded in the evaluation function file
+      static constexpr std::uint32_t kHashValue = 0x764CFB4Bu;
 
-  // Get a list of indices with a value of 1 among the features
-  static void AppendActiveIndices(const Position& pos, Color perspective,
-                                  IndexList* active);
+      // number of feature dimensions
+      static constexpr IndexType kDimensions = PS_END;
 
-  // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
-  static void AppendChangedIndices(const Position& pos, Color perspective,
-                                   IndexList* removed, IndexList* added);
+      // The maximum value of the number of indexes whose value is 1 at the same time among the feature values
+      static constexpr IndexType kMaxActiveDimensions = 30; // Kings don't count
 
- private:
-  // Index of a feature for a given piece on some square
-  static IndexType MakeIndex(Color perspective, Square s, Piece pc);
-};
+      // Timing of full calculation instead of difference calculation
+      static constexpr TriggerEvent kRefreshTrigger = TriggerEvent::kNone;
 
-}  // namespace Features
+      // Get a list of indices with a value of 1 among the features
+      static void AppendActiveIndices(const Position& pos, Color perspective,
+                                      IndexList* active);
 
-}  // namespace NNUE
+      // Get a list of indices whose values ​​have changed from the previous one in the feature quantity
+      static void AppendChangedIndices(const Position& pos, Color perspective,
+                                       IndexList* removed, IndexList* added);
 
-}  // namespace Eval
+  private:
+      // Index of a feature for a given piece on some square
+      static IndexType MakeIndex(Color perspective, Square s, Piece pc);
+  };
+
+}  // namespace Eval::NNUE::Features
 
 #endif

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -1,19 +1,19 @@
 /*
-  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
-  Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
+    Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+    Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
 
-  Stockfish is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+    Stockfish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-  Stockfish is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+    Stockfish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 // Definition of layer AffineTransform of NNUE evaluation function
@@ -21,267 +21,290 @@
 #ifndef NNUE_LAYERS_AFFINE_TRANSFORM_H_INCLUDED
 #define NNUE_LAYERS_AFFINE_TRANSFORM_H_INCLUDED
 
-#include <iostream>
-#include "../nnue_common.h"
+#include "nnue/nnue_common.h"
+
+#include <string>
+#include <type_traits>
+#include <cstdint>
 
 namespace Eval::NNUE::Layers {
 
-  // Affine transformation layer
-  template <typename PreviousLayer, IndexType OutputDimensions>
-  class AffineTransform {
-   public:
-    // Input/output type
-    using InputType = typename PreviousLayer::OutputType;
-    using OutputType = std::int32_t;
-    static_assert(std::is_same<InputType, std::uint8_t>::value, "");
+    // Affine transformation layer
+    template <typename PreviousLayer, IndexType OutputDimensions>
+    class AffineTransform {
+    public:
+        // Input/output type
+        using InputType = typename PreviousLayer::OutputType;
 
-    // Number of input/output dimensions
-    static constexpr IndexType kInputDimensions =
-        PreviousLayer::kOutputDimensions;
-    static constexpr IndexType kOutputDimensions = OutputDimensions;
-    static constexpr IndexType kPaddedInputDimensions =
-        CeilToMultiple<IndexType>(kInputDimensions, kMaxSimdWidth);
+        using OutputType = std::int32_t;
 
-    // Size of forward propagation buffer used in this layer
-    static constexpr std::size_t kSelfBufferSize =
-        CeilToMultiple(kOutputDimensions * sizeof(OutputType), kCacheLineSize);
+        static_assert(std::is_same<InputType, std::uint8_t>::value, "");
 
-    // Size of the forward propagation buffer used from the input layer to this layer
-    static constexpr std::size_t kBufferSize =
-        PreviousLayer::kBufferSize + kSelfBufferSize;
+        // Number of input/output dimensions
+        static constexpr IndexType kInputDimensions =
+            PreviousLayer::kOutputDimensions;
 
-    // Hash value embedded in the evaluation file
-    static constexpr std::uint32_t GetHashValue() {
-      std::uint32_t hash_value = 0xCC03DAE4u;
-      hash_value += kOutputDimensions;
-      hash_value ^= PreviousLayer::GetHashValue() >> 1;
-      hash_value ^= PreviousLayer::GetHashValue() << 31;
-      return hash_value;
-    }
+        static constexpr IndexType kOutputDimensions = OutputDimensions;
 
-    // A string that represents the structure from the input layer to this layer
-    static std::string GetStructureString() {
-      return "AffineTransform[" +
-        std::to_string(kOutputDimensions) + "<-" +
-        std::to_string(kInputDimensions) + "](" +
-        PreviousLayer::GetStructureString() + ")";
-    }
-    
-   // Read network parameters
-    bool ReadParameters(std::istream& stream) {
-      if (!previous_layer_.ReadParameters(stream)) return false;
-      for (std::size_t i = 0; i < kOutputDimensions; ++i)
-        biases_[i] = read_little_endian<BiasType>(stream);
-      for (std::size_t i = 0; i < kOutputDimensions * kPaddedInputDimensions; ++i)
-        weights_[i] = read_little_endian<WeightType>(stream);
-      return !stream.fail();
-    }
+        static constexpr IndexType kPaddedInputDimensions =
+            CeilToMultiple<IndexType>(kInputDimensions, kMaxSimdWidth);
 
-    // write parameters
-    bool WriteParameters(std::ostream& stream) const {
-      if (!previous_layer_.WriteParameters(stream)) return false;
-      stream.write(reinterpret_cast<const char*>(biases_),
-        kOutputDimensions * sizeof(BiasType));
-      stream.write(reinterpret_cast<const char*>(weights_),
-        kOutputDimensions * kPaddedInputDimensions *
-        sizeof(WeightType));
-      return !stream.fail();
-    }
+        // Size of forward propagation buffer used in this layer
+        static constexpr std::size_t kSelfBufferSize =
+            CeilToMultiple(kOutputDimensions * sizeof(OutputType), kCacheLineSize);
 
-    // Forward propagation
-    const OutputType* Propagate(
-        const TransformedFeatureType* transformed_features, char* buffer) const {
-      const auto input = previous_layer_.Propagate(
-          transformed_features, buffer + kSelfBufferSize);
-      const auto output = reinterpret_cast<OutputType*>(buffer);
+        // Size of the forward propagation buffer used from the input layer to this layer
+        static constexpr std::size_t kBufferSize =
+            PreviousLayer::kBufferSize + kSelfBufferSize;
 
-  #if defined(USE_AVX512)
-      constexpr IndexType kNumChunks = kPaddedInputDimensions / (kSimdWidth * 2);
-      const auto input_vector = reinterpret_cast<const __m512i*>(input);
-  #if !defined(USE_VNNI)
-      const __m512i kOnes = _mm512_set1_epi16(1);
-  #endif
-
-  #elif defined(USE_AVX2)
-      constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
-      const auto input_vector = reinterpret_cast<const __m256i*>(input);
-  #if !defined(USE_VNNI)
-      const __m256i kOnes = _mm256_set1_epi16(1);
-  #endif
-
-  #elif defined(USE_SSE2)
-      constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
-  #ifndef USE_SSSE3
-      const __m128i kZeros = _mm_setzero_si128();
-  #else
-      const __m128i kOnes = _mm_set1_epi16(1);
-  #endif
-      const auto input_vector = reinterpret_cast<const __m128i*>(input);
-
-  #elif defined(USE_MMX)
-      constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
-      const __m64 kZeros = _mm_setzero_si64();
-      const auto input_vector = reinterpret_cast<const __m64*>(input);
-
-  #elif defined(USE_NEON)
-      constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
-      const auto input_vector = reinterpret_cast<const int8x8_t*>(input);
-  #endif
-
-      for (IndexType i = 0; i < kOutputDimensions; ++i) {
-        const IndexType offset = i * kPaddedInputDimensions;
-
-  #if defined(USE_AVX512)
-        __m512i sum = _mm512_setzero_si512();
-        const auto row = reinterpret_cast<const __m512i*>(&weights_[offset]);
-        for (IndexType j = 0; j < kNumChunks; ++j) {
-  #if defined(USE_VNNI)
-            sum = _mm512_dpbusd_epi32(sum, _mm512_loadA_si512(&input_vector[j]), _mm512_load_si512(&row[j]));
-  #else
-            __m512i product = _mm512_maddubs_epi16(_mm512_loadA_si512(&input_vector[j]), _mm512_load_si512(&row[j]));
-            product = _mm512_madd_epi16(product, kOnes);
-            sum = _mm512_add_epi32(sum, product);
-  #endif
+        // Hash value embedded in the evaluation file
+        static constexpr std::uint32_t GetHashValue() {
+            std::uint32_t hash_value = 0xCC03DAE4u;
+            hash_value += kOutputDimensions;
+            hash_value ^= PreviousLayer::GetHashValue() >> 1;
+            hash_value ^= PreviousLayer::GetHashValue() << 31;
+            return hash_value;
         }
 
-        // Note: Changing kMaxSimdWidth from 32 to 64 breaks loading existing networks.
-        // As a result kPaddedInputDimensions may not be an even multiple of 64(512bit)
-        // and we have to do one more 256bit chunk.
-        if (kPaddedInputDimensions != kNumChunks * kSimdWidth * 2)
-        {
-            const auto iv256  = reinterpret_cast<const __m256i*>(&input_vector[kNumChunks]);
-            const auto row256 = reinterpret_cast<const __m256i*>(&row[kNumChunks]);
-  #if defined(USE_VNNI)
-            __m256i product256 = _mm256_dpbusd_epi32(
-                _mm512_castsi512_si256(sum), _mm256_loadA_si256(&iv256[0]), _mm256_load_si256(&row256[0]));
-            sum = _mm512_inserti32x8(sum, product256, 0);
-  #else
-            __m256i product256 = _mm256_maddubs_epi16(_mm256_loadA_si256(&iv256[0]), _mm256_load_si256(&row256[0]));
-            sum = _mm512_add_epi32(sum, _mm512_cvtepi16_epi32(product256));
-  #endif
+        // A string that represents the structure from the input layer to this layer
+        static std::string GetStructureString() {
+            return "AffineTransform[" +
+                std::to_string(kOutputDimensions) + "<-" +
+                std::to_string(kInputDimensions) + "](" +
+                PreviousLayer::GetStructureString() + ")";
         }
-        output[i] = _mm512_reduce_add_epi32(sum) + biases_[i];
 
-  #elif defined(USE_AVX2)
-        __m256i sum = _mm256_setzero_si256();
-        const auto row = reinterpret_cast<const __m256i*>(&weights_[offset]);
-        for (IndexType j = 0; j < kNumChunks; ++j) {
-  #if defined(USE_VNNI)
-          sum = _mm256_dpbusd_epi32(sum, _mm256_loadA_si256(&input_vector[j]), _mm256_load_si256(&row[j]));
-  #else
-          __m256i product = _mm256_maddubs_epi16(_mm256_loadA_si256(&input_vector[j]), _mm256_load_si256(&row[j]));
-          product = _mm256_madd_epi16(product, kOnes);
-          sum = _mm256_add_epi32(sum, product);
-  #endif
+       // Read network parameters
+        bool ReadParameters(std::istream& stream) {
+            if (!previous_layer_.ReadParameters(stream))
+                return false;
+
+            for (std::size_t i = 0; i < kOutputDimensions; ++i)
+                biases_[i] = read_little_endian<BiasType>(stream);
+
+            for (std::size_t i = 0; i < kOutputDimensions * kPaddedInputDimensions; ++i)
+                weights_[i] = read_little_endian<WeightType>(stream);
+
+            return !stream.fail();
         }
-        __m128i sum128 = _mm_add_epi32(_mm256_castsi256_si128(sum), _mm256_extracti128_si256(sum, 1));
-        sum128 = _mm_add_epi32(sum128, _mm_shuffle_epi32(sum128, _MM_PERM_BADC));
-        sum128 = _mm_add_epi32(sum128, _mm_shuffle_epi32(sum128, _MM_PERM_CDAB));
-        output[i] = _mm_cvtsi128_si32(sum128) + biases_[i];
 
-  #elif defined(USE_SSSE3)
-        __m128i sum = _mm_setzero_si128();
-        const auto row = reinterpret_cast<const __m128i*>(&weights_[offset]);
-        for (int j = 0; j < (int)kNumChunks - 1; j += 2) {
-          __m128i product0 = _mm_maddubs_epi16(_mm_load_si128(&input_vector[j]), _mm_load_si128(&row[j]));
-          product0 = _mm_madd_epi16(product0, kOnes);
-          sum = _mm_add_epi32(sum, product0);
-          __m128i product1 = _mm_maddubs_epi16(_mm_load_si128(&input_vector[j+1]), _mm_load_si128(&row[j+1]));
-          product1 = _mm_madd_epi16(product1, kOnes);
-          sum = _mm_add_epi32(sum, product1);
+        // write parameters
+        bool WriteParameters(std::ostream& stream) const {
+            if (!previous_layer_.WriteParameters(stream))
+                return false;
+
+            stream.write(reinterpret_cast<const char*>(biases_),
+                kOutputDimensions * sizeof(BiasType));
+
+            stream.write(reinterpret_cast<const char*>(weights_),
+                kOutputDimensions * kPaddedInputDimensions *
+                sizeof(WeightType));
+
+            return !stream.fail();
         }
-        if (kNumChunks & 0x1) {
-          __m128i product = _mm_maddubs_epi16(_mm_load_si128(&input_vector[kNumChunks-1]), _mm_load_si128(&row[kNumChunks-1]));
-          product = _mm_madd_epi16(product, kOnes);
-          sum = _mm_add_epi32(sum, product);
+
+        // Forward propagation
+        const OutputType* Propagate(
+            const TransformedFeatureType* transformed_features, char* buffer) const {
+
+            const auto input = previous_layer_.Propagate(
+                transformed_features, buffer + kSelfBufferSize);
+            const auto output = reinterpret_cast<OutputType*>(buffer);
+
+#if defined(USE_AVX512)
+            constexpr IndexType kNumChunks = kPaddedInputDimensions / (kSimdWidth * 2);
+            const auto input_vector = reinterpret_cast<const __m512i*>(input);
+#if !defined(USE_VNNI)
+            const __m512i kOnes = _mm512_set1_epi16(1);
+#endif
+
+#elif defined(USE_AVX2)
+            constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
+            const auto input_vector = reinterpret_cast<const __m256i*>(input);
+#if !defined(USE_VNNI)
+            const __m256i kOnes = _mm256_set1_epi16(1);
+#endif
+
+#elif defined(USE_SSE2)
+            constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
+#ifndef USE_SSSE3
+            const __m128i kZeros = _mm_setzero_si128();
+#else
+            const __m128i kOnes = _mm_set1_epi16(1);
+#endif
+            const auto input_vector = reinterpret_cast<const __m128i*>(input);
+
+#elif defined(USE_MMX)
+            constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
+            const __m64 kZeros = _mm_setzero_si64();
+            const auto input_vector = reinterpret_cast<const __m64*>(input);
+
+#elif defined(USE_NEON)
+            constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
+            const auto input_vector = reinterpret_cast<const int8x8_t*>(input);
+#endif
+
+            for (IndexType i = 0; i < kOutputDimensions; ++i) {
+                const IndexType offset = i * kPaddedInputDimensions;
+
+#if defined(USE_AVX512)
+                __m512i sum = _mm512_setzero_si512();
+                const auto row = reinterpret_cast<const __m512i*>(&weights_[offset]);
+                for (IndexType j = 0; j < kNumChunks; ++j) {
+#if defined(USE_VNNI)
+                    sum = _mm512_dpbusd_epi32(sum, _mm512_loadA_si512(&input_vector[j]), _mm512_load_si512(&row[j]));
+#else
+                    __m512i product = _mm512_maddubs_epi16(_mm512_loadA_si512(&input_vector[j]), _mm512_load_si512(&row[j]));
+                    product = _mm512_madd_epi16(product, kOnes);
+                    sum = _mm512_add_epi32(sum, product);
+#endif
+                }
+
+                // Note: Changing kMaxSimdWidth from 32 to 64 breaks loading existing networks.
+                // As a result kPaddedInputDimensions may not be an even multiple of 64(512bit)
+                // and we have to do one more 256bit chunk.
+                if (kPaddedInputDimensions != kNumChunks * kSimdWidth * 2)
+                {
+                    const auto iv256  = reinterpret_cast<const __m256i*>(&input_vector[kNumChunks]);
+                    const auto row256 = reinterpret_cast<const __m256i*>(&row[kNumChunks]);
+#if defined(USE_VNNI)
+                    __m256i product256 = _mm256_dpbusd_epi32(
+                        _mm512_castsi512_si256(sum), _mm256_loadA_si256(&iv256[0]), _mm256_load_si256(&row256[0]));
+                    sum = _mm512_inserti32x8(sum, product256, 0);
+#else
+                    __m256i product256 = _mm256_maddubs_epi16(_mm256_loadA_si256(&iv256[0]), _mm256_load_si256(&row256[0]));
+                    sum = _mm512_add_epi32(sum, _mm512_cvtepi16_epi32(product256));
+#endif
+                }
+
+                output[i] = _mm512_reduce_add_epi32(sum) + biases_[i];
+
+#elif defined(USE_AVX2)
+                __m256i sum = _mm256_setzero_si256();
+                const auto row = reinterpret_cast<const __m256i*>(&weights_[offset]);
+                for (IndexType j = 0; j < kNumChunks; ++j) {
+#if defined(USE_VNNI)
+                    sum = _mm256_dpbusd_epi32(sum, _mm256_loadA_si256(&input_vector[j]), _mm256_load_si256(&row[j]));
+#else
+                    __m256i product = _mm256_maddubs_epi16(_mm256_loadA_si256(&input_vector[j]), _mm256_load_si256(&row[j]));
+                    product = _mm256_madd_epi16(product, kOnes);
+                    sum = _mm256_add_epi32(sum, product);
+#endif
+                }
+
+                __m128i sum128 = _mm_add_epi32(_mm256_castsi256_si128(sum), _mm256_extracti128_si256(sum, 1));
+                sum128 = _mm_add_epi32(sum128, _mm_shuffle_epi32(sum128, _MM_PERM_BADC));
+                sum128 = _mm_add_epi32(sum128, _mm_shuffle_epi32(sum128, _MM_PERM_CDAB));
+                output[i] = _mm_cvtsi128_si32(sum128) + biases_[i];
+
+#elif defined(USE_SSSE3)
+                __m128i sum = _mm_setzero_si128();
+                const auto row = reinterpret_cast<const __m128i*>(&weights_[offset]);
+                for (int j = 0; j < (int)kNumChunks - 1; j += 2) {
+                    __m128i product0 = _mm_maddubs_epi16(_mm_load_si128(&input_vector[j]), _mm_load_si128(&row[j]));
+                    product0 = _mm_madd_epi16(product0, kOnes);
+                    sum = _mm_add_epi32(sum, product0);
+                    __m128i product1 = _mm_maddubs_epi16(_mm_load_si128(&input_vector[j+1]), _mm_load_si128(&row[j+1]));
+                    product1 = _mm_madd_epi16(product1, kOnes);
+                    sum = _mm_add_epi32(sum, product1);
+                }
+
+                if (kNumChunks & 0x1) {
+                    __m128i product = _mm_maddubs_epi16(_mm_load_si128(&input_vector[kNumChunks-1]), _mm_load_si128(&row[kNumChunks-1]));
+                    product = _mm_madd_epi16(product, kOnes);
+                    sum = _mm_add_epi32(sum, product);
+                }
+
+                sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0x4E)); //_MM_PERM_BADC
+                sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0xB1)); //_MM_PERM_CDAB
+                output[i] = _mm_cvtsi128_si32(sum) + biases_[i];
+
+#elif defined(USE_SSE2)
+                __m128i sum_lo = _mm_cvtsi32_si128(biases_[i]);
+                __m128i sum_hi = kZeros;
+                const auto row = reinterpret_cast<const __m128i*>(&weights_[offset]);
+                for (IndexType j = 0; j < kNumChunks; ++j) {
+                    __m128i row_j = _mm_load_si128(&row[j]);
+                    __m128i input_j = _mm_load_si128(&input_vector[j]);
+                    __m128i row_signs = _mm_cmpgt_epi8(kZeros, row_j);
+                    __m128i extended_row_lo = _mm_unpacklo_epi8(row_j, row_signs);
+                    __m128i extended_row_hi = _mm_unpackhi_epi8(row_j, row_signs);
+                    __m128i extended_input_lo = _mm_unpacklo_epi8(input_j, kZeros);
+                    __m128i extended_input_hi = _mm_unpackhi_epi8(input_j, kZeros);
+                    __m128i product_lo = _mm_madd_epi16(extended_row_lo, extended_input_lo);
+                    __m128i product_hi = _mm_madd_epi16(extended_row_hi, extended_input_hi);
+                    sum_lo = _mm_add_epi32(sum_lo, product_lo);
+                    sum_hi = _mm_add_epi32(sum_hi, product_hi);
+                }
+
+                __m128i sum = _mm_add_epi32(sum_lo, sum_hi);
+                __m128i sum_high_64 = _mm_shuffle_epi32(sum, _MM_SHUFFLE(1, 0, 3, 2));
+                sum = _mm_add_epi32(sum, sum_high_64);
+                __m128i sum_second_32 = _mm_shufflelo_epi16(sum, _MM_SHUFFLE(1, 0, 3, 2));
+                sum = _mm_add_epi32(sum, sum_second_32);
+                output[i] = _mm_cvtsi128_si32(sum);
+
+#elif defined(USE_MMX)
+                __m64 sum_lo = _mm_cvtsi32_si64(biases_[i]);
+                __m64 sum_hi = kZeros;
+                const auto row = reinterpret_cast<const __m64*>(&weights_[offset]);
+                for (IndexType j = 0; j < kNumChunks; ++j) {
+                    __m64 row_j = row[j];
+                    __m64 input_j = input_vector[j];
+                    __m64 row_signs = _mm_cmpgt_pi8(kZeros, row_j);
+                    __m64 extended_row_lo = _mm_unpacklo_pi8(row_j, row_signs);
+                    __m64 extended_row_hi = _mm_unpackhi_pi8(row_j, row_signs);
+                    __m64 extended_input_lo = _mm_unpacklo_pi8(input_j, kZeros);
+                    __m64 extended_input_hi = _mm_unpackhi_pi8(input_j, kZeros);
+                    __m64 product_lo = _mm_madd_pi16(extended_row_lo, extended_input_lo);
+                    __m64 product_hi = _mm_madd_pi16(extended_row_hi, extended_input_hi);
+                    sum_lo = _mm_add_pi32(sum_lo, product_lo);
+                    sum_hi = _mm_add_pi32(sum_hi, product_hi);
+                }
+
+                __m64 sum = _mm_add_pi32(sum_lo, sum_hi);
+                sum = _mm_add_pi32(sum, _mm_unpackhi_pi32(sum, sum));
+                output[i] = _mm_cvtsi64_si32(sum);
+
+#elif defined(USE_NEON)
+                int32x4_t sum = {biases_[i]};
+                const auto row = reinterpret_cast<const int8x8_t*>(&weights_[offset]);
+                for (IndexType j = 0; j < kNumChunks; ++j) {
+                    int16x8_t product = vmull_s8(input_vector[j * 2], row[j * 2]);
+                    product = vmlal_s8(product, input_vector[j * 2 + 1], row[j * 2 + 1]);
+                    sum = vpadalq_s16(sum, product);
+                }
+
+                output[i] = sum[0] + sum[1] + sum[2] + sum[3];
+
+#else
+                OutputType sum = biases_[i];
+                for (IndexType j = 0; j < kInputDimensions; ++j) {
+                    sum += weights_[offset + j] * input[j];
+                }
+
+                output[i] = sum;
+#endif
+
+            }
+#if defined(USE_MMX)
+            _mm_empty();
+#endif
+            return output;
         }
-        sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0x4E)); //_MM_PERM_BADC
-        sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0xB1)); //_MM_PERM_CDAB
-        output[i] = _mm_cvtsi128_si32(sum) + biases_[i];
 
-  #elif defined(USE_SSE2)
-        __m128i sum_lo = _mm_cvtsi32_si128(biases_[i]);
-        __m128i sum_hi = kZeros;
-        const auto row = reinterpret_cast<const __m128i*>(&weights_[offset]);
-        for (IndexType j = 0; j < kNumChunks; ++j) {
-          __m128i row_j = _mm_load_si128(&row[j]);
-          __m128i input_j = _mm_load_si128(&input_vector[j]);
-          __m128i row_signs = _mm_cmpgt_epi8(kZeros, row_j);
-          __m128i extended_row_lo = _mm_unpacklo_epi8(row_j, row_signs);
-          __m128i extended_row_hi = _mm_unpackhi_epi8(row_j, row_signs);
-          __m128i extended_input_lo = _mm_unpacklo_epi8(input_j, kZeros);
-          __m128i extended_input_hi = _mm_unpackhi_epi8(input_j, kZeros);
-          __m128i product_lo = _mm_madd_epi16(extended_row_lo, extended_input_lo);
-          __m128i product_hi = _mm_madd_epi16(extended_row_hi, extended_input_hi);
-          sum_lo = _mm_add_epi32(sum_lo, product_lo);
-          sum_hi = _mm_add_epi32(sum_hi, product_hi);
-        }
-        __m128i sum = _mm_add_epi32(sum_lo, sum_hi);
-        __m128i sum_high_64 = _mm_shuffle_epi32(sum, _MM_SHUFFLE(1, 0, 3, 2));
-        sum = _mm_add_epi32(sum, sum_high_64);
-        __m128i sum_second_32 = _mm_shufflelo_epi16(sum, _MM_SHUFFLE(1, 0, 3, 2));
-        sum = _mm_add_epi32(sum, sum_second_32);
-        output[i] = _mm_cvtsi128_si32(sum);
+    private:
+        using BiasType = OutputType;
+        using WeightType = std::int8_t;
 
-  #elif defined(USE_MMX)
-        __m64 sum_lo = _mm_cvtsi32_si64(biases_[i]);
-        __m64 sum_hi = kZeros;
-        const auto row = reinterpret_cast<const __m64*>(&weights_[offset]);
-        for (IndexType j = 0; j < kNumChunks; ++j) {
-          __m64 row_j = row[j];
-          __m64 input_j = input_vector[j];
-          __m64 row_signs = _mm_cmpgt_pi8(kZeros, row_j);
-          __m64 extended_row_lo = _mm_unpacklo_pi8(row_j, row_signs);
-          __m64 extended_row_hi = _mm_unpackhi_pi8(row_j, row_signs);
-          __m64 extended_input_lo = _mm_unpacklo_pi8(input_j, kZeros);
-          __m64 extended_input_hi = _mm_unpackhi_pi8(input_j, kZeros);
-          __m64 product_lo = _mm_madd_pi16(extended_row_lo, extended_input_lo);
-          __m64 product_hi = _mm_madd_pi16(extended_row_hi, extended_input_hi);
-          sum_lo = _mm_add_pi32(sum_lo, product_lo);
-          sum_hi = _mm_add_pi32(sum_hi, product_hi);
-        }
-        __m64 sum = _mm_add_pi32(sum_lo, sum_hi);
-        sum = _mm_add_pi32(sum, _mm_unpackhi_pi32(sum, sum));
-        output[i] = _mm_cvtsi64_si32(sum);
+        // Make the learning class a friend
+        friend class Trainer<AffineTransform>;
 
-  #elif defined(USE_NEON)
-        int32x4_t sum = {biases_[i]};
-        const auto row = reinterpret_cast<const int8x8_t*>(&weights_[offset]);
-        for (IndexType j = 0; j < kNumChunks; ++j) {
-          int16x8_t product = vmull_s8(input_vector[j * 2], row[j * 2]);
-          product = vmlal_s8(product, input_vector[j * 2 + 1], row[j * 2 + 1]);
-          sum = vpadalq_s16(sum, product);
-        }
-        output[i] = sum[0] + sum[1] + sum[2] + sum[3];
+        PreviousLayer previous_layer_;
 
-  #else
-        OutputType sum = biases_[i];
-        for (IndexType j = 0; j < kInputDimensions; ++j) {
-          sum += weights_[offset + j] * input[j];
-        }
-        output[i] = sum;
-  #endif
-
-      }
-  #if defined(USE_MMX)
-      _mm_empty();
-  #endif
-      return output;
-    }
-
-   private:
-    using BiasType = OutputType;
-    using WeightType = std::int8_t;
-
-    // Make the learning class a friend
-    friend class Trainer<AffineTransform>;
-
-    PreviousLayer previous_layer_;
-
-    alignas(kCacheLineSize) BiasType biases_[kOutputDimensions];
-    alignas(kCacheLineSize)
-        WeightType weights_[kOutputDimensions * kPaddedInputDimensions];
-  };
+        alignas(kCacheLineSize) BiasType biases_[kOutputDimensions];
+        alignas(kCacheLineSize) WeightType weights_[kOutputDimensions * kPaddedInputDimensions];
+    };
 
 }  // namespace Eval::NNUE::Layers
 

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -47,36 +47,36 @@ namespace Eval::NNUE::Layers {
         static constexpr IndexType kOutputDimensions = OutputDimensions;
 
         static constexpr IndexType kPaddedInputDimensions =
-            CeilToMultiple<IndexType>(kInputDimensions, kMaxSimdWidth);
+            ceil_to_multiple<IndexType>(kInputDimensions, kMaxSimdWidth);
 
         // Size of forward propagation buffer used in this layer
         static constexpr std::size_t kSelfBufferSize =
-            CeilToMultiple(kOutputDimensions * sizeof(OutputType), kCacheLineSize);
+            ceil_to_multiple(kOutputDimensions * sizeof(OutputType), kCacheLineSize);
 
         // Size of the forward propagation buffer used from the input layer to this layer
         static constexpr std::size_t kBufferSize =
             PreviousLayer::kBufferSize + kSelfBufferSize;
 
         // Hash value embedded in the evaluation file
-        static constexpr std::uint32_t GetHashValue() {
+        static constexpr std::uint32_t get_hash_value() {
             std::uint32_t hash_value = 0xCC03DAE4u;
             hash_value += kOutputDimensions;
-            hash_value ^= PreviousLayer::GetHashValue() >> 1;
-            hash_value ^= PreviousLayer::GetHashValue() << 31;
+            hash_value ^= PreviousLayer::get_hash_value() >> 1;
+            hash_value ^= PreviousLayer::get_hash_value() << 31;
             return hash_value;
         }
 
         // A string that represents the structure from the input layer to this layer
-        static std::string GetStructureString() {
+        static std::string get_structure_string() {
             return "AffineTransform[" +
                 std::to_string(kOutputDimensions) + "<-" +
                 std::to_string(kInputDimensions) + "](" +
-                PreviousLayer::GetStructureString() + ")";
+                PreviousLayer::get_structure_string() + ")";
         }
 
        // Read network parameters
-        bool ReadParameters(std::istream& stream) {
-            if (!previous_layer_.ReadParameters(stream))
+        bool read_parameters(std::istream& stream) {
+            if (!previous_layer_.read_parameters(stream))
                 return false;
 
             for (std::size_t i = 0; i < kOutputDimensions; ++i)
@@ -89,8 +89,8 @@ namespace Eval::NNUE::Layers {
         }
 
         // write parameters
-        bool WriteParameters(std::ostream& stream) const {
-            if (!previous_layer_.WriteParameters(stream))
+        bool write_parameters(std::ostream& stream) const {
+            if (!previous_layer_.write_parameters(stream))
                 return false;
 
             stream.write(reinterpret_cast<const char*>(biases_),
@@ -104,10 +104,10 @@ namespace Eval::NNUE::Layers {
         }
 
         // Forward propagation
-        const OutputType* Propagate(
+        const OutputType* propagate(
             const TransformedFeatureType* transformed_features, char* buffer) const {
 
-            const auto input = previous_layer_.Propagate(
+            const auto input = previous_layer_.propagate(
                 transformed_features, buffer + kSelfBufferSize);
             const auto output = reinterpret_cast<OutputType*>(buffer);
 

--- a/src/nnue/layers/clipped_relu.h
+++ b/src/nnue/layers/clipped_relu.h
@@ -48,41 +48,41 @@ namespace Eval::NNUE::Layers {
 
         // Size of forward propagation buffer used in this layer
         static constexpr std::size_t kSelfBufferSize =
-            CeilToMultiple(kOutputDimensions * sizeof(OutputType), kCacheLineSize);
+            ceil_to_multiple(kOutputDimensions * sizeof(OutputType), kCacheLineSize);
 
         // Size of the forward propagation buffer used from the input layer to this layer
         static constexpr std::size_t kBufferSize =
             PreviousLayer::kBufferSize + kSelfBufferSize;
 
         // Hash value embedded in the evaluation file
-        static constexpr std::uint32_t GetHashValue() {
+        static constexpr std::uint32_t get_hash_value() {
             std::uint32_t hash_value = 0x538D24C7u;
-            hash_value += PreviousLayer::GetHashValue();
+            hash_value += PreviousLayer::get_hash_value();
             return hash_value;
         }
 
         // A string that represents the structure from the input layer to this layer
-        static std::string GetStructureString() {
+        static std::string get_structure_string() {
             return "ClippedReLU[" +
                 std::to_string(kOutputDimensions) + "](" +
-                PreviousLayer::GetStructureString() + ")";
+                PreviousLayer::get_structure_string() + ")";
         }
 
         // Read network parameters
-        bool ReadParameters(std::istream& stream) {
-            return previous_layer_.ReadParameters(stream);
+        bool read_parameters(std::istream& stream) {
+            return previous_layer_.read_parameters(stream);
         }
 
         // write parameters
-        bool WriteParameters(std::ostream& stream) const {
-            return previous_layer_.WriteParameters(stream);
+        bool write_parameters(std::ostream& stream) const {
+            return previous_layer_.write_parameters(stream);
         }
 
         // Forward propagation
-        const OutputType* Propagate(
+        const OutputType* propagate(
             const TransformedFeatureType* transformed_features, char* buffer) const {
 
-            const auto input = previous_layer_.Propagate(
+            const auto input = previous_layer_.propagate(
                 transformed_features, buffer + kSelfBufferSize);
             const auto output = reinterpret_cast<OutputType*>(buffer);
 

--- a/src/nnue/layers/clipped_relu.h
+++ b/src/nnue/layers/clipped_relu.h
@@ -1,19 +1,19 @@
 /*
-  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
-  Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
+    Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+    Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
 
-  Stockfish is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+    Stockfish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-  Stockfish is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+    Stockfish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 // Definition of layer ClippedReLU of NNUE evaluation function
@@ -21,160 +21,169 @@
 #ifndef NNUE_LAYERS_CLIPPED_RELU_H_INCLUDED
 #define NNUE_LAYERS_CLIPPED_RELU_H_INCLUDED
 
-#include "../nnue_common.h"
+#include "nnue/nnue_common.h"
+
+#include <string>
+#include <cstdint>
+#include <type_traits>
 
 namespace Eval::NNUE::Layers {
 
-  // Clipped ReLU
-  template <typename PreviousLayer>
-  class ClippedReLU {
-   public:
-    // Input/output type
-    using InputType = typename PreviousLayer::OutputType;
-    using OutputType = std::uint8_t;
-    static_assert(std::is_same<InputType, std::int32_t>::value, "");
+    // Clipped ReLU
+    template <typename PreviousLayer>
+    class ClippedReLU {
+    public:
+        // Input/output type
+        using InputType = typename PreviousLayer::OutputType;
 
-    // Number of input/output dimensions
-    static constexpr IndexType kInputDimensions =
-        PreviousLayer::kOutputDimensions;
-    static constexpr IndexType kOutputDimensions = kInputDimensions;
+        using OutputType = std::uint8_t;
 
-    // Size of forward propagation buffer used in this layer
-    static constexpr std::size_t kSelfBufferSize =
-        CeilToMultiple(kOutputDimensions * sizeof(OutputType), kCacheLineSize);
+        static_assert(std::is_same<InputType, std::int32_t>::value, "");
 
-    // Size of the forward propagation buffer used from the input layer to this layer
-    static constexpr std::size_t kBufferSize =
-        PreviousLayer::kBufferSize + kSelfBufferSize;
+        // Number of input/output dimensions
+        static constexpr IndexType kInputDimensions =
+            PreviousLayer::kOutputDimensions;
 
-    // Hash value embedded in the evaluation file
-    static constexpr std::uint32_t GetHashValue() {
-      std::uint32_t hash_value = 0x538D24C7u;
-      hash_value += PreviousLayer::GetHashValue();
-      return hash_value;
-    }
+        static constexpr IndexType kOutputDimensions = kInputDimensions;
 
-    // A string that represents the structure from the input layer to this layer
-    static std::string GetStructureString() {
-      return "ClippedReLU[" +
-        std::to_string(kOutputDimensions) + "](" +
-        PreviousLayer::GetStructureString() + ")";
-    }
+        // Size of forward propagation buffer used in this layer
+        static constexpr std::size_t kSelfBufferSize =
+            CeilToMultiple(kOutputDimensions * sizeof(OutputType), kCacheLineSize);
 
-    // Read network parameters
-    bool ReadParameters(std::istream& stream) {
-      return previous_layer_.ReadParameters(stream);
-    }
+        // Size of the forward propagation buffer used from the input layer to this layer
+        static constexpr std::size_t kBufferSize =
+            PreviousLayer::kBufferSize + kSelfBufferSize;
 
-    // write parameters
-    bool WriteParameters(std::ostream& stream) const {
-      return previous_layer_.WriteParameters(stream);
-    }
+        // Hash value embedded in the evaluation file
+        static constexpr std::uint32_t GetHashValue() {
+            std::uint32_t hash_value = 0x538D24C7u;
+            hash_value += PreviousLayer::GetHashValue();
+            return hash_value;
+        }
 
-    // Forward propagation
-    const OutputType* Propagate(
-        const TransformedFeatureType* transformed_features, char* buffer) const {
-      const auto input = previous_layer_.Propagate(
-          transformed_features, buffer + kSelfBufferSize);
-      const auto output = reinterpret_cast<OutputType*>(buffer);
+        // A string that represents the structure from the input layer to this layer
+        static std::string GetStructureString() {
+            return "ClippedReLU[" +
+                std::to_string(kOutputDimensions) + "](" +
+                PreviousLayer::GetStructureString() + ")";
+        }
 
-  #if defined(USE_AVX2)
-      constexpr IndexType kNumChunks = kInputDimensions / kSimdWidth;
-      const __m256i kZero = _mm256_setzero_si256();
-      const __m256i kOffsets = _mm256_set_epi32(7, 3, 6, 2, 5, 1, 4, 0);
-      const auto in = reinterpret_cast<const __m256i*>(input);
-      const auto out = reinterpret_cast<__m256i*>(output);
-      for (IndexType i = 0; i < kNumChunks; ++i) {
-        const __m256i words0 = _mm256_srai_epi16(_mm256_packs_epi32(
-            _mm256_loadA_si256(&in[i * 4 + 0]),
-            _mm256_loadA_si256(&in[i * 4 + 1])), kWeightScaleBits);
-        const __m256i words1 = _mm256_srai_epi16(_mm256_packs_epi32(
-            _mm256_loadA_si256(&in[i * 4 + 2]),
-            _mm256_loadA_si256(&in[i * 4 + 3])), kWeightScaleBits);
-        _mm256_storeA_si256(&out[i], _mm256_permutevar8x32_epi32(_mm256_max_epi8(
-            _mm256_packs_epi16(words0, words1), kZero), kOffsets));
-      }
-      constexpr IndexType kStart = kNumChunks * kSimdWidth;
+        // Read network parameters
+        bool ReadParameters(std::istream& stream) {
+            return previous_layer_.ReadParameters(stream);
+        }
 
-  #elif defined(USE_SSE2)
-      constexpr IndexType kNumChunks = kInputDimensions / kSimdWidth;
+        // write parameters
+        bool WriteParameters(std::ostream& stream) const {
+            return previous_layer_.WriteParameters(stream);
+        }
 
-  #ifdef USE_SSE41
-      const __m128i kZero = _mm_setzero_si128();
-  #else
-      const __m128i k0x80s = _mm_set1_epi8(-128);
-  #endif
+        // Forward propagation
+        const OutputType* Propagate(
+            const TransformedFeatureType* transformed_features, char* buffer) const {
 
-      const auto in = reinterpret_cast<const __m128i*>(input);
-      const auto out = reinterpret_cast<__m128i*>(output);
-      for (IndexType i = 0; i < kNumChunks; ++i) {
-        const __m128i words0 = _mm_srai_epi16(_mm_packs_epi32(
-            _mm_load_si128(&in[i * 4 + 0]),
-            _mm_load_si128(&in[i * 4 + 1])), kWeightScaleBits);
-        const __m128i words1 = _mm_srai_epi16(_mm_packs_epi32(
-            _mm_load_si128(&in[i * 4 + 2]),
-            _mm_load_si128(&in[i * 4 + 3])), kWeightScaleBits);
-        const __m128i packedbytes = _mm_packs_epi16(words0, words1);
-        _mm_store_si128(&out[i],
+            const auto input = previous_layer_.Propagate(
+                transformed_features, buffer + kSelfBufferSize);
+            const auto output = reinterpret_cast<OutputType*>(buffer);
 
-  #ifdef USE_SSE41
-          _mm_max_epi8(packedbytes, kZero)
-  #else
-          _mm_subs_epi8(_mm_adds_epi8(packedbytes, k0x80s), k0x80s)
-  #endif
+#if defined(USE_AVX2)
+            constexpr IndexType kNumChunks = kInputDimensions / kSimdWidth;
+            const __m256i kZero = _mm256_setzero_si256();
+            const __m256i kOffsets = _mm256_set_epi32(7, 3, 6, 2, 5, 1, 4, 0);
+            const auto in = reinterpret_cast<const __m256i*>(input);
+            const auto out = reinterpret_cast<__m256i*>(output);
+            for (IndexType i = 0; i < kNumChunks; ++i) {
+                const __m256i words0 = _mm256_srai_epi16(_mm256_packs_epi32(
+                    _mm256_loadA_si256(&in[i * 4 + 0]),
+                    _mm256_loadA_si256(&in[i * 4 + 1])), kWeightScaleBits);
+                const __m256i words1 = _mm256_srai_epi16(_mm256_packs_epi32(
+                    _mm256_loadA_si256(&in[i * 4 + 2]),
+                    _mm256_loadA_si256(&in[i * 4 + 3])), kWeightScaleBits);
+                _mm256_storeA_si256(&out[i], _mm256_permutevar8x32_epi32(_mm256_max_epi8(
+                    _mm256_packs_epi16(words0, words1), kZero), kOffsets));
+            }
 
-        );
-      }
-      constexpr IndexType kStart = kNumChunks * kSimdWidth;
+            constexpr IndexType kStart = kNumChunks * kSimdWidth;
 
-  #elif defined(USE_MMX)
-      constexpr IndexType kNumChunks = kInputDimensions / kSimdWidth;
-      const __m64 k0x80s = _mm_set1_pi8(-128);
-      const auto in = reinterpret_cast<const __m64*>(input);
-      const auto out = reinterpret_cast<__m64*>(output);
-      for (IndexType i = 0; i < kNumChunks; ++i) {
-        const __m64 words0 = _mm_srai_pi16(
-            _mm_packs_pi32(in[i * 4 + 0], in[i * 4 + 1]),
-            kWeightScaleBits);
-        const __m64 words1 = _mm_srai_pi16(
-            _mm_packs_pi32(in[i * 4 + 2], in[i * 4 + 3]),
-            kWeightScaleBits);
-        const __m64 packedbytes = _mm_packs_pi16(words0, words1);
-        out[i] = _mm_subs_pi8(_mm_adds_pi8(packedbytes, k0x80s), k0x80s);
-      }
-      _mm_empty();
-      constexpr IndexType kStart = kNumChunks * kSimdWidth;
+#elif defined(USE_SSE2)
+            constexpr IndexType kNumChunks = kInputDimensions / kSimdWidth;
 
-  #elif defined(USE_NEON)
-      constexpr IndexType kNumChunks = kInputDimensions / (kSimdWidth / 2);
-      const int8x8_t kZero = {0};
-      const auto in = reinterpret_cast<const int32x4_t*>(input);
-      const auto out = reinterpret_cast<int8x8_t*>(output);
-      for (IndexType i = 0; i < kNumChunks; ++i) {
-        int16x8_t shifted;
-        const auto pack = reinterpret_cast<int16x4_t*>(&shifted);
-        pack[0] = vqshrn_n_s32(in[i * 2 + 0], kWeightScaleBits);
-        pack[1] = vqshrn_n_s32(in[i * 2 + 1], kWeightScaleBits);
-        out[i] = vmax_s8(vqmovn_s16(shifted), kZero);
-      }
-      constexpr IndexType kStart = kNumChunks * (kSimdWidth / 2);
-  #else
-      constexpr IndexType kStart = 0;
-  #endif
+#if defined(USE_SSE41)
+            const __m128i kZero = _mm_setzero_si128();
+#else
+            const __m128i k0x80s = _mm_set1_epi8(-128);
+#endif
 
-      for (IndexType i = kStart; i < kInputDimensions; ++i) {
-        output[i] = static_cast<OutputType>(
-            std::max(0, std::min(127, input[i] >> kWeightScaleBits)));
-      }
-      return output;
-    }
+            const auto in = reinterpret_cast<const __m128i*>(input);
+            const auto out = reinterpret_cast<__m128i*>(output);
+            for (IndexType i = 0; i < kNumChunks; ++i) {
+                const __m128i words0 = _mm_srai_epi16(_mm_packs_epi32(
+                    _mm_load_si128(&in[i * 4 + 0]),
+                    _mm_load_si128(&in[i * 4 + 1])), kWeightScaleBits);
+                const __m128i words1 = _mm_srai_epi16(_mm_packs_epi32(
+                    _mm_load_si128(&in[i * 4 + 2]),
+                    _mm_load_si128(&in[i * 4 + 3])), kWeightScaleBits);
+                const __m128i packedbytes = _mm_packs_epi16(words0, words1);
+                _mm_store_si128(&out[i],
 
-   private:
-     // Make the learning class a friend
-     friend class Trainer<ClippedReLU>;
-     
-    PreviousLayer previous_layer_;
-  };
+#if defined(USE_SSE41)
+                    _mm_max_epi8(packedbytes, kZero)
+            #else
+                    _mm_subs_epi8(_mm_adds_epi8(packedbytes, k0x80s), k0x80s)
+#endif
+
+                );
+            }
+            constexpr IndexType kStart = kNumChunks * kSimdWidth;
+
+#elif defined(USE_MMX)
+            constexpr IndexType kNumChunks = kInputDimensions / kSimdWidth;
+            const __m64 k0x80s = _mm_set1_pi8(-128);
+            const auto in = reinterpret_cast<const __m64*>(input);
+            const auto out = reinterpret_cast<__m64*>(output);
+            for (IndexType i = 0; i < kNumChunks; ++i) {
+                const __m64 words0 = _mm_srai_pi16(
+                    _mm_packs_pi32(in[i * 4 + 0], in[i * 4 + 1]),
+                    kWeightScaleBits);
+                const __m64 words1 = _mm_srai_pi16(
+                    _mm_packs_pi32(in[i * 4 + 2], in[i * 4 + 3]),
+                    kWeightScaleBits);
+                const __m64 packedbytes = _mm_packs_pi16(words0, words1);
+                out[i] = _mm_subs_pi8(_mm_adds_pi8(packedbytes, k0x80s), k0x80s);
+            }
+            _mm_empty();
+            constexpr IndexType kStart = kNumChunks * kSimdWidth;
+
+#elif defined(USE_NEON)
+            constexpr IndexType kNumChunks = kInputDimensions / (kSimdWidth / 2);
+            const int8x8_t kZero = {0};
+            const auto in = reinterpret_cast<const int32x4_t*>(input);
+            const auto out = reinterpret_cast<int8x8_t*>(output);
+            for (IndexType i = 0; i < kNumChunks; ++i) {
+                int16x8_t shifted;
+                const auto pack = reinterpret_cast<int16x4_t*>(&shifted);
+                pack[0] = vqshrn_n_s32(in[i * 2 + 0], kWeightScaleBits);
+                pack[1] = vqshrn_n_s32(in[i * 2 + 1], kWeightScaleBits);
+                out[i] = vmax_s8(vqmovn_s16(shifted), kZero);
+            }
+            constexpr IndexType kStart = kNumChunks * (kSimdWidth / 2);
+#else
+            constexpr IndexType kStart = 0;
+#endif
+
+            for (IndexType i = kStart; i < kInputDimensions; ++i) {
+                output[i] = static_cast<OutputType>(
+                    std::max(0, std::min(127, input[i] >> kWeightScaleBits)));
+            }
+            return output;
+        }
+
+    private:
+        // Make the learning class a friend
+        friend class Trainer<ClippedReLU>;
+
+        PreviousLayer previous_layer_;
+    };
 
 }  // namespace Eval::NNUE::Layers
 

--- a/src/nnue/layers/input_slice.h
+++ b/src/nnue/layers/input_slice.h
@@ -1,19 +1,19 @@
 /*
-  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
-  Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
+    Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+    Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
 
-  Stockfish is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+    Stockfish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-  Stockfish is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+    Stockfish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 // NNUE evaluation function layer InputSlice definition
@@ -21,59 +21,63 @@
 #ifndef NNUE_LAYERS_INPUT_SLICE_H_INCLUDED
 #define NNUE_LAYERS_INPUT_SLICE_H_INCLUDED
 
-#include "../nnue_common.h"
+#include "nnue/nnue_common.h"
+
+#include <string>
+#include <cstdint>
 
 namespace Eval::NNUE::Layers {
 
-// Input layer
-template <IndexType OutputDimensions, IndexType Offset = 0>
-class InputSlice {
- public:
-  // Need to maintain alignment
-  static_assert(Offset % kMaxSimdWidth == 0, "");
+  // Input layer
+  template <IndexType OutputDimensions, IndexType Offset = 0>
+  class InputSlice {
+  public:
+      // Need to maintain alignment
+      static_assert(Offset % kMaxSimdWidth == 0, "");
 
-  // Output type
-  using OutputType = TransformedFeatureType;
+      // Output type
+      using OutputType = TransformedFeatureType;
 
-  // Output dimensionality
-  static constexpr IndexType kOutputDimensions = OutputDimensions;
+      // Output dimensionality
+      static constexpr IndexType kOutputDimensions = OutputDimensions;
 
-  // Size of forward propagation buffer used from the input layer to this layer
-  static constexpr std::size_t kBufferSize = 0;
+      // Size of forward propagation buffer used from the input layer to this layer
+      static constexpr std::size_t kBufferSize = 0;
 
-  // Hash value embedded in the evaluation file
-  static constexpr std::uint32_t GetHashValue() {
-    std::uint32_t hash_value = 0xEC42E90Du;
-    hash_value ^= kOutputDimensions ^ (Offset << 10);
-    return hash_value;
-  }
+      // Hash value embedded in the evaluation file
+      static constexpr std::uint32_t GetHashValue() {
+          std::uint32_t hash_value = 0xEC42E90Du;
+          hash_value ^= kOutputDimensions ^ (Offset << 10);
+          return hash_value;
+      }
 
-  // A string that represents the structure from the input layer to this layer
-  static std::string GetStructureString() {
-    return "InputSlice[" + std::to_string(kOutputDimensions) + "(" +
-      std::to_string(Offset) + ":" +
-      std::to_string(Offset + kOutputDimensions) + ")]";
-  }
+      // A string that represents the structure from the input layer to this layer
+      static std::string GetStructureString() {
+          return "InputSlice[" + std::to_string(kOutputDimensions) + "(" +
+              std::to_string(Offset) + ":" +
+              std::to_string(Offset + kOutputDimensions) + ")]";
+      }
 
-  // Read network parameters
-  bool ReadParameters(std::istream& /*stream*/) {
-    return true;
-  }
+      // Read network parameters
+      bool ReadParameters(std::istream& /*stream*/) {
+          return true;
+      }
 
-  // write parameters
-  bool WriteParameters(std::ostream& /*stream*/) const {
-    return true;
-  }
+      // write parameters
+      bool WriteParameters(std::ostream& /*stream*/) const {
+          return true;
+      }
 
-  // Forward propagation
-  const OutputType* Propagate(
-      const TransformedFeatureType* transformed_features,
-      char* /*buffer*/) const {
-    return transformed_features + Offset;
-  }
+      // Forward propagation
+      const OutputType* Propagate(
+          const TransformedFeatureType* transformed_features,
+          char* /*buffer*/) const {
 
- private:
-};
+          return transformed_features + Offset;
+      }
+
+  private:
+  };
 
 }  // namespace Layers
 

--- a/src/nnue/layers/input_slice.h
+++ b/src/nnue/layers/input_slice.h
@@ -45,31 +45,31 @@ namespace Eval::NNUE::Layers {
       static constexpr std::size_t kBufferSize = 0;
 
       // Hash value embedded in the evaluation file
-      static constexpr std::uint32_t GetHashValue() {
+      static constexpr std::uint32_t get_hash_value() {
           std::uint32_t hash_value = 0xEC42E90Du;
           hash_value ^= kOutputDimensions ^ (Offset << 10);
           return hash_value;
       }
 
       // A string that represents the structure from the input layer to this layer
-      static std::string GetStructureString() {
+      static std::string get_structure_string() {
           return "InputSlice[" + std::to_string(kOutputDimensions) + "(" +
               std::to_string(Offset) + ":" +
               std::to_string(Offset + kOutputDimensions) + ")]";
       }
 
       // Read network parameters
-      bool ReadParameters(std::istream& /*stream*/) {
+      bool read_parameters(std::istream& /*stream*/) {
           return true;
       }
 
       // write parameters
-      bool WriteParameters(std::ostream& /*stream*/) const {
+      bool write_parameters(std::ostream& /*stream*/) const {
           return true;
       }
 
       // Forward propagation
-      const OutputType* Propagate(
+      const OutputType* propagate(
           const TransformedFeatureType* transformed_features,
           char* /*buffer*/) const {
 

--- a/src/nnue/layers/sum.h
+++ b/src/nnue/layers/sum.h
@@ -1,159 +1,166 @@
-﻿// Definition of layer Sum of NNUE evaluation function
-
-#ifndef _NNUE_LAYERS_SUM_H_
+﻿#ifndef _NNUE_LAYERS_SUM_H_
 #define _NNUE_LAYERS_SUM_H_
 
-#include "../nnue_common.h"
+#include "nnue/nnue_common.h"
 
-namespace Eval {
+// Definition of layer Sum of NNUE evaluation function
+namespace Eval::NNUE::Layers {
 
-namespace NNUE {
+    // Layer that sums the output of multiple layers
+    template <typename FirstPreviousLayer, typename... RemainingPreviousLayers>
+    class Sum : public Sum<RemainingPreviousLayers...> {
+    private:
+        using Head = FirstPreviousLayer;
+        using Tail = Sum<RemainingPreviousLayers...>;
 
-namespace Layers {
+     public:
+        // Input/output type
+        using InputType = typename Head::OutputType;
 
-// Layer that sums the output of multiple layers
-template <typename FirstPreviousLayer, typename... RemainingPreviousLayers>
-class Sum : public Sum<RemainingPreviousLayers...> {
- private:
-  using Head = FirstPreviousLayer;
-  using Tail = Sum<RemainingPreviousLayers...>;
+        using OutputType = InputType;
 
- public:
-  // Input/output type
-  using InputType = typename Head::OutputType;
-  using OutputType = InputType;
-  static_assert(std::is_same<InputType, typename Tail::InputType>::value, "");
+        static_assert(std::is_same<InputType, typename Tail::InputType>::value, "");
 
-  // number of input/output dimensions
-  static constexpr IndexType kInputDimensions = Head::kOutputDimensions;
-  static constexpr IndexType kOutputDimensions = kInputDimensions;
-  static_assert(kInputDimensions == Tail::kInputDimensions ,"");
+        // number of input/output dimensions
+        static constexpr IndexType kInputDimensions = Head::kOutputDimensions;
 
-  // Size of forward propagation buffer used in this layer
-  static constexpr std::size_t kSelfBufferSize =
-      CeilToMultiple(kOutputDimensions * sizeof(OutputType), kCacheLineSize);
+        static constexpr IndexType kOutputDimensions = kInputDimensions;
 
-  // Size of the forward propagation buffer used from the input layer to this layer
-  static constexpr std::size_t kBufferSize =
-      std::max(Head::kBufferSize + kSelfBufferSize, Tail::kBufferSize);
+        static_assert(kInputDimensions == Tail::kInputDimensions ,"");
 
-  // Hash value embedded in the evaluation function file
-  static constexpr std::uint32_t GetHashValue() {
-    std::uint32_t hash_value = 0xBCE400B4u;
-    hash_value ^= Head::GetHashValue() >> 1;
-    hash_value ^= Head::GetHashValue() << 31;
-    hash_value ^= Tail::GetHashValue() >> 2;
-    hash_value ^= Tail::GetHashValue() << 30;
-    return hash_value;
-  }
+        // Size of forward propagation buffer used in this layer
+        static constexpr std::size_t kSelfBufferSize =
+            CeilToMultiple(kOutputDimensions * sizeof(OutputType), kCacheLineSize);
 
-  // A string that represents the structure from the input layer to this layer
-  static std::string GetStructureString() {
-    return "Sum[" +
-        std::to_string(kOutputDimensions) + "](" + GetSummandsString() + ")";
-  }
+        // Size of the forward propagation buffer used from the input layer to this layer
+        static constexpr std::size_t kBufferSize =
+            std::max(Head::kBufferSize + kSelfBufferSize, Tail::kBufferSize);
 
-  // read parameters
-  bool ReadParameters(std::istream& stream) {
-    if (!Tail::ReadParameters(stream)) return false;
-    return previous_layer_.ReadParameters(stream);
-  }
+        // Hash value embedded in the evaluation function file
+        static constexpr std::uint32_t GetHashValue() {
+            std::uint32_t hash_value = 0xBCE400B4u;
+            hash_value ^= Head::GetHashValue() >> 1;
+            hash_value ^= Head::GetHashValue() << 31;
+            hash_value ^= Tail::GetHashValue() >> 2;
+            hash_value ^= Tail::GetHashValue() << 30;
+            return hash_value;
+        }
 
-  // write parameters
-  bool WriteParameters(std::ostream& stream) const {
-    if (!Tail::WriteParameters(stream)) return false;
-    return previous_layer_.WriteParameters(stream);
-  }
+        // A string that represents the structure from the input layer to this layer
+        static std::string GetStructureString() {
+            return "Sum[" +
+                std::to_string(kOutputDimensions) + "](" + GetSummandsString() + ")";
+        }
 
-  // forward propagation
-  const OutputType* Propagate(
-      const TransformedFeatureType* transformed_features, char* buffer) const {
-    Tail::Propagate(transformed_features, buffer);
-    const auto head_output = previous_layer_.Propagate(
-        transformed_features, buffer + kSelfBufferSize);
-    const auto output = reinterpret_cast<OutputType*>(buffer);
-    for (IndexType i = 0; i <kOutputDimensions; ++i) {
-      output[i] += head_output[i];
-    }
-    return output;
-  }
+        // read parameters
+        bool ReadParameters(std::istream& stream) {
+            if (!Tail::ReadParameters(stream))
+                return false;
 
- protected:
-  // A string that represents the list of layers to be summed
-  static std::string GetSummandsString() {
-    return Head::GetStructureString() + "," + Tail::GetSummandsString();
-  }
+            return previous_layer_.ReadParameters(stream);
+        }
 
-  // Make the learning class a friend
-  friend class Trainer<Sum>;
+        // write parameters
+        bool WriteParameters(std::ostream& stream) const {
+            if (!Tail::WriteParameters(stream))
+                return false;
 
-  // the layer immediately before this layer
-  FirstPreviousLayer previous_layer_;
-};
+            return previous_layer_.WriteParameters(stream);
+        }
 
-// Layer that sums the output of multiple layers (when there is one template argument)
-template <typename PreviousLayer>
-class Sum<PreviousLayer> {
- public:
-  // Input/output type
-  using InputType = typename PreviousLayer::OutputType;
-  using OutputType = InputType;
+        // forward propagation
+        const OutputType* Propagate(
+            const TransformedFeatureType* transformed_features, char* buffer) const {
 
-  // number of input/output dimensions
-  static constexpr IndexType kInputDimensions =
-      PreviousLayer::kOutputDimensions;
-  static constexpr IndexType kOutputDimensions = kInputDimensions;
+            Tail::Propagate(transformed_features, buffer);
 
-  // Size of the forward propagation buffer used from the input layer to this layer
-  static constexpr std::size_t kBufferSize = PreviousLayer::kBufferSize;
+            const auto head_output = previous_layer_.Propagate(
+                transformed_features, buffer + kSelfBufferSize);
 
-  // Hash value embedded in the evaluation function file
-  static constexpr std::uint32_t GetHashValue() {
-    std::uint32_t hash_value = 0xBCE400B4u;
-    hash_value ^= PreviousLayer::GetHashValue() >> 1;
-    hash_value ^= PreviousLayer::GetHashValue() << 31;
-    return hash_value;
-  }
+            const auto output = reinterpret_cast<OutputType*>(buffer);
 
-  // A string that represents the structure from the input layer to this layer
-  static std::string GetStructureString() {
-    return "Sum[" +
-        std::to_string(kOutputDimensions) + "](" + GetSummandsString() + ")";
-  }
+            for (IndexType i = 0; i <kOutputDimensions; ++i) {
+                output[i] += head_output[i];
+            }
 
-  // read parameters
-  bool ReadParameters(std::istream& stream) {
-    return previous_layer_.ReadParameters(stream);
-  }
+            return output;
+        }
 
-  // write parameters
-  bool WriteParameters(std::ostream& stream) const {
-    return previous_layer_.WriteParameters(stream);
-  }
+    protected:
+        // A string that represents the list of layers to be summed
+        static std::string GetSummandsString() {
+            return Head::GetStructureString() + "," + Tail::GetSummandsString();
+        }
 
-  // forward propagation
-  const OutputType* Propagate(
-      const TransformedFeatureType* transformed_features, char* buffer) const {
-    return previous_layer_.Propagate(transformed_features, buffer);
-  }
+        // Make the learning class a friend
+        friend class Trainer<Sum>;
 
- protected:
-  // A string that represents the list of layers to be summed
-  static std::string GetSummandsString() {
-    return PreviousLayer::GetStructureString();
-  }
+        // the layer immediately before this layer
+        FirstPreviousLayer previous_layer_;
+    };
 
-  // Make the learning class a friend
-  friend class Trainer<Sum>;
+    // Layer that sums the output of multiple layers (when there is one template argument)
+    template <typename PreviousLayer>
+    class Sum<PreviousLayer> {
+    public:
+        // Input/output type
+        using InputType = typename PreviousLayer::OutputType;
 
-  // the layer immediately before this layer
-  PreviousLayer previous_layer_;
-};
+        using OutputType = InputType;
 
-}  // namespace Layers
+        // number of input/output dimensions
+        static constexpr IndexType kInputDimensions =
+            PreviousLayer::kOutputDimensions;
 
-}  // namespace NNUE
+        static constexpr IndexType kOutputDimensions = kInputDimensions;
 
-}  // namespace Eval
+        // Size of the forward propagation buffer used from the input layer to this layer
+        static constexpr std::size_t kBufferSize = PreviousLayer::kBufferSize;
+
+        // Hash value embedded in the evaluation function file
+        static constexpr std::uint32_t GetHashValue() {
+            std::uint32_t hash_value = 0xBCE400B4u;
+            hash_value ^= PreviousLayer::GetHashValue() >> 1;
+            hash_value ^= PreviousLayer::GetHashValue() << 31;
+            return hash_value;
+        }
+
+        // A string that represents the structure from the input layer to this layer
+        static std::string GetStructureString() {
+            return "Sum[" +
+                std::to_string(kOutputDimensions) + "](" + GetSummandsString() + ")";
+        }
+
+        // read parameters
+        bool ReadParameters(std::istream& stream) {
+            return previous_layer_.ReadParameters(stream);
+        }
+
+        // write parameters
+        bool WriteParameters(std::ostream& stream) const {
+            return previous_layer_.WriteParameters(stream);
+        }
+
+        // forward propagation
+        const OutputType* Propagate(
+            const TransformedFeatureType* transformed_features, char* buffer) const {
+
+            return previous_layer_.Propagate(transformed_features, buffer);
+        }
+
+    protected:
+        // A string that represents the list of layers to be summed
+        static std::string GetSummandsString() {
+            return PreviousLayer::GetStructureString();
+        }
+
+        // Make the learning class a friend
+        friend class Trainer<Sum>;
+
+        // the layer immediately before this layer
+        PreviousLayer previous_layer_;
+    };
+
+}  // namespace Eval::NNUE::Layers
 
 #endif

--- a/src/nnue/layers/sum.h
+++ b/src/nnue/layers/sum.h
@@ -30,51 +30,51 @@ namespace Eval::NNUE::Layers {
 
         // Size of forward propagation buffer used in this layer
         static constexpr std::size_t kSelfBufferSize =
-            CeilToMultiple(kOutputDimensions * sizeof(OutputType), kCacheLineSize);
+            ceil_to_multiple(kOutputDimensions * sizeof(OutputType), kCacheLineSize);
 
         // Size of the forward propagation buffer used from the input layer to this layer
         static constexpr std::size_t kBufferSize =
             std::max(Head::kBufferSize + kSelfBufferSize, Tail::kBufferSize);
 
         // Hash value embedded in the evaluation function file
-        static constexpr std::uint32_t GetHashValue() {
+        static constexpr std::uint32_t get_hash_value() {
             std::uint32_t hash_value = 0xBCE400B4u;
-            hash_value ^= Head::GetHashValue() >> 1;
-            hash_value ^= Head::GetHashValue() << 31;
-            hash_value ^= Tail::GetHashValue() >> 2;
-            hash_value ^= Tail::GetHashValue() << 30;
+            hash_value ^= Head::get_hash_value() >> 1;
+            hash_value ^= Head::get_hash_value() << 31;
+            hash_value ^= Tail::get_hash_value() >> 2;
+            hash_value ^= Tail::get_hash_value() << 30;
             return hash_value;
         }
 
         // A string that represents the structure from the input layer to this layer
-        static std::string GetStructureString() {
+        static std::string get_structure_string() {
             return "Sum[" +
-                std::to_string(kOutputDimensions) + "](" + GetSummandsString() + ")";
+                std::to_string(kOutputDimensions) + "](" + get_summands_string() + ")";
         }
 
         // read parameters
-        bool ReadParameters(std::istream& stream) {
-            if (!Tail::ReadParameters(stream))
+        bool read_parameters(std::istream& stream) {
+            if (!Tail::read_parameters(stream))
                 return false;
 
-            return previous_layer_.ReadParameters(stream);
+            return previous_layer_.read_parameters(stream);
         }
 
         // write parameters
-        bool WriteParameters(std::ostream& stream) const {
-            if (!Tail::WriteParameters(stream))
+        bool write_parameters(std::ostream& stream) const {
+            if (!Tail::write_parameters(stream))
                 return false;
 
-            return previous_layer_.WriteParameters(stream);
+            return previous_layer_.write_parameters(stream);
         }
 
         // forward propagation
-        const OutputType* Propagate(
+        const OutputType* propagate(
             const TransformedFeatureType* transformed_features, char* buffer) const {
 
-            Tail::Propagate(transformed_features, buffer);
+            Tail::propagate(transformed_features, buffer);
 
-            const auto head_output = previous_layer_.Propagate(
+            const auto head_output = previous_layer_.propagate(
                 transformed_features, buffer + kSelfBufferSize);
 
             const auto output = reinterpret_cast<OutputType*>(buffer);
@@ -88,8 +88,8 @@ namespace Eval::NNUE::Layers {
 
     protected:
         // A string that represents the list of layers to be summed
-        static std::string GetSummandsString() {
-            return Head::GetStructureString() + "," + Tail::GetSummandsString();
+        static std::string get_summands_string() {
+            return Head::get_structure_string() + "," + Tail::get_summands_string();
         }
 
         // Make the learning class a friend
@@ -118,40 +118,40 @@ namespace Eval::NNUE::Layers {
         static constexpr std::size_t kBufferSize = PreviousLayer::kBufferSize;
 
         // Hash value embedded in the evaluation function file
-        static constexpr std::uint32_t GetHashValue() {
+        static constexpr std::uint32_t get_hash_value() {
             std::uint32_t hash_value = 0xBCE400B4u;
-            hash_value ^= PreviousLayer::GetHashValue() >> 1;
-            hash_value ^= PreviousLayer::GetHashValue() << 31;
+            hash_value ^= PreviousLayer::get_hash_value() >> 1;
+            hash_value ^= PreviousLayer::get_hash_value() << 31;
             return hash_value;
         }
 
         // A string that represents the structure from the input layer to this layer
-        static std::string GetStructureString() {
+        static std::string get_structure_string() {
             return "Sum[" +
-                std::to_string(kOutputDimensions) + "](" + GetSummandsString() + ")";
+                std::to_string(kOutputDimensions) + "](" + get_summands_string() + ")";
         }
 
         // read parameters
-        bool ReadParameters(std::istream& stream) {
-            return previous_layer_.ReadParameters(stream);
+        bool read_parameters(std::istream& stream) {
+            return previous_layer_.read_parameters(stream);
         }
 
         // write parameters
-        bool WriteParameters(std::ostream& stream) const {
-            return previous_layer_.WriteParameters(stream);
+        bool write_parameters(std::ostream& stream) const {
+            return previous_layer_.write_parameters(stream);
         }
 
         // forward propagation
-        const OutputType* Propagate(
+        const OutputType* propagate(
             const TransformedFeatureType* transformed_features, char* buffer) const {
 
-            return previous_layer_.Propagate(transformed_features, buffer);
+            return previous_layer_.propagate(transformed_features, buffer);
         }
 
     protected:
         // A string that represents the list of layers to be summed
-        static std::string GetSummandsString() {
-            return PreviousLayer::GetStructureString();
+        static std::string get_summands_string() {
+            return PreviousLayer::get_structure_string();
         }
 
         // Make the learning class a friend

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -1,36 +1,34 @@
 /*
-  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
-  Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
+    Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+    Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
 
-  Stockfish is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+    Stockfish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-  Stockfish is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+    Stockfish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-
-// Class for difference calculation of NNUE evaluation function
 
 #ifndef NNUE_ACCUMULATOR_H_INCLUDED
 #define NNUE_ACCUMULATOR_H_INCLUDED
 
 #include "nnue_architecture.h"
 
+// Class for difference calculation of NNUE evaluation function
 namespace Eval::NNUE {
 
-  // Class that holds the result of affine transformation of input features
-  struct alignas(kCacheLineSize) Accumulator {
-    std::int16_t
-        accumulation[2][kRefreshTriggers.size()][kTransformedFeatureDimensions];
-    bool computed_accumulation;
-  };
+    // Class that holds the result of affine transformation of input features
+    struct alignas(kCacheLineSize) Accumulator {
+        std::int16_t accumulation[2][kRefreshTriggers.size()][kTransformedFeatureDimensions];
+        bool computed_accumulation;
+    };
 
 }  // namespace Eval::NNUE
 

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -1,22 +1,20 @@
 /*
-  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
-  Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
+    Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+    Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
 
-  Stockfish is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+    Stockfish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-  Stockfish is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+    Stockfish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-
-// Input features and network structure used in NNUE evaluation function
 
 #ifndef NNUE_ARCHITECTURE_H_INCLUDED
 #define NNUE_ARCHITECTURE_H_INCLUDED
@@ -24,14 +22,15 @@
 // Defines the network structure
 #include "architectures/halfkp_256x2-32-32.h"
 
+// Input features and network structure used in NNUE evaluation function
 namespace Eval::NNUE {
 
-  static_assert(kTransformedFeatureDimensions % kMaxSimdWidth == 0, "");
-  static_assert(Network::kOutputDimensions == 1, "");
-  static_assert(std::is_same<Network::OutputType, std::int32_t>::value, "");
+    static_assert(kTransformedFeatureDimensions % kMaxSimdWidth == 0, "");
+    static_assert(Network::kOutputDimensions == 1, "");
+    static_assert(std::is_same<Network::OutputType, std::int32_t>::value, "");
 
-  // Trigger for full calculation instead of difference calculation
-  constexpr auto kRefreshTriggers = RawFeatures::kRefreshTriggers;
+    // Trigger for full calculation instead of difference calculation
+    constexpr auto kRefreshTriggers = RawFeatures::kRefreshTriggers;
 
 }  // namespace Eval::NNUE
 

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -127,7 +127,7 @@ namespace Eval::NNUE {
 
     // Round n up to be a multiple of base
     template <typename IntType>
-    constexpr IntType CeilToMultiple(IntType n, IntType base) {
+    constexpr IntType ceil_to_multiple(IntType n, IntType base) {
         return (n + base - 1) / base * base;
     }
 

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -1,19 +1,19 @@
 /*
-  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
-  Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
+    Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+    Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
 
-  Stockfish is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+    Stockfish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-  Stockfish is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+    Stockfish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 // Constants used in NNUE evaluation function
@@ -21,10 +21,10 @@
 #ifndef NNUE_COMMON_H_INCLUDED
 #define NNUE_COMMON_H_INCLUDED
 
+#include "types.h"
+
 #include <cstring>
 #include <iostream>
-
-#include "../types.h"
 
 #if defined(USE_AVX2)
 #include <immintrin.h>
@@ -70,84 +70,84 @@
 
 namespace Eval::NNUE {
 
-  // Version of the evaluation file
-  constexpr std::uint32_t kVersion = 0x7AF32F17u;
+    // Version of the evaluation file
+    constexpr std::uint32_t kVersion = 0x7AF32F17u;
 
-  // Constant used in evaluation value calculation
-  constexpr int FV_SCALE = 16;
-  constexpr int kWeightScaleBits = 6;
+    // Constant used in evaluation value calculation
+    constexpr int FV_SCALE = 16;
+    constexpr int kWeightScaleBits = 6;
 
-  // Size of cache line (in bytes)
-  constexpr std::size_t kCacheLineSize = 64;
+    // Size of cache line (in bytes)
+    constexpr std::size_t kCacheLineSize = 64;
 
-  // SIMD width (in bytes)
-  #if defined(USE_AVX2)
-  constexpr std::size_t kSimdWidth = 32;
+    // SIMD width (in bytes)
+#if defined(USE_AVX2)
+    constexpr std::size_t kSimdWidth = 32;
 
-  #elif defined(USE_SSE2)
-  constexpr std::size_t kSimdWidth = 16;
+#elif defined(USE_SSE2)
+    constexpr std::size_t kSimdWidth = 16;
 
-  #elif defined(USE_MMX)
-  constexpr std::size_t kSimdWidth = 8;
+#elif defined(USE_MMX)
+    constexpr std::size_t kSimdWidth = 8;
 
-  #elif defined(USE_NEON)
-  constexpr std::size_t kSimdWidth = 16;
-  #endif
+#elif defined(USE_NEON)
+    constexpr std::size_t kSimdWidth = 16;
+#endif
 
-  constexpr std::size_t kMaxSimdWidth = 32;
+    constexpr std::size_t kMaxSimdWidth = 32;
 
-  // unique number for each piece type on each square
-  enum {
-    PS_NONE     =  0,
-    PS_W_PAWN   =  1,
-    PS_B_PAWN   =  1 * SQUARE_NB + 1,
-    PS_W_KNIGHT =  2 * SQUARE_NB + 1,
-    PS_B_KNIGHT =  3 * SQUARE_NB + 1,
-    PS_W_BISHOP =  4 * SQUARE_NB + 1,
-    PS_B_BISHOP =  5 * SQUARE_NB + 1,
-    PS_W_ROOK   =  6 * SQUARE_NB + 1,
-    PS_B_ROOK   =  7 * SQUARE_NB + 1,
-    PS_W_QUEEN  =  8 * SQUARE_NB + 1,
-    PS_B_QUEEN  =  9 * SQUARE_NB + 1,
-    PS_W_KING   = 10 * SQUARE_NB + 1,
-    PS_END      = PS_W_KING, // pieces without kings (pawns included)
-    PS_B_KING   = 11 * SQUARE_NB + 1,
-    PS_END2     = 12 * SQUARE_NB + 1
-  };
+    // unique number for each piece type on each square
+    enum {
+        PS_NONE     =  0,
+        PS_W_PAWN   =  1,
+        PS_B_PAWN   =  1 * SQUARE_NB + 1,
+        PS_W_KNIGHT =  2 * SQUARE_NB + 1,
+        PS_B_KNIGHT =  3 * SQUARE_NB + 1,
+        PS_W_BISHOP =  4 * SQUARE_NB + 1,
+        PS_B_BISHOP =  5 * SQUARE_NB + 1,
+        PS_W_ROOK   =  6 * SQUARE_NB + 1,
+        PS_B_ROOK   =  7 * SQUARE_NB + 1,
+        PS_W_QUEEN  =  8 * SQUARE_NB + 1,
+        PS_B_QUEEN  =  9 * SQUARE_NB + 1,
+        PS_W_KING   = 10 * SQUARE_NB + 1,
+        PS_END      = PS_W_KING, // pieces without kings (pawns included)
+        PS_B_KING   = 11 * SQUARE_NB + 1,
+        PS_END2     = 12 * SQUARE_NB + 1
+    };
 
-  extern const uint32_t kpp_board_index[PIECE_NB][COLOR_NB];
+    extern const uint32_t kpp_board_index[PIECE_NB][COLOR_NB];
 
-  // Type of input feature after conversion
-  using TransformedFeatureType = std::uint8_t;
-  using IndexType = std::uint32_t;
+    // Type of input feature after conversion
+    using TransformedFeatureType = std::uint8_t;
+    using IndexType = std::uint32_t;
 
-  // Forward declaration of learning class template
-  template <typename Layer>
-  class Trainer;
+    // Forward declaration of learning class template
+    template <typename Layer>
+    class Trainer;
 
-  // Round n up to be a multiple of base
-  template <typename IntType>
-  constexpr IntType CeilToMultiple(IntType n, IntType base) {
-      return (n + base - 1) / base * base;
-  }
+    // Round n up to be a multiple of base
+    template <typename IntType>
+    constexpr IntType CeilToMultiple(IntType n, IntType base) {
+        return (n + base - 1) / base * base;
+    }
 
-  // read_little_endian() is our utility to read an integer (signed or unsigned, any size)
-  // from a stream in little-endian order. We swap the byte order after the read if
-  // necessary to return a result with the byte ordering of the compiling machine.
-  template <typename IntType>
-  inline IntType read_little_endian(std::istream& stream) {
+    // read_little_endian() is our utility to read an integer (signed or unsigned, any size)
+    // from a stream in little-endian order. We swap the byte order after the read if
+    // necessary to return a result with the byte ordering of the compiling machine.
+    template <typename IntType>
+    inline IntType read_little_endian(std::istream& stream) {
 
-      IntType result;
-      std::uint8_t u[sizeof(IntType)];
-      typename std::make_unsigned<IntType>::type v = 0;
+        IntType result;
+        std::uint8_t u[sizeof(IntType)];
+        typename std::make_unsigned<IntType>::type v = 0;
 
-      stream.read(reinterpret_cast<char*>(u), sizeof(IntType));
-      for (std::size_t i = 0; i < sizeof(IntType); ++i)
-          v = (v << 8) | u[sizeof(IntType) - i - 1];
+        stream.read(reinterpret_cast<char*>(u), sizeof(IntType));
+        for (std::size_t i = 0; i < sizeof(IntType); ++i)
+            v = (v << 8) | u[sizeof(IntType) - i - 1];
 
-      std::memcpy(&result, &v, sizeof(IntType));
-      return result;
-  }
+        std::memcpy(&result, &v, sizeof(IntType));
+        return result;
+    }
 
 }  // namespace Eval::NNUE
 

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -24,6 +24,8 @@
 #include <cstring>
 #include <iostream>
 
+#include "../types.h"
+
 #if defined(USE_AVX2)
 #include <immintrin.h>
 

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -111,20 +111,20 @@ namespace Eval::NNUE {
             kOutputDimensions * sizeof(OutputType);
 
         // Hash value embedded in the evaluation file
-        static constexpr std::uint32_t GetHashValue() {
+        static constexpr std::uint32_t get_hash_value() {
 
             return RawFeatures::kHashValue ^ kOutputDimensions;
         }
 
         // a string representing the structure
-        static std::string GetStructureString() {
-            return RawFeatures::GetName() + "[" +
+        static std::string get_structure_string() {
+            return RawFeatures::get_name() + "[" +
                 std::to_string(kInputDimensions) + "->" +
                 std::to_string(kHalfDimensions) + "x2]";
         }
 
         // Read network parameters
-        bool ReadParameters(std::istream& stream) {
+        bool read_parameters(std::istream& stream) {
 
             for (std::size_t i = 0; i < kHalfDimensions; ++i)
                 biases_[i] = read_little_endian<BiasType>(stream);
@@ -136,7 +136,7 @@ namespace Eval::NNUE {
         }
 
         // write parameters
-        bool WriteParameters(std::ostream& stream) const {
+        bool write_parameters(std::ostream& stream) const {
             stream.write(reinterpret_cast<const char*>(biases_),
                 kHalfDimensions * sizeof(BiasType));
 
@@ -147,7 +147,7 @@ namespace Eval::NNUE {
         }
 
         // Proceed with the difference calculation if possible
-        bool UpdateAccumulatorIfPossible(const Position& pos) const {
+        bool update_accumulator_if_possible(const Position& pos) const {
 
             const auto now = pos.state();
             if (now->accumulator.computed_accumulation)
@@ -155,7 +155,7 @@ namespace Eval::NNUE {
 
             const auto prev = now->previous;
             if (prev && prev->accumulator.computed_accumulation) {
-                UpdateAccumulator(pos);
+                update_accumulator(pos);
                 return true;
             }
 
@@ -163,10 +163,10 @@ namespace Eval::NNUE {
         }
 
         // Convert input features
-        void Transform(const Position& pos, OutputType* output) const {
+        void transform(const Position& pos, OutputType* output) const {
 
-            if (!UpdateAccumulatorIfPossible(pos))
-              RefreshAccumulator(pos);
+            if (!update_accumulator_if_possible(pos))
+              refresh_accumulator(pos);
 
             const auto& accumulation = pos.state()->accumulator.accumulation;
 
@@ -294,13 +294,13 @@ namespace Eval::NNUE {
 
     private:
         // Calculate cumulative value without using difference calculation
-        void RefreshAccumulator(const Position& pos) const {
+        void refresh_accumulator(const Position& pos) const {
 
             auto& accumulator = pos.state()->accumulator;
             for (IndexType i = 0; i < kRefreshTriggers.size(); ++i) {
                 Features::IndexList active_indices[2];
-                RawFeatures::AppendActiveIndices(pos, kRefreshTriggers[i],
-                                                 active_indices);
+                RawFeatures::append_active_indices(pos, kRefreshTriggers[i],
+                                                   active_indices);
                 for (Color perspective : { WHITE, BLACK }) {
 #ifdef TILING
                     for (unsigned j = 0; j < kHalfDimensions / kTileHeight; ++j) {
@@ -357,15 +357,15 @@ namespace Eval::NNUE {
         }
 
         // Calculate cumulative value using difference calculation
-        void UpdateAccumulator(const Position& pos) const {
+        void update_accumulator(const Position& pos) const {
 
             const auto& prev_accumulator = pos.state()->previous->accumulator;
             auto& accumulator = pos.state()->accumulator;
             for (IndexType i = 0; i < kRefreshTriggers.size(); ++i) {
                 Features::IndexList removed_indices[2], added_indices[2];
                 bool reset[2] = { false, false };
-                RawFeatures::AppendChangedIndices(pos, kRefreshTriggers[i],
-                                                  removed_indices, added_indices, reset);
+                RawFeatures::append_changed_indices(pos, kRefreshTriggers[i],
+                                                    removed_indices, added_indices, reset);
 
 #ifdef TILING
                 for (IndexType j = 0; j < kHalfDimensions / kTileHeight; ++j) {

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -1,19 +1,19 @@
 /*
-  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
-  Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
+    Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+    Copyright (C) 2004-2020 The Stockfish developers (see AUTHORS file)
 
-  Stockfish is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+    Stockfish is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-  Stockfish is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+    Stockfish is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 // A class that converts the input features of the NNUE evaluation function
@@ -23,435 +23,450 @@
 
 #include "nnue_common.h"
 #include "nnue_architecture.h"
+
 #include "features/index_list.h"
 
-#include <cstring> // std::memset()
+#include <cstring>
+#include <string>
 
 namespace Eval::NNUE {
 
-  // If vector instructions are enabled, we update and refresh the
-  // accumulator tile by tile such that each tile fits in the CPU's
-  // vector registers.
-  #define TILING
+    // If vector instructions are enabled, we update and refresh the
+    // accumulator tile by tile such that each tile fits in the CPU's
+    // vector registers.
+#define TILING
 
-  #ifdef USE_AVX512
-  typedef __m512i vec_t;
-  #define vec_load(a) _mm512_loadA_si512(a)
-  #define vec_store(a,b) _mm512_storeA_si512(a,b)
-  #define vec_add_16(a,b) _mm512_add_epi16(a,b)
-  #define vec_sub_16(a,b) _mm512_sub_epi16(a,b)
-  #define vec_zero _mm512_setzero_si512()
-  static constexpr IndexType kNumRegs = 8; // only 8 are needed
+#ifdef USE_AVX512
+    typedef __m512i vec_t;
+#define vec_load(a) _mm512_loadA_si512(a)
+#define vec_store(a,b) _mm512_storeA_si512(a,b)
+#define vec_add_16(a,b) _mm512_add_epi16(a,b)
+#define vec_sub_16(a,b) _mm512_sub_epi16(a,b)
+#define vec_zero _mm512_setzero_si512()
+    static constexpr IndexType kNumRegs = 8; // only 8 are needed
 
-  #elif USE_AVX2
-  typedef __m256i vec_t;
-  #define vec_load(a) _mm256_loadA_si256(a)
-  #define vec_store(a,b) _mm256_storeA_si256(a,b)
-  #define vec_add_16(a,b) _mm256_add_epi16(a,b)
-  #define vec_sub_16(a,b) _mm256_sub_epi16(a,b)
-  #define vec_zero _mm256_setzero_si256()
-  static constexpr IndexType kNumRegs = 16;
+#elif USE_AVX2
+    typedef __m256i vec_t;
+#define vec_load(a) _mm256_loadA_si256(a)
+#define vec_store(a,b) _mm256_storeA_si256(a,b)
+#define vec_add_16(a,b) _mm256_add_epi16(a,b)
+#define vec_sub_16(a,b) _mm256_sub_epi16(a,b)
+#define vec_zero _mm256_setzero_si256()
+    static constexpr IndexType kNumRegs = 16;
 
-  #elif USE_SSE2
-  typedef __m128i vec_t;
-  #define vec_load(a) (*(a))
-  #define vec_store(a,b) *(a)=(b)
-  #define vec_add_16(a,b) _mm_add_epi16(a,b)
-  #define vec_sub_16(a,b) _mm_sub_epi16(a,b)
-  #define vec_zero _mm_setzero_si128()
-  static constexpr IndexType kNumRegs = Is64Bit ? 16 : 8;
+#elif USE_SSE2
+    typedef __m128i vec_t;
+#define vec_load(a) (*(a))
+#define vec_store(a,b) *(a)=(b)
+#define vec_add_16(a,b) _mm_add_epi16(a,b)
+#define vec_sub_16(a,b) _mm_sub_epi16(a,b)
+#define vec_zero _mm_setzero_si128()
+    static constexpr IndexType kNumRegs = Is64Bit ? 16 : 8;
 
-  #elif USE_MMX
-  typedef __m64 vec_t;
-  #define vec_load(a) (*(a))
-  #define vec_store(a,b) *(a)=(b)
-  #define vec_add_16(a,b) _mm_add_pi16(a,b)
-  #define vec_sub_16(a,b) _mm_sub_pi16(a,b)
-  #define vec_zero _mm_setzero_si64()
-  static constexpr IndexType kNumRegs = 8;
+#elif USE_MMX
+    typedef __m64 vec_t;
+#define vec_load(a) (*(a))
+#define vec_store(a,b) *(a)=(b)
+#define vec_add_16(a,b) _mm_add_pi16(a,b)
+#define vec_sub_16(a,b) _mm_sub_pi16(a,b)
+#define vec_zero _mm_setzero_si64()
+    static constexpr IndexType kNumRegs = 8;
 
-  #elif USE_NEON
-  typedef int16x8_t vec_t;
-  #define vec_load(a) (*(a))
-  #define vec_store(a,b) *(a)=(b)
-  #define vec_add_16(a,b) vaddq_s16(a,b)
-  #define vec_sub_16(a,b) vsubq_s16(a,b)
-  #define vec_zero {0}
-  static constexpr IndexType kNumRegs = 16;
+#elif USE_NEON
+    typedef int16x8_t vec_t;
+#define vec_load(a) (*(a))
+#define vec_store(a,b) *(a)=(b)
+#define vec_add_16(a,b) vaddq_s16(a,b)
+#define vec_sub_16(a,b) vsubq_s16(a,b)
+#define vec_zero {0}
+    static constexpr IndexType kNumRegs = 16;
 
-  #else
-  #undef TILING
+#else
+#undef TILING
 
-  #endif
+#endif
 
-  // Input feature converter
-  class FeatureTransformer {
+    // Input feature converter
+    class FeatureTransformer {
 
-   private:
-    // Number of output dimensions for one side
-    static constexpr IndexType kHalfDimensions = kTransformedFeatureDimensions;
+    private:
+        // Number of output dimensions for one side
+        static constexpr IndexType kHalfDimensions = kTransformedFeatureDimensions;
 
-    #ifdef TILING
-    static constexpr IndexType kTileHeight = kNumRegs * sizeof(vec_t) / 2;
-    static_assert(kHalfDimensions % kTileHeight == 0, "kTileHeight must divide kHalfDimensions");
-    #endif
+#ifdef TILING
+        static constexpr IndexType kTileHeight = kNumRegs * sizeof(vec_t) / 2;
+        static_assert(kHalfDimensions % kTileHeight == 0, "kTileHeight must divide kHalfDimensions");
+#endif
 
-   public:
-    // Output type
-    using OutputType = TransformedFeatureType;
+    public:
+        // Output type
+        using OutputType = TransformedFeatureType;
 
-    // Number of input/output dimensions
-    static constexpr IndexType kInputDimensions = RawFeatures::kDimensions;
-    static constexpr IndexType kOutputDimensions = kHalfDimensions * 2;
+        // Number of input/output dimensions
+        static constexpr IndexType kInputDimensions = RawFeatures::kDimensions;
+        static constexpr IndexType kOutputDimensions = kHalfDimensions * 2;
 
-    // Size of forward propagation buffer
-    static constexpr std::size_t kBufferSize =
-        kOutputDimensions * sizeof(OutputType);
+        // Size of forward propagation buffer
+        static constexpr std::size_t kBufferSize =
+            kOutputDimensions * sizeof(OutputType);
 
-    // Hash value embedded in the evaluation file
-    static constexpr std::uint32_t GetHashValue() {
+        // Hash value embedded in the evaluation file
+        static constexpr std::uint32_t GetHashValue() {
 
-      return RawFeatures::kHashValue ^ kOutputDimensions;
-    }
-
-    // a string representing the structure
-    static std::string GetStructureString() {
-      return RawFeatures::GetName() + "[" +
-        std::to_string(kInputDimensions) + "->" +
-        std::to_string(kHalfDimensions) + "x2]";
-    }
-
-    // Read network parameters
-    bool ReadParameters(std::istream& stream) {
-
-      for (std::size_t i = 0; i < kHalfDimensions; ++i)
-        biases_[i] = read_little_endian<BiasType>(stream);
-      for (std::size_t i = 0; i < kHalfDimensions * kInputDimensions; ++i)
-        weights_[i] = read_little_endian<WeightType>(stream);
-      return !stream.fail();
-    }
-
-    // write parameters
-    bool WriteParameters(std::ostream& stream) const {
-      stream.write(reinterpret_cast<const char*>(biases_),
-        kHalfDimensions * sizeof(BiasType));
-      stream.write(reinterpret_cast<const char*>(weights_),
-        kHalfDimensions * kInputDimensions * sizeof(WeightType));
-      return !stream.fail();
-    }
-
-    // Proceed with the difference calculation if possible
-    bool UpdateAccumulatorIfPossible(const Position& pos) const {
-
-      const auto now = pos.state();
-      if (now->accumulator.computed_accumulation)
-        return true;
-
-      const auto prev = now->previous;
-      if (prev && prev->accumulator.computed_accumulation) {
-        UpdateAccumulator(pos);
-        return true;
-      }
-
-      return false;
-    }
-
-    // Convert input features
-    void Transform(const Position& pos, OutputType* output) const {
-
-      if (!UpdateAccumulatorIfPossible(pos))
-        RefreshAccumulator(pos);
-
-      const auto& accumulation = pos.state()->accumulator.accumulation;
-
-  #if defined(USE_AVX2)
-      constexpr IndexType kNumChunks = kHalfDimensions / kSimdWidth;
-      constexpr int kControl = 0b11011000;
-      const __m256i kZero = _mm256_setzero_si256();
-
-  #elif defined(USE_SSE2)
-      constexpr IndexType kNumChunks = kHalfDimensions / kSimdWidth;
-
-  #ifdef USE_SSE41
-      const __m128i kZero = _mm_setzero_si128();
-  #else
-      const __m128i k0x80s = _mm_set1_epi8(-128);
-  #endif
-
-  #elif defined(USE_MMX)
-      constexpr IndexType kNumChunks = kHalfDimensions / kSimdWidth;
-      const __m64 k0x80s = _mm_set1_pi8(-128);
-
-  #elif defined(USE_NEON)
-      constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth / 2);
-      const int8x8_t kZero = {0};
-  #endif
-
-      const Color perspectives[2] = {pos.side_to_move(), ~pos.side_to_move()};
-      for (IndexType p = 0; p < 2; ++p) {
-        const IndexType offset = kHalfDimensions * p;
-
-  #if defined(USE_AVX2)
-        auto out = reinterpret_cast<__m256i*>(&output[offset]);
-        for (IndexType j = 0; j < kNumChunks; ++j) {
-          __m256i sum0 = _mm256_loadA_si256(
-              &reinterpret_cast<const __m256i*>(accumulation[perspectives[p]][0])[j * 2 + 0]);
-          __m256i sum1 = _mm256_loadA_si256(
-            &reinterpret_cast<const __m256i*>(accumulation[perspectives[p]][0])[j * 2 + 1]);
-          for (IndexType i = 1; i < kRefreshTriggers.size(); ++i) {
-            sum0 = _mm256_add_epi16(sum0, reinterpret_cast<const __m256i*>(
-                accumulation[perspectives[p]][i])[j * 2 + 0]);
-            sum1 = _mm256_add_epi16(sum1, reinterpret_cast<const __m256i*>(
-                accumulation[perspectives[p]][i])[j * 2 + 1]);
-          }
-          _mm256_storeA_si256(&out[j], _mm256_permute4x64_epi64(_mm256_max_epi8(
-              _mm256_packs_epi16(sum0, sum1), kZero), kControl));
+            return RawFeatures::kHashValue ^ kOutputDimensions;
         }
 
-  #elif defined(USE_SSE2)
-        auto out = reinterpret_cast<__m128i*>(&output[offset]);
-        for (IndexType j = 0; j < kNumChunks; ++j) {
-          __m128i sum0 = _mm_load_si128(&reinterpret_cast<const __m128i*>(
-              accumulation[perspectives[p]][0])[j * 2 + 0]);
-          __m128i sum1 = _mm_load_si128(&reinterpret_cast<const __m128i*>(
-              accumulation[perspectives[p]][0])[j * 2 + 1]);
-          for (IndexType i = 1; i < kRefreshTriggers.size(); ++i) {
-            sum0 = _mm_add_epi16(sum0, reinterpret_cast<const __m128i*>(
-                accumulation[perspectives[p]][i])[j * 2 + 0]);
-            sum1 = _mm_add_epi16(sum1, reinterpret_cast<const __m128i*>(
-                accumulation[perspectives[p]][i])[j * 2 + 1]);
-          }
-      const __m128i packedbytes = _mm_packs_epi16(sum0, sum1);
-
-          _mm_store_si128(&out[j],
-
-  #ifdef USE_SSE41
-            _mm_max_epi8(packedbytes, kZero)
-  #else
-            _mm_subs_epi8(_mm_adds_epi8(packedbytes, k0x80s), k0x80s)
-  #endif
-
-          );
+        // a string representing the structure
+        static std::string GetStructureString() {
+            return RawFeatures::GetName() + "[" +
+                std::to_string(kInputDimensions) + "->" +
+                std::to_string(kHalfDimensions) + "x2]";
         }
 
-  #elif defined(USE_MMX)
-        auto out = reinterpret_cast<__m64*>(&output[offset]);
-        for (IndexType j = 0; j < kNumChunks; ++j) {
-          __m64 sum0 = *(&reinterpret_cast<const __m64*>(
-              accumulation[perspectives[p]][0])[j * 2 + 0]);
-          __m64 sum1 = *(&reinterpret_cast<const __m64*>(
-              accumulation[perspectives[p]][0])[j * 2 + 1]);
-          for (IndexType i = 1; i < kRefreshTriggers.size(); ++i) {
-            sum0 = _mm_add_pi16(sum0, reinterpret_cast<const __m64*>(
-                accumulation[perspectives[p]][i])[j * 2 + 0]);
-            sum1 = _mm_add_pi16(sum1, reinterpret_cast<const __m64*>(
-                accumulation[perspectives[p]][i])[j * 2 + 1]);
-          }
-          const __m64 packedbytes = _mm_packs_pi16(sum0, sum1);
-          out[j] = _mm_subs_pi8(_mm_adds_pi8(packedbytes, k0x80s), k0x80s);
+        // Read network parameters
+        bool ReadParameters(std::istream& stream) {
+
+            for (std::size_t i = 0; i < kHalfDimensions; ++i)
+                biases_[i] = read_little_endian<BiasType>(stream);
+
+            for (std::size_t i = 0; i < kHalfDimensions * kInputDimensions; ++i)
+                weights_[i] = read_little_endian<WeightType>(stream);
+
+            return !stream.fail();
         }
 
-  #elif defined(USE_NEON)
-        const auto out = reinterpret_cast<int8x8_t*>(&output[offset]);
-        for (IndexType j = 0; j < kNumChunks; ++j) {
-          int16x8_t sum = reinterpret_cast<const int16x8_t*>(
-              accumulation[perspectives[p]][0])[j];
-          for (IndexType i = 1; i < kRefreshTriggers.size(); ++i) {
-            sum = vaddq_s16(sum, reinterpret_cast<const int16x8_t*>(
-                accumulation[perspectives[p]][i])[j]);
-          }
-          out[j] = vmax_s8(vqmovn_s16(sum), kZero);
+        // write parameters
+        bool WriteParameters(std::ostream& stream) const {
+            stream.write(reinterpret_cast<const char*>(biases_),
+                kHalfDimensions * sizeof(BiasType));
+
+            stream.write(reinterpret_cast<const char*>(weights_),
+                kHalfDimensions * kInputDimensions * sizeof(WeightType));
+
+            return !stream.fail();
         }
 
-  #else
-        for (IndexType j = 0; j < kHalfDimensions; ++j) {
-          BiasType sum = accumulation[static_cast<int>(perspectives[p])][0][j];
-          for (IndexType i = 1; i < kRefreshTriggers.size(); ++i) {
-            sum += accumulation[static_cast<int>(perspectives[p])][i][j];
-          }
-          output[offset + j] = static_cast<OutputType>(
-              std::max<int>(0, std::min<int>(127, sum)));
-        }
-  #endif
+        // Proceed with the difference calculation if possible
+        bool UpdateAccumulatorIfPossible(const Position& pos) const {
 
-      }
-  #if defined(USE_MMX)
-      _mm_empty();
-  #endif
-    }
+            const auto now = pos.state();
+            if (now->accumulator.computed_accumulation)
+                return true;
 
-   private:
-    // Calculate cumulative value without using difference calculation
-    void RefreshAccumulator(const Position& pos) const {
-
-      auto& accumulator = pos.state()->accumulator;
-      for (IndexType i = 0; i < kRefreshTriggers.size(); ++i) {
-        Features::IndexList active_indices[2];
-        RawFeatures::AppendActiveIndices(pos, kRefreshTriggers[i],
-                                         active_indices);
-        for (Color perspective : { WHITE, BLACK }) {
-    #ifdef TILING
-          for (unsigned j = 0; j < kHalfDimensions / kTileHeight; ++j) {
-            auto accTile = reinterpret_cast<vec_t*>(
-                &accumulator.accumulation[perspective][i][j * kTileHeight]);
-            vec_t acc[kNumRegs];
-
-            if (i == 0) {
-              auto biasesTile = reinterpret_cast<const vec_t*>(
-                  &biases_[j * kTileHeight]);
-              for (unsigned k = 0; k < kNumRegs; ++k)
-                acc[k] = biasesTile[k];
-            } else {
-              for (unsigned k = 0; k < kNumRegs; ++k)
-                acc[k] = vec_zero;
-            }
-            for (const auto index : active_indices[perspective]) {
-              const IndexType offset = kHalfDimensions * index + j * kTileHeight;
-              auto column = reinterpret_cast<const vec_t*>(&weights_[offset]);
-
-              for (unsigned k = 0; k < kNumRegs; ++k)
-                acc[k] = vec_add_16(acc[k], column[k]);
+            const auto prev = now->previous;
+            if (prev && prev->accumulator.computed_accumulation) {
+                UpdateAccumulator(pos);
+                return true;
             }
 
-            for (unsigned k = 0; k < kNumRegs; k++)
-              vec_store(&accTile[k], acc[k]);
-          }
-    #else
-          if (i == 0) {
-            std::memcpy(accumulator.accumulation[perspective][i], biases_,
-                        kHalfDimensions * sizeof(BiasType));
-          } else {
-            std::memset(accumulator.accumulation[perspective][i], 0,
-                        kHalfDimensions * sizeof(BiasType));
-          }
-
-          for (const auto index : active_indices[perspective]) {
-            const IndexType offset = kHalfDimensions * index;
-
-            for (IndexType j = 0; j < kHalfDimensions; ++j)
-              accumulator.accumulation[perspective][i][j] += weights_[offset + j];
-          }
-    #endif
+            return false;
         }
 
-      }
+        // Convert input features
+        void Transform(const Position& pos, OutputType* output) const {
 
-  #if defined(USE_MMX)
-      _mm_empty();
-  #endif
+            if (!UpdateAccumulatorIfPossible(pos))
+              RefreshAccumulator(pos);
 
-      accumulator.computed_accumulation = true;
-    }
+            const auto& accumulation = pos.state()->accumulator.accumulation;
 
-    // Calculate cumulative value using difference calculation
-    void UpdateAccumulator(const Position& pos) const {
+#if defined(USE_AVX2)
+            constexpr IndexType kNumChunks = kHalfDimensions / kSimdWidth;
+            constexpr int kControl = 0b11011000;
+            const __m256i kZero = _mm256_setzero_si256();
 
-      const auto& prev_accumulator = pos.state()->previous->accumulator;
-      auto& accumulator = pos.state()->accumulator;
-      for (IndexType i = 0; i < kRefreshTriggers.size(); ++i) {
-        Features::IndexList removed_indices[2], added_indices[2];
-        bool reset[2] = { false, false };
-        RawFeatures::AppendChangedIndices(pos, kRefreshTriggers[i],
-                                          removed_indices, added_indices, reset);
+#elif defined(USE_SSE2)
+            constexpr IndexType kNumChunks = kHalfDimensions / kSimdWidth;
 
-    #ifdef TILING
-        for (IndexType j = 0; j < kHalfDimensions / kTileHeight; ++j) {
-          for (Color perspective : { WHITE, BLACK }) {
-            auto accTile = reinterpret_cast<vec_t*>(
-                &accumulator.accumulation[perspective][i][j * kTileHeight]);
-            vec_t acc[kNumRegs];
+#ifdef USE_SSE41
+            const __m128i kZero = _mm_setzero_si128();
+#else
+            const __m128i k0x80s = _mm_set1_epi8(-128);
+#endif
 
-            if (reset[perspective]) {
-              if (i == 0) {
-                auto biasesTile = reinterpret_cast<const vec_t*>(
-                    &biases_[j * kTileHeight]);
-                for (unsigned k = 0; k < kNumRegs; ++k)
-                  acc[k] = biasesTile[k];
-              } else {
-                for (unsigned k = 0; k < kNumRegs; ++k)
-                  acc[k] = vec_zero;
-              }
-            } else {
-              auto prevAccTile = reinterpret_cast<const vec_t*>(
-                  &prev_accumulator.accumulation[perspective][i][j * kTileHeight]);
-              for (IndexType k = 0; k < kNumRegs; ++k)
-                acc[k] = vec_load(&prevAccTile[k]);
+#elif defined(USE_MMX)
+            constexpr IndexType kNumChunks = kHalfDimensions / kSimdWidth;
+            const __m64 k0x80s = _mm_set1_pi8(-128);
 
-              // Difference calculation for the deactivated features
-              for (const auto index : removed_indices[perspective]) {
-                const IndexType offset = kHalfDimensions * index + j * kTileHeight;
-                auto column = reinterpret_cast<const vec_t*>(&weights_[offset]);
+#elif defined(USE_NEON)
+            constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth / 2);
+            const int8x8_t kZero = {0};
+#endif
 
-                for (IndexType k = 0; k < kNumRegs; ++k)
-                  acc[k] = vec_sub_16(acc[k], column[k]);
-              }
+            const Color perspectives[2] = {pos.side_to_move(), ~pos.side_to_move()};
+            for (IndexType p = 0; p < 2; ++p) {
+                const IndexType offset = kHalfDimensions * p;
+
+#if defined(USE_AVX2)
+                auto out = reinterpret_cast<__m256i*>(&output[offset]);
+                for (IndexType j = 0; j < kNumChunks; ++j) {
+                    __m256i sum0 = _mm256_loadA_si256(
+                        &reinterpret_cast<const __m256i*>(accumulation[perspectives[p]][0])[j * 2 + 0]);
+                    __m256i sum1 = _mm256_loadA_si256(
+                      &reinterpret_cast<const __m256i*>(accumulation[perspectives[p]][0])[j * 2 + 1]);
+                    for (IndexType i = 1; i < kRefreshTriggers.size(); ++i) {
+                        sum0 = _mm256_add_epi16(sum0, reinterpret_cast<const __m256i*>(
+                            accumulation[perspectives[p]][i])[j * 2 + 0]);
+                        sum1 = _mm256_add_epi16(sum1, reinterpret_cast<const __m256i*>(
+                            accumulation[perspectives[p]][i])[j * 2 + 1]);
+                    }
+
+                    _mm256_storeA_si256(&out[j], _mm256_permute4x64_epi64(_mm256_max_epi8(
+                        _mm256_packs_epi16(sum0, sum1), kZero), kControl));
+                }
+
+#elif defined(USE_SSE2)
+                auto out = reinterpret_cast<__m128i*>(&output[offset]);
+                for (IndexType j = 0; j < kNumChunks; ++j) {
+                    __m128i sum0 = _mm_load_si128(&reinterpret_cast<const __m128i*>(
+                        accumulation[perspectives[p]][0])[j * 2 + 0]);
+                    __m128i sum1 = _mm_load_si128(&reinterpret_cast<const __m128i*>(
+                        accumulation[perspectives[p]][0])[j * 2 + 1]);
+                    for (IndexType i = 1; i < kRefreshTriggers.size(); ++i) {
+                        sum0 = _mm_add_epi16(sum0, reinterpret_cast<const __m128i*>(
+                            accumulation[perspectives[p]][i])[j * 2 + 0]);
+                        sum1 = _mm_add_epi16(sum1, reinterpret_cast<const __m128i*>(
+                            accumulation[perspectives[p]][i])[j * 2 + 1]);
+                    }
+
+                    const __m128i packedbytes = _mm_packs_epi16(sum0, sum1);
+
+                    _mm_store_si128(&out[j],
+
+#ifdef USE_SSE41
+                        _mm_max_epi8(packedbytes, kZero)
+#else
+                        _mm_subs_epi8(_mm_adds_epi8(packedbytes, k0x80s), k0x80s)
+#endif
+
+                    );
+                }
+
+#elif defined(USE_MMX)
+                auto out = reinterpret_cast<__m64*>(&output[offset]);
+                for (IndexType j = 0; j < kNumChunks; ++j) {
+                    __m64 sum0 = *(&reinterpret_cast<const __m64*>(
+                        accumulation[perspectives[p]][0])[j * 2 + 0]);
+                    __m64 sum1 = *(&reinterpret_cast<const __m64*>(
+                        accumulation[perspectives[p]][0])[j * 2 + 1]);
+                    for (IndexType i = 1; i < kRefreshTriggers.size(); ++i) {
+                        sum0 = _mm_add_pi16(sum0, reinterpret_cast<const __m64*>(
+                            accumulation[perspectives[p]][i])[j * 2 + 0]);
+                        sum1 = _mm_add_pi16(sum1, reinterpret_cast<const __m64*>(
+                            accumulation[perspectives[p]][i])[j * 2 + 1]);
+                    }
+
+                    const __m64 packedbytes = _mm_packs_pi16(sum0, sum1);
+                    out[j] = _mm_subs_pi8(_mm_adds_pi8(packedbytes, k0x80s), k0x80s);
+                }
+
+#elif defined(USE_NEON)
+                const auto out = reinterpret_cast<int8x8_t*>(&output[offset]);
+                for (IndexType j = 0; j < kNumChunks; ++j) {
+                    int16x8_t sum = reinterpret_cast<const int16x8_t*>(
+                        accumulation[perspectives[p]][0])[j];
+
+                    for (IndexType i = 1; i < kRefreshTriggers.size(); ++i) {
+                        sum = vaddq_s16(sum, reinterpret_cast<const int16x8_t*>(
+                            accumulation[perspectives[p]][i])[j]);
+                    }
+
+                    out[j] = vmax_s8(vqmovn_s16(sum), kZero);
+                }
+
+#else
+                for (IndexType j = 0; j < kHalfDimensions; ++j) {
+                    BiasType sum = accumulation[static_cast<int>(perspectives[p])][0][j];
+                    for (IndexType i = 1; i < kRefreshTriggers.size(); ++i) {
+                        sum += accumulation[static_cast<int>(perspectives[p])][i][j];
+                    }
+
+                    output[offset + j] = static_cast<OutputType>(
+                        std::max<int>(0, std::min<int>(127, sum)));
+                }
+#endif
+
             }
-            { // Difference calculation for the activated features
-              for (const auto index : added_indices[perspective]) {
-                const IndexType offset = kHalfDimensions * index + j * kTileHeight;
-                auto column = reinterpret_cast<const vec_t*>(&weights_[offset]);
-
-                for (IndexType k = 0; k < kNumRegs; ++k)
-                  acc[k] = vec_add_16(acc[k], column[k]);
-              }
-            }
-
-            for (IndexType k = 0; k < kNumRegs; ++k)
-              vec_store(&accTile[k], acc[k]);
-          }
+#if defined(USE_MMX)
+            _mm_empty();
+#endif
         }
-    #if defined(USE_MMX)
-        _mm_empty();
-    #endif
 
-    #else
-        for (Color perspective : { WHITE, BLACK }) {
+    private:
+        // Calculate cumulative value without using difference calculation
+        void RefreshAccumulator(const Position& pos) const {
 
-          if (reset[perspective]) {
-            if (i == 0) {
-              std::memcpy(accumulator.accumulation[perspective][i], biases_,
-                          kHalfDimensions * sizeof(BiasType));
-            } else {
-              std::memset(accumulator.accumulation[perspective][i], 0,
-                          kHalfDimensions * sizeof(BiasType));
+            auto& accumulator = pos.state()->accumulator;
+            for (IndexType i = 0; i < kRefreshTriggers.size(); ++i) {
+                Features::IndexList active_indices[2];
+                RawFeatures::AppendActiveIndices(pos, kRefreshTriggers[i],
+                                                 active_indices);
+                for (Color perspective : { WHITE, BLACK }) {
+#ifdef TILING
+                    for (unsigned j = 0; j < kHalfDimensions / kTileHeight; ++j) {
+                        auto accTile = reinterpret_cast<vec_t*>(
+                            &accumulator.accumulation[perspective][i][j * kTileHeight]);
+                        vec_t acc[kNumRegs];
+
+                        if (i == 0) {
+                            auto biasesTile = reinterpret_cast<const vec_t*>(
+                                &biases_[j * kTileHeight]);
+                            for (unsigned k = 0; k < kNumRegs; ++k)
+                                acc[k] = biasesTile[k];
+                        } else {
+                            for (unsigned k = 0; k < kNumRegs; ++k)
+                                acc[k] = vec_zero;
+                        }
+
+                        for (const auto index : active_indices[perspective]) {
+                            const IndexType offset = kHalfDimensions * index + j * kTileHeight;
+                            auto column = reinterpret_cast<const vec_t*>(&weights_[offset]);
+
+                            for (unsigned k = 0; k < kNumRegs; ++k)
+                                acc[k] = vec_add_16(acc[k], column[k]);
+                        }
+
+                        for (unsigned k = 0; k < kNumRegs; k++)
+                            vec_store(&accTile[k], acc[k]);
+                    }
+#else
+                    if (i == 0) {
+                        std::memcpy(accumulator.accumulation[perspective][i], biases_,
+                                    kHalfDimensions * sizeof(BiasType));
+                    } else {
+                        std::memset(accumulator.accumulation[perspective][i], 0,
+                                    kHalfDimensions * sizeof(BiasType));
+                    }
+
+                    for (const auto index : active_indices[perspective]) {
+                        const IndexType offset = kHalfDimensions * index;
+
+                        for (IndexType j = 0; j < kHalfDimensions; ++j)
+                            accumulator.accumulation[perspective][i][j] += weights_[offset + j];
+                    }
+#endif
+                }
+
             }
-          } else {
-            std::memcpy(accumulator.accumulation[perspective][i],
-                        prev_accumulator.accumulation[perspective][i],
-                        kHalfDimensions * sizeof(BiasType));
-            // Difference calculation for the deactivated features
-            for (const auto index : removed_indices[perspective]) {
-              const IndexType offset = kHalfDimensions * index;
 
-              for (IndexType j = 0; j < kHalfDimensions; ++j)
-                accumulator.accumulation[perspective][i][j] -= weights_[offset + j];
-            }
-          }
-          { // Difference calculation for the activated features
-            for (const auto index : added_indices[perspective]) {
-              const IndexType offset = kHalfDimensions * index;
+#if defined(USE_MMX)
+            _mm_empty();
+#endif
 
-              for (IndexType j = 0; j < kHalfDimensions; ++j)
-                accumulator.accumulation[perspective][i][j] += weights_[offset + j];
-            }
-          }
+            accumulator.computed_accumulation = true;
         }
-    #endif
-      }
-      accumulator.computed_accumulation = true;
-    }
 
-    using BiasType = std::int16_t;
-    using WeightType = std::int16_t;
+        // Calculate cumulative value using difference calculation
+        void UpdateAccumulator(const Position& pos) const {
 
-    // Make the learning class a friend
-    friend class Trainer<FeatureTransformer>;
+            const auto& prev_accumulator = pos.state()->previous->accumulator;
+            auto& accumulator = pos.state()->accumulator;
+            for (IndexType i = 0; i < kRefreshTriggers.size(); ++i) {
+                Features::IndexList removed_indices[2], added_indices[2];
+                bool reset[2] = { false, false };
+                RawFeatures::AppendChangedIndices(pos, kRefreshTriggers[i],
+                                                  removed_indices, added_indices, reset);
 
-    alignas(kCacheLineSize) BiasType biases_[kHalfDimensions];
-    alignas(kCacheLineSize)
-        WeightType weights_[kHalfDimensions * kInputDimensions];
-  };
+#ifdef TILING
+                for (IndexType j = 0; j < kHalfDimensions / kTileHeight; ++j) {
+                    for (Color perspective : { WHITE, BLACK }) {
+                        auto accTile = reinterpret_cast<vec_t*>(
+                            &accumulator.accumulation[perspective][i][j * kTileHeight]);
+                        vec_t acc[kNumRegs];
+
+                        if (reset[perspective]) {
+                            if (i == 0) {
+                                auto biasesTile = reinterpret_cast<const vec_t*>(
+                                    &biases_[j * kTileHeight]);
+                                for (unsigned k = 0; k < kNumRegs; ++k)
+                                    acc[k] = biasesTile[k];
+                            } else {
+                                for (unsigned k = 0; k < kNumRegs; ++k)
+                                    acc[k] = vec_zero;
+                            }
+                        } else {
+                            auto prevAccTile = reinterpret_cast<const vec_t*>(
+                                &prev_accumulator.accumulation[perspective][i][j * kTileHeight]);
+
+                            for (IndexType k = 0; k < kNumRegs; ++k)
+                                acc[k] = vec_load(&prevAccTile[k]);
+
+                            // Difference calculation for the deactivated features
+                            for (const auto index : removed_indices[perspective]) {
+                                const IndexType offset = kHalfDimensions * index + j * kTileHeight;
+                                auto column = reinterpret_cast<const vec_t*>(&weights_[offset]);
+
+                                for (IndexType k = 0; k < kNumRegs; ++k)
+                                    acc[k] = vec_sub_16(acc[k], column[k]);
+                            }
+                        }
+
+                        { // Difference calculation for the activated features
+                          for (const auto index : added_indices[perspective]) {
+                              const IndexType offset = kHalfDimensions * index + j * kTileHeight;
+                              auto column = reinterpret_cast<const vec_t*>(&weights_[offset]);
+
+                              for (IndexType k = 0; k < kNumRegs; ++k)
+                                  acc[k] = vec_add_16(acc[k], column[k]);
+                          }
+                        }
+
+                        for (IndexType k = 0; k < kNumRegs; ++k)
+                          vec_store(&accTile[k], acc[k]);
+                    }
+                }
+#if defined(USE_MMX)
+                _mm_empty();
+#endif
+
+#else
+                for (Color perspective : { WHITE, BLACK }) {
+
+                    if (reset[perspective]) {
+                        if (i == 0) {
+                            std::memcpy(accumulator.accumulation[perspective][i], biases_,
+                                        kHalfDimensions * sizeof(BiasType));
+                        } else {
+                            std::memset(accumulator.accumulation[perspective][i], 0,
+                                        kHalfDimensions * sizeof(BiasType));
+                        }
+                    } else {
+                        std::memcpy(accumulator.accumulation[perspective][i],
+                                    prev_accumulator.accumulation[perspective][i],
+                                    kHalfDimensions * sizeof(BiasType));
+                        // Difference calculation for the deactivated features
+                        for (const auto index : removed_indices[perspective]) {
+                            const IndexType offset = kHalfDimensions * index;
+
+                            for (IndexType j = 0; j < kHalfDimensions; ++j)
+                                accumulator.accumulation[perspective][i][j] -= weights_[offset + j];
+                        }
+                    }
+                    { // Difference calculation for the activated features
+                        for (const auto index : added_indices[perspective]) {
+                          const IndexType offset = kHalfDimensions * index;
+
+                          for (IndexType j = 0; j < kHalfDimensions; ++j)
+                              accumulator.accumulation[perspective][i][j] += weights_[offset + j];
+                        }
+                    }
+                }
+#endif
+            }
+            accumulator.computed_accumulation = true;
+        }
+
+        using BiasType = std::int16_t;
+        using WeightType = std::int16_t;
+
+        // Make the learning class a friend
+        friend class Trainer<FeatureTransformer>;
+
+        alignas(kCacheLineSize) BiasType biases_[kHalfDimensions];
+        alignas(kCacheLineSize)
+            WeightType weights_[kHalfDimensions * kInputDimensions];
+    };
 
 }  // namespace Eval::NNUE
 
-#endif // #ifndef NNUE_FEATURE_TRANSFORMER_H_INCLUDED
+#endif //#ifndef NNUE_FEATURE_TRANSFORMER_H_INCLUDED

--- a/src/nnue/nnue_test_command.cpp
+++ b/src/nnue/nnue_test_command.cpp
@@ -1,197 +1,215 @@
-﻿// USI extended command for NNUE evaluation function
-
-#include "../thread.h"
-#include "../uci.h"
-#include "evaluate_nnue.h"
+﻿#include "evaluate_nnue.h"
 #include "nnue_test_command.h"
+
+#include "thread.h"
+#include "uci.h"
 
 #include <set>
 #include <fstream>
 
-#define ASSERT(X) { if (!(X)) { std::cout << "\nError : ASSERT(" << #X << "), " << __FILE__ << "(" << __LINE__ << "): " << __func__ << std::endl; \
- std::this_thread::sleep_for(std::chrono::microseconds(3000)); *(int*)1 =0;} }
-
-namespace Eval {
-
-namespace NNUE {
-
-namespace {
-
-// Testing RawFeatures mainly for difference calculation
-void TestFeatures(Position& pos) {
-  const std::uint64_t num_games = 1000;
-  StateInfo si;
-  pos.set(StartFEN, false, &si, Threads.main());
-  const int MAX_PLY = 256; // test up to 256 hands
-
-  StateInfo state[MAX_PLY]; // StateInfo only for the maximum number of steps
-  int ply; // Trouble from the initial phase
-
-  PRNG prng(20171128);
-
-  std::uint64_t num_moves = 0;
-  std::vector<std::uint64_t> num_updates(kRefreshTriggers.size() + 1);
-  std::vector<std::uint64_t> num_resets(kRefreshTriggers.size());
-  constexpr IndexType kUnknown = -1;
-  std::vector<IndexType> trigger_map(RawFeatures::kDimensions, kUnknown);
-  auto make_index_sets = [&](const Position& position) {
-    std::vector<std::vector<std::set<IndexType>>> index_sets(
-        kRefreshTriggers.size(), std::vector<std::set<IndexType>>(2));
-    for (IndexType i = 0; i < kRefreshTriggers.size(); ++i) {
-      Features::IndexList active_indices[2];
-      RawFeatures::AppendActiveIndices(position, kRefreshTriggers[i],
-                                       active_indices);
-      for (const auto perspective : Colors) {
-        for (const auto index : active_indices[perspective]) {
-          ASSERT(index < RawFeatures::kDimensions);
-          ASSERT(index_sets[i][perspective].count(index) == 0);
-          ASSERT(trigger_map[index] == kUnknown || trigger_map[index] == i);
-          index_sets[i][perspective].insert(index);
-          trigger_map[index] = i;
-        }
-      }
-    }
-    return index_sets;
-  };
-  auto update_index_sets = [&](const Position& position, auto* index_sets) {
-    for (IndexType i = 0; i < kRefreshTriggers.size(); ++i) {
-      Features::IndexList removed_indices[2], added_indices[2];
-      bool reset[2] = { false, false };
-      RawFeatures::AppendChangedIndices(position, kRefreshTriggers[i],
-                                        removed_indices, added_indices, reset);
-      for (const auto perspective : Colors) {
-        if (reset[perspective]) {
-          (*index_sets)[i][perspective].clear();
-          ++num_resets[i];
-        } else {
-          for (const auto index : removed_indices[perspective]) {
-            ASSERT(index < RawFeatures::kDimensions);
-            ASSERT((*index_sets)[i][perspective].count(index) == 1);
-            ASSERT(trigger_map[index] == kUnknown || trigger_map[index] == i);
-            (*index_sets)[i][perspective].erase(index);
-            ++num_updates.back();
-            ++num_updates[i];
-            trigger_map[index] = i;
-          }
-        }
-        for (const auto index : added_indices[perspective]) {
-          ASSERT(index < RawFeatures::kDimensions);
-          ASSERT((*index_sets)[i][perspective].count(index) == 0);
-          ASSERT(trigger_map[index] == kUnknown || trigger_map[index] == i);
-          (*index_sets)[i][perspective].insert(index);
-          ++num_updates.back();
-          ++num_updates[i];
-          trigger_map[index] = i;
-        }
-      }
-    }
-  };
-
-  std::cout << "feature set: " << RawFeatures::GetName()
-            << "[" << RawFeatures::kDimensions << "]" << std::endl;
-  std::cout << "start testing with random games";
-
-  for (std::uint64_t i = 0; i < num_games; ++i) {
-    auto index_sets = make_index_sets(pos);
-    for (ply = 0; ply < MAX_PLY; ++ply) {
-      MoveList<LEGAL> mg(pos); // Generate all legal hands
-
-      // There was no legal move == Clog
-      if (mg.size() == 0)
-        break;
-
-      // Randomly choose from the generated moves and advance the phase with the moves.
-      Move m = mg.begin()[prng.rand(mg.size())];
-      pos.do_move(m, state[ply]);
-
-      ++num_moves;
-      update_index_sets(pos, &index_sets);
-      ASSERT(index_sets == make_index_sets(pos));
-    }
-
-    pos.set(StartFEN, false, &si, Threads.main());
-
-    // Output'.' every 100 times (so you can see that it's progressing)
-    if ((i % 100) == 0)
-      std::cout << "." << std::flush;
-  }
-  std::cout << "passed." << std::endl;
-  std::cout << num_games << " games, " << num_moves << " moves, "
-            << num_updates.back() << " updates, "
-            << (1.0 * num_updates.back() / num_moves)
-            << " updates per move" << std::endl;
-  std::size_t num_observed_indices = 0;
-  for (IndexType i = 0; i < kRefreshTriggers.size(); ++i) {
-    const auto count = std::count(trigger_map.begin(), trigger_map.end(), i);
-    num_observed_indices += count;
-    std::cout << "TriggerEvent(" << static_cast<int>(kRefreshTriggers[i])
-              << "): " << count << " features ("
-              << (100.0 * count / RawFeatures::kDimensions) << "%), "
-              << num_updates[i] << " updates ("
-              << (1.0 * num_updates[i] / num_moves) << " per move), "
-              << num_resets[i] << " resets ("
-              << (100.0 * num_resets[i] / num_moves) << "%)"
-              << std::endl;
-  }
-  std::cout << "observed " << num_observed_indices << " ("
-            << (100.0 * num_observed_indices / RawFeatures::kDimensions)
-            << "% of " << RawFeatures::kDimensions
-            << ") features" << std::endl;
+#define ASSERT(X) { \
+    if (!(X)) { \
+        std::cout \
+            << "\nError : ASSERT(" << #X << "), " \
+            << __FILE__ << "(" << __LINE__ << "): " \
+            << __func__ << std::endl; \
+            std::this_thread::sleep_for(std::chrono::microseconds(3000)); \
+            *(int*)1 =0; \
+    } \
 }
-
-// Output a string that represents the structure of the evaluation function
-void PrintInfo(std::istream& stream) {
-  std::cout << "network architecture: " << GetArchitectureString() << std::endl;
-
-  while (true) {
-    std::string file_name;
-    stream >> file_name;
-    if (file_name.empty()) break;
-
-    std::uint32_t hash_value;
-    std::string architecture;
-    const bool success = [&]() {
-      std::ifstream file_stream(file_name, std::ios::binary);
-      if (!file_stream) return false;
-      if (!ReadHeader(file_stream, &hash_value, &architecture)) return false;
-      return true;
-    }();
-
-    std::cout << file_name << ": ";
-    if (success) {
-      if (hash_value == kHashValue) {
-        std::cout << "matches with this binary";
-        if (architecture != GetArchitectureString()) {
-          std::cout << ", but architecture string differs: " << architecture;
-        }
-        std::cout << std::endl;
-      } else {
-        std::cout << architecture << std::endl;
-      }
-    } else {
-      std::cout << "failed to read header" << std::endl;
-    }
-  }
-}
-
-}  // namespace
 
 // USI extended command for NNUE evaluation function
-void TestCommand(Position& pos, std::istream& stream) {
-  std::string sub_command;
-  stream >> sub_command;
+namespace Eval::NNUE {
 
-  if (sub_command == "test_features") {
-    TestFeatures(pos);
-  } else if (sub_command == "info") {
-    PrintInfo(stream);
-  } else {
-    std::cout << "usage:" << std::endl;
-    std::cout << " test nnue test_features" << std::endl;
-    std::cout << " test nnue info [path/to/" << fileName << "...]" << std::endl;
-  }
-}
+    namespace {
 
-}  // namespace NNUE
+        // Testing RawFeatures mainly for difference calculation
+        void TestFeatures(Position& pos) {
+            const std::uint64_t num_games = 1000;
+            StateInfo si;
+            pos.set(StartFEN, false, &si, Threads.main());
+            const int MAX_PLY = 256; // test up to 256 hands
 
-}  // namespace Eval
+            StateInfo state[MAX_PLY]; // StateInfo only for the maximum number of steps
+            int ply; // Trouble from the initial phase
+
+            PRNG prng(20171128);
+
+            std::uint64_t num_moves = 0;
+            std::vector<std::uint64_t> num_updates(kRefreshTriggers.size() + 1);
+            std::vector<std::uint64_t> num_resets(kRefreshTriggers.size());
+            constexpr IndexType kUnknown = -1;
+            std::vector<IndexType> trigger_map(RawFeatures::kDimensions, kUnknown);
+
+            auto make_index_sets = [&](const Position& position) {
+                std::vector<std::vector<std::set<IndexType>>> index_sets(
+                    kRefreshTriggers.size(), std::vector<std::set<IndexType>>(2));
+
+                for (IndexType i = 0; i < kRefreshTriggers.size(); ++i) {
+                    Features::IndexList active_indices[2];
+                    RawFeatures::AppendActiveIndices(position, kRefreshTriggers[i],
+                                                     active_indices);
+
+                    for (const auto perspective : Colors) {
+                        for (const auto index : active_indices[perspective]) {
+                            ASSERT(index < RawFeatures::kDimensions);
+                            ASSERT(index_sets[i][perspective].count(index) == 0);
+                            ASSERT(trigger_map[index] == kUnknown || trigger_map[index] == i);
+                            index_sets[i][perspective].insert(index);
+                            trigger_map[index] = i;
+                        }
+                    }
+                }
+
+                return index_sets;
+            };
+
+            auto update_index_sets = [&](const Position& position, auto* index_sets) {
+                for (IndexType i = 0; i < kRefreshTriggers.size(); ++i) {
+                    Features::IndexList removed_indices[2], added_indices[2];
+                    bool reset[2] = { false, false };
+                    RawFeatures::AppendChangedIndices(position, kRefreshTriggers[i],
+                                                      removed_indices, added_indices, reset);
+                    for (const auto perspective : Colors) {
+                        if (reset[perspective]) {
+                            (*index_sets)[i][perspective].clear();
+                            ++num_resets[i];
+                        } else {
+                            for (const auto index : removed_indices[perspective]) {
+                                ASSERT(index < RawFeatures::kDimensions);
+                                ASSERT((*index_sets)[i][perspective].count(index) == 1);
+                                ASSERT(trigger_map[index] == kUnknown || trigger_map[index] == i);
+                                (*index_sets)[i][perspective].erase(index);
+                                ++num_updates.back();
+                                ++num_updates[i];
+                                trigger_map[index] = i;
+                            }
+                        }
+
+                        for (const auto index : added_indices[perspective]) {
+                            ASSERT(index < RawFeatures::kDimensions);
+                            ASSERT((*index_sets)[i][perspective].count(index) == 0);
+                            ASSERT(trigger_map[index] == kUnknown || trigger_map[index] == i);
+                            (*index_sets)[i][perspective].insert(index);
+                            ++num_updates.back();
+                            ++num_updates[i];
+                            trigger_map[index] = i;
+                        }
+                    }
+                }
+            };
+
+            std::cout << "feature set: " << RawFeatures::GetName()
+                      << "[" << RawFeatures::kDimensions << "]" << std::endl;
+            std::cout << "start testing with random games";
+
+            for (std::uint64_t i = 0; i < num_games; ++i) {
+                auto index_sets = make_index_sets(pos);
+                for (ply = 0; ply < MAX_PLY; ++ply) {
+                    MoveList<LEGAL> mg(pos); // Generate all legal hands
+
+                    // There was no legal move == Clog
+                    if (mg.size() == 0)
+                        break;
+
+                    // Randomly choose from the generated moves and advance the phase with the moves.
+                    Move m = mg.begin()[prng.rand(mg.size())];
+                    pos.do_move(m, state[ply]);
+
+                    ++num_moves;
+                    update_index_sets(pos, &index_sets);
+                    ASSERT(index_sets == make_index_sets(pos));
+                }
+
+                pos.set(StartFEN, false, &si, Threads.main());
+
+                // Output'.' every 100 times (so you can see that it's progressing)
+                if ((i % 100) == 0)
+                    std::cout << "." << std::flush;
+            }
+
+            std::cout << "passed." << std::endl;
+            std::cout << num_games << " games, " << num_moves << " moves, "
+                      << num_updates.back() << " updates, "
+                      << (1.0 * num_updates.back() / num_moves)
+                      << " updates per move" << std::endl;
+            std::size_t num_observed_indices = 0;
+
+            for (IndexType i = 0; i < kRefreshTriggers.size(); ++i) {
+                const auto count = std::count(trigger_map.begin(), trigger_map.end(), i);
+                num_observed_indices += count;
+                std::cout << "TriggerEvent(" << static_cast<int>(kRefreshTriggers[i])
+                          << "): " << count << " features ("
+                          << (100.0 * count / RawFeatures::kDimensions) << "%), "
+                          << num_updates[i] << " updates ("
+                          << (1.0 * num_updates[i] / num_moves) << " per move), "
+                          << num_resets[i] << " resets ("
+                          << (100.0 * num_resets[i] / num_moves) << "%)"
+                          << std::endl;
+            }
+            std::cout << "observed " << num_observed_indices << " ("
+                      << (100.0 * num_observed_indices / RawFeatures::kDimensions)
+                      << "% of " << RawFeatures::kDimensions
+                      << ") features" << std::endl;
+        }
+
+        // Output a string that represents the structure of the evaluation function
+        void PrintInfo(std::istream& stream) {
+            std::cout << "network architecture: " << GetArchitectureString() << std::endl;
+
+            while (true) {
+                std::string file_name;
+                stream >> file_name;
+                if (file_name.empty())
+                    break;
+
+                std::uint32_t hash_value;
+                std::string architecture;
+                const bool success = [&]() {
+                    std::ifstream file_stream(file_name, std::ios::binary);
+
+                    if (!file_stream)
+                        return false;
+                    if (!ReadHeader(file_stream, &hash_value, &architecture))
+                        return false;
+
+                    return true;
+                }();
+
+                std::cout << file_name << ": ";
+                if (success) {
+                    if (hash_value == kHashValue) {
+                        std::cout << "matches with this binary";
+                        if (architecture != GetArchitectureString()) {
+                            std::cout << ", but architecture string differs: " << architecture;
+                        }
+
+                        std::cout << std::endl;
+                    } else {
+                        std::cout << architecture << std::endl;
+                    }
+                } else {
+                    std::cout << "failed to read header" << std::endl;
+                }
+            }
+        }
+
+    }  // namespace
+
+    // USI extended command for NNUE evaluation function
+    void TestCommand(Position& pos, std::istream& stream) {
+        std::string sub_command;
+        stream >> sub_command;
+
+        if (sub_command == "test_features") {
+            TestFeatures(pos);
+        } else if (sub_command == "info") {
+            PrintInfo(stream);
+        } else {
+            std::cout << "usage:" << std::endl;
+            std::cout << " test nnue test_features" << std::endl;
+            std::cout << " test nnue info [path/to/" << fileName << "...]" << std::endl;
+        }
+    }
+
+}  // namespace Eval::NNUE

--- a/src/nnue/nnue_test_command.cpp
+++ b/src/nnue/nnue_test_command.cpp
@@ -24,7 +24,7 @@ namespace Eval::NNUE {
     namespace {
 
         // Testing RawFeatures mainly for difference calculation
-        void TestFeatures(Position& pos) {
+        void test_features(Position& pos) {
             const std::uint64_t num_games = 1000;
             StateInfo si;
             pos.set(StartFEN, false, &si, Threads.main());
@@ -47,7 +47,7 @@ namespace Eval::NNUE {
 
                 for (IndexType i = 0; i < kRefreshTriggers.size(); ++i) {
                     Features::IndexList active_indices[2];
-                    RawFeatures::AppendActiveIndices(position, kRefreshTriggers[i],
+                    RawFeatures::append_active_indices(position, kRefreshTriggers[i],
                                                      active_indices);
 
                     for (const auto perspective : Colors) {
@@ -68,7 +68,7 @@ namespace Eval::NNUE {
                 for (IndexType i = 0; i < kRefreshTriggers.size(); ++i) {
                     Features::IndexList removed_indices[2], added_indices[2];
                     bool reset[2] = { false, false };
-                    RawFeatures::AppendChangedIndices(position, kRefreshTriggers[i],
+                    RawFeatures::append_changed_indices(position, kRefreshTriggers[i],
                                                       removed_indices, added_indices, reset);
                     for (const auto perspective : Colors) {
                         if (reset[perspective]) {
@@ -99,7 +99,7 @@ namespace Eval::NNUE {
                 }
             };
 
-            std::cout << "feature set: " << RawFeatures::GetName()
+            std::cout << "feature set: " << RawFeatures::get_name()
                       << "[" << RawFeatures::kDimensions << "]" << std::endl;
             std::cout << "start testing with random games";
 
@@ -154,8 +154,8 @@ namespace Eval::NNUE {
         }
 
         // Output a string that represents the structure of the evaluation function
-        void PrintInfo(std::istream& stream) {
-            std::cout << "network architecture: " << GetArchitectureString() << std::endl;
+        void print_info(std::istream& stream) {
+            std::cout << "network architecture: " << get_architecture_string() << std::endl;
 
             while (true) {
                 std::string file_name;
@@ -170,7 +170,7 @@ namespace Eval::NNUE {
 
                     if (!file_stream)
                         return false;
-                    if (!ReadHeader(file_stream, &hash_value, &architecture))
+                    if (!read_header(file_stream, &hash_value, &architecture))
                         return false;
 
                     return true;
@@ -180,7 +180,7 @@ namespace Eval::NNUE {
                 if (success) {
                     if (hash_value == kHashValue) {
                         std::cout << "matches with this binary";
-                        if (architecture != GetArchitectureString()) {
+                        if (architecture != get_architecture_string()) {
                             std::cout << ", but architecture string differs: " << architecture;
                         }
 
@@ -197,14 +197,14 @@ namespace Eval::NNUE {
     }  // namespace
 
     // USI extended command for NNUE evaluation function
-    void TestCommand(Position& pos, std::istream& stream) {
+    void test_command(Position& pos, std::istream& stream) {
         std::string sub_command;
         stream >> sub_command;
 
         if (sub_command == "test_features") {
-            TestFeatures(pos);
+            test_features(pos);
         } else if (sub_command == "info") {
-            PrintInfo(stream);
+            print_info(stream);
         } else {
             std::cout << "usage:" << std::endl;
             std::cout << " test nnue test_features" << std::endl;

--- a/src/nnue/nnue_test_command.h
+++ b/src/nnue/nnue_test_command.h
@@ -1,17 +1,12 @@
-﻿// USI extended command interface for NNUE evaluation function
-
-#ifndef _NNUE_TEST_COMMAND_H_
+﻿#ifndef _NNUE_TEST_COMMAND_H_
 #define _NNUE_TEST_COMMAND_H_
 
-namespace Eval {
+// USI extended command interface for NNUE evaluation function
+namespace Eval::NNUE {
 
-namespace NNUE {
+    // USI extended command for NNUE evaluation function
+    void TestCommand(Position& pos, std::istream& stream);
 
-// USI extended command for NNUE evaluation function
-void TestCommand(Position& pos, std::istream& stream);
-
-}  // namespace NNUE
-
-}  // namespace Eval
+}  // namespace Eval::NNUE
 
 #endif

--- a/src/nnue/nnue_test_command.h
+++ b/src/nnue/nnue_test_command.h
@@ -5,7 +5,7 @@
 namespace Eval::NNUE {
 
     // USI extended command for NNUE evaluation function
-    void TestCommand(Position& pos, std::istream& stream);
+    void test_command(Position& pos, std::istream& stream);
 
 }  // namespace Eval::NNUE
 

--- a/src/nnue/trainer/features/factorizer.h
+++ b/src/nnue/trainer/features/factorizer.h
@@ -14,12 +14,12 @@ namespace Eval::NNUE::Features {
     class Factorizer {
     public:
         // Get the dimensionality of the learning feature
-        static constexpr IndexType GetDimensions() {
+        static constexpr IndexType get_dimensions() {
             return FeatureType::kDimensions;
         }
 
         // Get index of learning feature and scale of learning rate
-        static void AppendTrainingFeatures(
+        static void append_training_features(
             IndexType base_index, std::vector<TrainingFeature>* training_features) {
 
             assert(base_index <FeatureType::kDimensions);
@@ -35,7 +35,7 @@ namespace Eval::NNUE::Features {
 
     // Add the original input features to the learning features
     template <typename FeatureType>
-    IndexType AppendBaseFeature(
+    IndexType append_base_feature(
         FeatureProperties properties, IndexType base_index,
         std::vector<TrainingFeature>* training_features) {
 
@@ -47,7 +47,7 @@ namespace Eval::NNUE::Features {
 
     // If the learning rate scale is not 0, inherit other types of learning features
     template <typename FeatureType>
-    IndexType InheritFeaturesIfRequired(
+    IndexType inherit_features_if_required(
         IndexType index_offset, FeatureProperties properties, IndexType base_index,
         std::vector<TrainingFeature>* training_features) {
 
@@ -55,17 +55,17 @@ namespace Eval::NNUE::Features {
             return 0;
         }
 
-        assert(properties.dimensions == Factorizer<FeatureType>::GetDimensions());
+        assert(properties.dimensions == Factorizer<FeatureType>::get_dimensions());
         assert(base_index < FeatureType::kDimensions);
 
         const auto start = training_features->size();
-        Factorizer<FeatureType>::AppendTrainingFeatures(
+        Factorizer<FeatureType>::append_training_features(
             base_index, training_features);
 
         for (auto i = start; i < training_features->size(); ++i) {
             auto& feature = (*training_features)[i];
-            assert(feature.GetIndex() < Factorizer<FeatureType>::GetDimensions());
-            feature.ShiftIndex(index_offset);
+            assert(feature.get_index() < Factorizer<FeatureType>::get_dimensions());
+            feature.shift_index(index_offset);
         }
 
         return properties.dimensions;
@@ -73,7 +73,7 @@ namespace Eval::NNUE::Features {
 
     // Return the index difference as needed, without adding learning features
     // Call instead of InheritFeaturesIfRequired() if there are no corresponding features
-    IndexType SkipFeatures(FeatureProperties properties) {
+    IndexType skip_features(FeatureProperties properties) {
         if (!properties.active)
             return 0;
 
@@ -82,7 +82,7 @@ namespace Eval::NNUE::Features {
 
     // Get the dimensionality of the learning feature
     template <std::size_t N>
-    constexpr IndexType GetActiveDimensions(
+    constexpr IndexType get_active_dimensions(
         const FeatureProperties (&properties)[N]) {
 
         static_assert(N > 0, "");
@@ -100,7 +100,7 @@ namespace Eval::NNUE::Features {
 
     // get the number of elements in the array
     template <typename T, std::size_t N>
-    constexpr std::size_t GetArrayLength(const T (&/*array*/)[N]) {
+    constexpr std::size_t get_array_length(const T (&/*array*/)[N]) {
         return N;
     }
 

--- a/src/nnue/trainer/features/factorizer.h
+++ b/src/nnue/trainer/features/factorizer.h
@@ -1,106 +1,109 @@
-﻿// NNUE evaluation function feature conversion class template
-
-#ifndef _NNUE_TRAINER_FEATURES_FACTORIZER_H_
+﻿#ifndef _NNUE_TRAINER_FEATURES_FACTORIZER_H_
 #define _NNUE_TRAINER_FEATURES_FACTORIZER_H_
 
-#include "../../nnue_common.h"
-#include "../trainer.h"
+#include "nnue/nnue_common.h"
 
-namespace Eval {
+#include "nnue/trainer/trainer.h"
 
-namespace NNUE {
+// NNUE evaluation function feature conversion class template
+namespace Eval::NNUE::Features {
 
-namespace Features {
+    // Class template that converts input features into learning features
+    // By default, the learning feature is the same as the original input feature, and specialized as necessary
+    template <typename FeatureType>
+    class Factorizer {
+    public:
+        // Get the dimensionality of the learning feature
+        static constexpr IndexType GetDimensions() {
+            return FeatureType::kDimensions;
+        }
 
-// Class template that converts input features into learning features
-// By default, the learning feature is the same as the original input feature, and specialized as necessary
-template <typename FeatureType>
-class Factorizer {
- public:
-  // Get the dimensionality of the learning feature
-  static constexpr IndexType GetDimensions() {
-    return FeatureType::kDimensions;
-  }
+        // Get index of learning feature and scale of learning rate
+        static void AppendTrainingFeatures(
+            IndexType base_index, std::vector<TrainingFeature>* training_features) {
 
-  // Get index of learning feature and scale of learning rate
-  static void AppendTrainingFeatures(
-      IndexType base_index, std::vector<TrainingFeature>* training_features) {
-    assert(base_index <FeatureType::kDimensions);
-    training_features->emplace_back(base_index);
-  }
-};
+            assert(base_index <FeatureType::kDimensions);
+            training_features->emplace_back(base_index);
+        }
+    };
 
-// Learning feature information
-struct FeatureProperties {
-  bool active;
-  IndexType dimensions;
-};
+    // Learning feature information
+    struct FeatureProperties {
+        bool active;
+        IndexType dimensions;
+    };
 
-// Add the original input features to the learning features
-template <typename FeatureType>
-IndexType AppendBaseFeature(
-    FeatureProperties properties, IndexType base_index,
-    std::vector<TrainingFeature>* training_features) {
-  assert(properties.dimensions == FeatureType::kDimensions);
-  assert(base_index < FeatureType::kDimensions);
-  training_features->emplace_back(base_index);
-  return properties.dimensions;
-}
+    // Add the original input features to the learning features
+    template <typename FeatureType>
+    IndexType AppendBaseFeature(
+        FeatureProperties properties, IndexType base_index,
+        std::vector<TrainingFeature>* training_features) {
 
-// If the learning rate scale is not 0, inherit other types of learning features
-template <typename FeatureType>
-IndexType InheritFeaturesIfRequired(
-    IndexType index_offset, FeatureProperties properties, IndexType base_index,
-    std::vector<TrainingFeature>* training_features) {
-  if (!properties.active) {
-    return 0;
-  }
-  assert(properties.dimensions == Factorizer<FeatureType>::GetDimensions());
-  assert(base_index < FeatureType::kDimensions);
-  const auto start = training_features->size();
-  Factorizer<FeatureType>::AppendTrainingFeatures(
-      base_index, training_features);
-  for (auto i = start; i < training_features->size(); ++i) {
-    auto& feature = (*training_features)[i];
-    assert(feature.GetIndex() < Factorizer<FeatureType>::GetDimensions());
-    feature.ShiftIndex(index_offset);
-  }
-  return properties.dimensions;
-}
-
-// Return the index difference as needed, without adding learning features
-// Call instead of InheritFeaturesIfRequired() if there are no corresponding features
-IndexType SkipFeatures(FeatureProperties properties) {
-  if (!properties.active) {
-    return 0;
-  }
-  return properties.dimensions;
-}
-
-// Get the dimensionality of the learning feature
-template <std::size_t N>
-constexpr IndexType GetActiveDimensions(
-    const FeatureProperties (&properties)[N]) {
-  static_assert(N > 0, "");
-  IndexType dimensions = properties[0].dimensions;
-  for (std::size_t i = 1; i < N; ++i) {
-    if (properties[i].active) {
-      dimensions += properties[i].dimensions;
+        assert(properties.dimensions == FeatureType::kDimensions);
+        assert(base_index < FeatureType::kDimensions);
+        training_features->emplace_back(base_index);
+        return properties.dimensions;
     }
-  }
-  return dimensions;
-}
 
-// get the number of elements in the array
-template <typename T, std::size_t N>
-constexpr std::size_t GetArrayLength(const T (&/*array*/)[N]) {
-  return N;
-}
+    // If the learning rate scale is not 0, inherit other types of learning features
+    template <typename FeatureType>
+    IndexType InheritFeaturesIfRequired(
+        IndexType index_offset, FeatureProperties properties, IndexType base_index,
+        std::vector<TrainingFeature>* training_features) {
 
-}  // namespace Features
+        if (!properties.active) {
+            return 0;
+        }
 
-}  // namespace NNUE
+        assert(properties.dimensions == Factorizer<FeatureType>::GetDimensions());
+        assert(base_index < FeatureType::kDimensions);
 
-}  // namespace Eval
+        const auto start = training_features->size();
+        Factorizer<FeatureType>::AppendTrainingFeatures(
+            base_index, training_features);
+
+        for (auto i = start; i < training_features->size(); ++i) {
+            auto& feature = (*training_features)[i];
+            assert(feature.GetIndex() < Factorizer<FeatureType>::GetDimensions());
+            feature.ShiftIndex(index_offset);
+        }
+
+        return properties.dimensions;
+    }
+
+    // Return the index difference as needed, without adding learning features
+    // Call instead of InheritFeaturesIfRequired() if there are no corresponding features
+    IndexType SkipFeatures(FeatureProperties properties) {
+        if (!properties.active)
+            return 0;
+
+        return properties.dimensions;
+    }
+
+    // Get the dimensionality of the learning feature
+    template <std::size_t N>
+    constexpr IndexType GetActiveDimensions(
+        const FeatureProperties (&properties)[N]) {
+
+        static_assert(N > 0, "");
+
+        IndexType dimensions = properties[0].dimensions;
+
+        for (std::size_t i = 1; i < N; ++i) {
+            if (properties[i].active) {
+                dimensions += properties[i].dimensions;
+            }
+        }
+
+        return dimensions;
+    }
+
+    // get the number of elements in the array
+    template <typename T, std::size_t N>
+    constexpr std::size_t GetArrayLength(const T (&/*array*/)[N]) {
+        return N;
+    }
+
+}  // namespace Eval::NNUE::Features
 
 #endif

--- a/src/nnue/trainer/features/factorizer_feature_set.h
+++ b/src/nnue/trainer/features/factorizer_feature_set.h
@@ -1,100 +1,105 @@
-﻿// Specialization for feature set of feature conversion class template of NNUE evaluation function
-
-#ifndef _NNUE_TRAINER_FEATURES_FACTORIZER_FEATURE_SET_H_
+﻿#ifndef _NNUE_TRAINER_FEATURES_FACTORIZER_FEATURE_SET_H_
 #define _NNUE_TRAINER_FEATURES_FACTORIZER_FEATURE_SET_H_
 
-#include "../../features/feature_set.h"
 #include "factorizer.h"
 
-namespace Eval {
+#include "nnue/features/feature_set.h"
 
-namespace NNUE {
+// Specialization for feature set of feature conversion class template of NNUE evaluation function
+namespace Eval::NNUE::Features {
 
-namespace Features {
+    // Class template that converts input features into learning features
+    // Specialization for FeatureSet
+    template <typename FirstFeatureType, typename... RemainingFeatureTypes>
+    class Factorizer<FeatureSet<FirstFeatureType, RemainingFeatureTypes...>> {
+    private:
+        using Head = Factorizer<FeatureSet<FirstFeatureType>>;
+        using Tail = Factorizer<FeatureSet<RemainingFeatureTypes...>>;
 
-// Class template that converts input features into learning features
-// Specialization for FeatureSet
-template <typename FirstFeatureType, typename... RemainingFeatureTypes>
-class Factorizer<FeatureSet<FirstFeatureType, RemainingFeatureTypes...>> {
- private:
-  using Head = Factorizer<FeatureSet<FirstFeatureType>>;
-  using Tail = Factorizer<FeatureSet<RemainingFeatureTypes...>>;
+    public:
+        // number of dimensions of original input features
+        static constexpr IndexType kBaseDimensions =
+            FeatureSet<FirstFeatureType, RemainingFeatureTypes...>::kDimensions;
 
- public:
-  // number of dimensions of original input features
-  static constexpr IndexType kBaseDimensions =
-      FeatureSet<FirstFeatureType, RemainingFeatureTypes...>::kDimensions;
-
-  // Get the dimensionality of the learning feature
-  static constexpr IndexType GetDimensions() {
-    return Head::GetDimensions() + Tail::GetDimensions();
-  }
-
-  // Get index of learning feature and scale of learning rate
-  static void AppendTrainingFeatures(
-      IndexType base_index, std::vector<TrainingFeature>* training_features,
-      IndexType base_dimensions = kBaseDimensions) {
-    assert(base_index < kBaseDimensions);
-    constexpr auto boundary = FeatureSet<RemainingFeatureTypes...>::kDimensions;
-    if (base_index < boundary) {
-      Tail::AppendTrainingFeatures(
-          base_index, training_features, base_dimensions);
-    } else {
-      const auto start = training_features->size();
-      Head::AppendTrainingFeatures(
-          base_index - boundary, training_features, base_dimensions);
-      for (auto i = start; i < training_features->size(); ++i) {
-        auto& feature = (*training_features)[i];
-        const auto index = feature.GetIndex();
-        assert(index < Head::GetDimensions() ||
-                   (index >= base_dimensions &&
-                    index < base_dimensions +
-                            Head::GetDimensions() - Head::kBaseDimensions));
-        if (index < Head::kBaseDimensions) {
-          feature.ShiftIndex(Tail::kBaseDimensions);
-        } else {
-          feature.ShiftIndex(Tail::GetDimensions() - Tail::kBaseDimensions);
+        // Get the dimensionality of the learning feature
+        static constexpr IndexType GetDimensions() {
+            return Head::GetDimensions() + Tail::GetDimensions();
         }
-      }
-    }
-  }
-};
 
-// Class template that converts input features into learning features
-// Specialization when FeatureSet has one template argument
-template <typename FeatureType>
-class Factorizer<FeatureSet<FeatureType>> {
-public:
-  // number of dimensions of original input features
-  static constexpr IndexType kBaseDimensions = FeatureType::kDimensions;
+        // Get index of learning feature and scale of learning rate
+        static void AppendTrainingFeatures(
+            IndexType base_index, std::vector<TrainingFeature>* training_features,
+            IndexType base_dimensions = kBaseDimensions) {
 
-  // Get the dimensionality of the learning feature
-  static constexpr IndexType GetDimensions() {
-    return Factorizer<FeatureType>::GetDimensions();
-  }
+            assert(base_index < kBaseDimensions);
 
-  // Get index of learning feature and scale of learning rate
-  static void AppendTrainingFeatures(
-      IndexType base_index, std::vector<TrainingFeature>* training_features,
-      IndexType base_dimensions = kBaseDimensions) {
-    assert(base_index < kBaseDimensions);
-    const auto start = training_features->size();
-    Factorizer<FeatureType>::AppendTrainingFeatures(
-        base_index, training_features);
-    for (auto i = start; i < training_features->size(); ++i) {
-      auto& feature = (*training_features)[i];
-      assert(feature.GetIndex() < Factorizer<FeatureType>::GetDimensions());
-      if (feature.GetIndex() >= kBaseDimensions) {
-        feature.ShiftIndex(base_dimensions - kBaseDimensions);
-      }
-    }
-  }
-};
+            constexpr auto boundary = FeatureSet<RemainingFeatureTypes...>::kDimensions;
 
-}  // namespace Features
+            if (base_index < boundary) {
+                Tail::AppendTrainingFeatures(
+                    base_index, training_features, base_dimensions);
+            }
+            else {
+                const auto start = training_features->size();
 
-}  // namespace NNUE
+                Head::AppendTrainingFeatures(
+                    base_index - boundary, training_features, base_dimensions);
 
-}  // namespace Eval
+                for (auto i = start; i < training_features->size(); ++i) {
+                    auto& feature = (*training_features)[i];
+                    const auto index = feature.GetIndex();
+
+                    assert(index < Head::GetDimensions() ||
+                               (index >= base_dimensions &&
+                                index < base_dimensions +
+                                        Head::GetDimensions() - Head::kBaseDimensions));
+
+                    if (index < Head::kBaseDimensions) {
+                        feature.ShiftIndex(Tail::kBaseDimensions);
+                    }
+                    else {
+                        feature.ShiftIndex(Tail::GetDimensions() - Tail::kBaseDimensions);
+                    }
+                }
+            }
+        }
+    };
+
+    // Class template that converts input features into learning features
+    // Specialization when FeatureSet has one template argument
+    template <typename FeatureType>
+    class Factorizer<FeatureSet<FeatureType>> {
+    public:
+        // number of dimensions of original input features
+        static constexpr IndexType kBaseDimensions = FeatureType::kDimensions;
+
+        // Get the dimensionality of the learning feature
+        static constexpr IndexType GetDimensions() {
+            return Factorizer<FeatureType>::GetDimensions();
+        }
+
+        // Get index of learning feature and scale of learning rate
+        static void AppendTrainingFeatures(
+            IndexType base_index, std::vector<TrainingFeature>* training_features,
+            IndexType base_dimensions = kBaseDimensions) {
+
+            assert(base_index < kBaseDimensions);
+
+            const auto start = training_features->size();
+
+            Factorizer<FeatureType>::AppendTrainingFeatures(
+                base_index, training_features);
+
+            for (auto i = start; i < training_features->size(); ++i) {
+                auto& feature = (*training_features)[i];
+                assert(feature.GetIndex() < Factorizer<FeatureType>::GetDimensions());
+                if (feature.GetIndex() >= kBaseDimensions) {
+                    feature.ShiftIndex(base_dimensions - kBaseDimensions);
+                }
+            }
+        }
+    };
+
+}  // namespace Eval::NNUE::Features
 
 #endif

--- a/src/nnue/trainer/features/factorizer_feature_set.h
+++ b/src/nnue/trainer/features/factorizer_feature_set.h
@@ -22,12 +22,12 @@ namespace Eval::NNUE::Features {
             FeatureSet<FirstFeatureType, RemainingFeatureTypes...>::kDimensions;
 
         // Get the dimensionality of the learning feature
-        static constexpr IndexType GetDimensions() {
-            return Head::GetDimensions() + Tail::GetDimensions();
+        static constexpr IndexType get_dimensions() {
+            return Head::get_dimensions() + Tail::get_dimensions();
         }
 
         // Get index of learning feature and scale of learning rate
-        static void AppendTrainingFeatures(
+        static void append_training_features(
             IndexType base_index, std::vector<TrainingFeature>* training_features,
             IndexType base_dimensions = kBaseDimensions) {
 
@@ -36,29 +36,29 @@ namespace Eval::NNUE::Features {
             constexpr auto boundary = FeatureSet<RemainingFeatureTypes...>::kDimensions;
 
             if (base_index < boundary) {
-                Tail::AppendTrainingFeatures(
+                Tail::append_training_features(
                     base_index, training_features, base_dimensions);
             }
             else {
                 const auto start = training_features->size();
 
-                Head::AppendTrainingFeatures(
+                Head::append_training_features(
                     base_index - boundary, training_features, base_dimensions);
 
                 for (auto i = start; i < training_features->size(); ++i) {
                     auto& feature = (*training_features)[i];
-                    const auto index = feature.GetIndex();
+                    const auto index = feature.get_index();
 
-                    assert(index < Head::GetDimensions() ||
+                    assert(index < Head::get_dimensions() ||
                                (index >= base_dimensions &&
                                 index < base_dimensions +
-                                        Head::GetDimensions() - Head::kBaseDimensions));
+                                        Head::get_dimensions() - Head::kBaseDimensions));
 
                     if (index < Head::kBaseDimensions) {
-                        feature.ShiftIndex(Tail::kBaseDimensions);
+                        feature.shift_index(Tail::kBaseDimensions);
                     }
                     else {
-                        feature.ShiftIndex(Tail::GetDimensions() - Tail::kBaseDimensions);
+                        feature.shift_index(Tail::get_dimensions() - Tail::kBaseDimensions);
                     }
                 }
             }
@@ -74,12 +74,12 @@ namespace Eval::NNUE::Features {
         static constexpr IndexType kBaseDimensions = FeatureType::kDimensions;
 
         // Get the dimensionality of the learning feature
-        static constexpr IndexType GetDimensions() {
-            return Factorizer<FeatureType>::GetDimensions();
+        static constexpr IndexType get_dimensions() {
+            return Factorizer<FeatureType>::get_dimensions();
         }
 
         // Get index of learning feature and scale of learning rate
-        static void AppendTrainingFeatures(
+        static void append_training_features(
             IndexType base_index, std::vector<TrainingFeature>* training_features,
             IndexType base_dimensions = kBaseDimensions) {
 
@@ -87,14 +87,14 @@ namespace Eval::NNUE::Features {
 
             const auto start = training_features->size();
 
-            Factorizer<FeatureType>::AppendTrainingFeatures(
+            Factorizer<FeatureType>::append_training_features(
                 base_index, training_features);
 
             for (auto i = start; i < training_features->size(); ++i) {
                 auto& feature = (*training_features)[i];
-                assert(feature.GetIndex() < Factorizer<FeatureType>::GetDimensions());
-                if (feature.GetIndex() >= kBaseDimensions) {
-                    feature.ShiftIndex(base_dimensions - kBaseDimensions);
+                assert(feature.get_index() < Factorizer<FeatureType>::get_dimensions());
+                if (feature.get_index() >= kBaseDimensions) {
+                    feature.shift_index(base_dimensions - kBaseDimensions);
                 }
             }
         }

--- a/src/nnue/trainer/features/factorizer_half_kp.h
+++ b/src/nnue/trainer/features/factorizer_half_kp.h
@@ -1,99 +1,96 @@
-﻿// Specialization of NNUE evaluation function feature conversion class template for HalfKP
-
-#ifndef _NNUE_TRAINER_FEATURES_FACTORIZER_HALF_KP_H_
+﻿#ifndef _NNUE_TRAINER_FEATURES_FACTORIZER_HALF_KP_H_
 #define _NNUE_TRAINER_FEATURES_FACTORIZER_HALF_KP_H_
 
-#include "../../features/half_kp.h"
-#include "../../features/p.h"
-#include "../../features/half_relative_kp.h"
 #include "factorizer.h"
 
-namespace Eval {
+#include "nnue/features/half_kp.h"
+#include "nnue/features/p.h"
+#include "nnue/features/half_relative_kp.h"
 
-namespace NNUE {
+// Specialization of NNUE evaluation function feature conversion class template for HalfKP
+namespace Eval::NNUE::Features {
 
-namespace Features {
+    // Class template that converts input features into learning features
+    // Specialization for HalfKP
+    template <Side AssociatedKing>
+    class Factorizer<HalfKP<AssociatedKing>> {
+    private:
+        using FeatureType = HalfKP<AssociatedKing>;
 
-// Class template that converts input features into learning features
-// Specialization for HalfKP
-template <Side AssociatedKing>
-class Factorizer<HalfKP<AssociatedKing>> {
- private:
-  using FeatureType = HalfKP<AssociatedKing>;
+        // The maximum value of the number of indexes whose value is 1 at the same time among the feature values
+        static constexpr IndexType kMaxActiveDimensions =
+            FeatureType::kMaxActiveDimensions;
 
-  // The maximum value of the number of indexes whose value is 1 at the same time among the feature values
-  static constexpr IndexType kMaxActiveDimensions =
-      FeatureType::kMaxActiveDimensions;
+        // Type of learning feature
+        enum TrainingFeatureType {
+            kFeaturesHalfKP,
+            kFeaturesHalfK,
+            kFeaturesP,
+            kFeaturesHalfRelativeKP,
+            kNumTrainingFeatureTypes,
+        };
 
-  // Type of learning feature
-  enum TrainingFeatureType {
-    kFeaturesHalfKP,
-    kFeaturesHalfK,
-    kFeaturesP,
-    kFeaturesHalfRelativeKP,
-    kNumTrainingFeatureTypes,
-  };
+        // Learning feature information
+        static constexpr FeatureProperties kProperties[] = {
+            // kFeaturesHalfKP
+            {true, FeatureType::kDimensions},
+            // kFeaturesHalfK
+            {true, SQUARE_NB},
+            // kFeaturesP
+            {true, Factorizer<P>::GetDimensions()},
+            // kFeaturesHalfRelativeKP
+            {true, Factorizer<HalfRelativeKP<AssociatedKing>>::GetDimensions()},
+        };
 
-  // Learning feature information
-  static constexpr FeatureProperties kProperties[] = {
-    // kFeaturesHalfKP
-    {true, FeatureType::kDimensions},
-    // kFeaturesHalfK
-    {true, SQUARE_NB},
-    // kFeaturesP
-    {true, Factorizer<P>::GetDimensions()},
-    // kFeaturesHalfRelativeKP
-    {true, Factorizer<HalfRelativeKP<AssociatedKing>>::GetDimensions()},
-  };
-  static_assert(GetArrayLength(kProperties) == kNumTrainingFeatureTypes, "");
+        static_assert(GetArrayLength(kProperties) == kNumTrainingFeatureTypes, "");
 
- public:
-  // Get the dimensionality of the learning feature
-  static constexpr IndexType GetDimensions() {
-    return GetActiveDimensions(kProperties);
-  }
+    public:
+        // Get the dimensionality of the learning feature
+        static constexpr IndexType GetDimensions() {
+            return GetActiveDimensions(kProperties);
+        }
 
-  // Get index of learning feature and scale of learning rate
-  static void AppendTrainingFeatures(
-      IndexType base_index, std::vector<TrainingFeature>* training_features) {
-    // kFeaturesHalfKP
-    IndexType index_offset = AppendBaseFeature<FeatureType>(
-        kProperties[kFeaturesHalfKP], base_index, training_features);
+        // Get index of learning feature and scale of learning rate
+        static void AppendTrainingFeatures(
+            IndexType base_index, std::vector<TrainingFeature>* training_features) {
 
-    const auto sq_k = static_cast<Square>(base_index / PS_END);
-    const auto p = static_cast<IndexType>(base_index % PS_END);
-    // kFeaturesHalfK
-    {
-      const auto& properties = kProperties[kFeaturesHalfK];
-      if (properties.active) {
-        training_features->emplace_back(index_offset + sq_k);
-        index_offset += properties.dimensions;
-      }
-    }
-    // kFeaturesP
-    index_offset += InheritFeaturesIfRequired<P>(
-        index_offset, kProperties[kFeaturesP], p, training_features);
-    // kFeaturesHalfRelativeKP
-    if (p >= PS_W_PAWN) {
-      index_offset += InheritFeaturesIfRequired<HalfRelativeKP<AssociatedKing>>(
-          index_offset, kProperties[kFeaturesHalfRelativeKP],
-          HalfRelativeKP<AssociatedKing>::MakeIndex(sq_k, p),
-          training_features);
-    } else {
-      index_offset += SkipFeatures(kProperties[kFeaturesHalfRelativeKP]);
-    }
+            // kFeaturesHalfKP
+            IndexType index_offset = AppendBaseFeature<FeatureType>(
+                kProperties[kFeaturesHalfKP], base_index, training_features);
 
-    assert(index_offset == GetDimensions());
-  }
-};
+            const auto sq_k = static_cast<Square>(base_index / PS_END);
+            const auto p = static_cast<IndexType>(base_index % PS_END);
 
-template <Side AssociatedKing>
-constexpr FeatureProperties Factorizer<HalfKP<AssociatedKing>>::kProperties[];
+            // kFeaturesHalfK
+            {
+                const auto& properties = kProperties[kFeaturesHalfK];
+                if (properties.active) {
+                    training_features->emplace_back(index_offset + sq_k);
+                    index_offset += properties.dimensions;
+                }
+            }
 
-}  // namespace Features
+            // kFeaturesP
+            index_offset += InheritFeaturesIfRequired<P>(
+                index_offset, kProperties[kFeaturesP], p, training_features);
+            // kFeaturesHalfRelativeKP
+            if (p >= PS_W_PAWN) {
+                index_offset += InheritFeaturesIfRequired<HalfRelativeKP<AssociatedKing>>(
+                    index_offset, kProperties[kFeaturesHalfRelativeKP],
+                    HalfRelativeKP<AssociatedKing>::MakeIndex(sq_k, p),
+                    training_features);
+            }
+            else {
+                index_offset += SkipFeatures(kProperties[kFeaturesHalfRelativeKP]);
+            }
 
-}  // namespace NNUE
+            assert(index_offset == GetDimensions());
+        }
+    };
 
-}  // namespace Eval
+    template <Side AssociatedKing>
+    constexpr FeatureProperties Factorizer<HalfKP<AssociatedKing>>::kProperties[];
+
+}  // namespace Eval::NNUE::Features
 
 #endif

--- a/src/nnue/trainer/features/factorizer_half_kp.h
+++ b/src/nnue/trainer/features/factorizer_half_kp.h
@@ -37,25 +37,25 @@ namespace Eval::NNUE::Features {
             // kFeaturesHalfK
             {true, SQUARE_NB},
             // kFeaturesP
-            {true, Factorizer<P>::GetDimensions()},
+            {true, Factorizer<P>::get_dimensions()},
             // kFeaturesHalfRelativeKP
-            {true, Factorizer<HalfRelativeKP<AssociatedKing>>::GetDimensions()},
+            {true, Factorizer<HalfRelativeKP<AssociatedKing>>::get_dimensions()},
         };
 
-        static_assert(GetArrayLength(kProperties) == kNumTrainingFeatureTypes, "");
+        static_assert(get_array_length(kProperties) == kNumTrainingFeatureTypes, "");
 
     public:
         // Get the dimensionality of the learning feature
-        static constexpr IndexType GetDimensions() {
-            return GetActiveDimensions(kProperties);
+        static constexpr IndexType get_dimensions() {
+            return get_active_dimensions(kProperties);
         }
 
         // Get index of learning feature and scale of learning rate
-        static void AppendTrainingFeatures(
+        static void append_training_features(
             IndexType base_index, std::vector<TrainingFeature>* training_features) {
 
             // kFeaturesHalfKP
-            IndexType index_offset = AppendBaseFeature<FeatureType>(
+            IndexType index_offset = append_base_feature<FeatureType>(
                 kProperties[kFeaturesHalfKP], base_index, training_features);
 
             const auto sq_k = static_cast<Square>(base_index / PS_END);
@@ -71,20 +71,20 @@ namespace Eval::NNUE::Features {
             }
 
             // kFeaturesP
-            index_offset += InheritFeaturesIfRequired<P>(
+            index_offset += inherit_features_if_required<P>(
                 index_offset, kProperties[kFeaturesP], p, training_features);
             // kFeaturesHalfRelativeKP
             if (p >= PS_W_PAWN) {
-                index_offset += InheritFeaturesIfRequired<HalfRelativeKP<AssociatedKing>>(
+                index_offset += inherit_features_if_required<HalfRelativeKP<AssociatedKing>>(
                     index_offset, kProperties[kFeaturesHalfRelativeKP],
-                    HalfRelativeKP<AssociatedKing>::MakeIndex(sq_k, p),
+                    HalfRelativeKP<AssociatedKing>::make_index(sq_k, p),
                     training_features);
             }
             else {
-                index_offset += SkipFeatures(kProperties[kFeaturesHalfRelativeKP]);
+                index_offset += skip_features(kProperties[kFeaturesHalfRelativeKP]);
             }
 
-            assert(index_offset == GetDimensions());
+            assert(index_offset == get_dimensions());
         }
     };
 

--- a/src/nnue/trainer/trainer.h
+++ b/src/nnue/trainer/trainer.h
@@ -1,121 +1,134 @@
-﻿// Common header of class template for learning NNUE evaluation function
-
-#ifndef _NNUE_TRAINER_H_
+﻿#ifndef _NNUE_TRAINER_H_
 #define _NNUE_TRAINER_H_
 
-#include "../nnue_common.h"
-#include "../features/index_list.h"
+#include "nnue/nnue_common.h"
+#include "nnue/features/index_list.h"
 
 #include <sstream>
+
 #if defined(USE_BLAS)
 static_assert(std::is_same<LearnFloatType, float>::value, "");
 #include <cblas.h>
 #endif
 
-namespace Eval {
+// Common header of class template for learning NNUE evaluation function
+namespace Eval::NNUE {
 
-namespace NNUE {
+    // Ponanza constant used in the relation between evaluation value and winning percentage
+    constexpr double kPonanzaConstant = 600.0;
 
-// Ponanza constant used in the relation between evaluation value and winning percentage
-constexpr double kPonanzaConstant = 600.0;
+    // Class that represents one index of learning feature
+    class TrainingFeature {
+        using StorageType = std::uint32_t;
+        static_assert(std::is_unsigned<StorageType>::value, "");
 
-// Class that represents one index of learning feature
-class TrainingFeature {
-  using StorageType = std::uint32_t;
-  static_assert(std::is_unsigned<StorageType>::value, "");
+    public:
+        static constexpr std::uint32_t kIndexBits = 24;
 
- public:
-  static constexpr std::uint32_t kIndexBits = 24;
-  static_assert(kIndexBits < std::numeric_limits<StorageType>::digits, "");
-  static constexpr std::uint32_t kCountBits =
-      std::numeric_limits<StorageType>::digits - kIndexBits;
+        static_assert(kIndexBits < std::numeric_limits<StorageType>::digits, "");
 
-  explicit TrainingFeature(IndexType index) :
-      index_and_count_((index << kCountBits) | 1) {
-    assert(index < (1 << kIndexBits));
-  }
-  TrainingFeature& operator+=(const TrainingFeature& other) {
-    assert(other.GetIndex() == GetIndex());
-    assert(other.GetCount() + GetCount() < (1 << kCountBits));
-    index_and_count_ += other.GetCount();
-    return *this;
-  }
-  IndexType GetIndex() const {
-    return static_cast<IndexType>(index_and_count_ >> kCountBits);
-  }
-  void ShiftIndex(IndexType offset) {
-    assert(GetIndex() + offset < (1 << kIndexBits));
-    index_and_count_ += offset << kCountBits;
-  }
-  IndexType GetCount() const {
-    return static_cast<IndexType>(index_and_count_ & ((1 << kCountBits) - 1));
-  }
-  bool operator<(const TrainingFeature& other) const {
-    return index_and_count_ < other.index_and_count_;
-  }
+        static constexpr std::uint32_t kCountBits =
+            std::numeric_limits<StorageType>::digits - kIndexBits;
 
- private:
-  StorageType index_and_count_;
-};
+        explicit TrainingFeature(IndexType index) :
+            index_and_count_((index << kCountBits) | 1) {
 
-// Structure that represents one sample of training data
-struct Example {
-  std::vector<TrainingFeature> training_features[2];
-  Learner::PackedSfenValue psv;
-  int sign;
-  double weight;
-};
+            assert(index < (1 << kIndexBits));
+        }
 
-// Message used for setting hyperparameters
-struct Message {
-  Message(const std::string& message_name, const std::string& message_value = ""):
-      name(message_name), value(message_value), num_peekers(0), num_receivers(0) {}
-  const std::string name;
-  const std::string value;
-  std::uint32_t num_peekers;
-  std::uint32_t num_receivers;
-};
+        TrainingFeature& operator+=(const TrainingFeature& other) {
+            assert(other.GetIndex() == GetIndex());
+            assert(other.GetCount() + GetCount() < (1 << kCountBits));
+            index_and_count_ += other.GetCount();
+            return *this;
+        }
 
-// determine whether to accept the message
-bool ReceiveMessage(const std::string& name, Message* message) {
-  const auto subscript = "[" + std::to_string(message->num_peekers) + "]";
-  if (message->name.substr(0, name.size() + 1) == name + "[") {
-    ++message->num_peekers;
-  }
-  if (message->name == name || message->name == name + subscript) {
-    ++message->num_receivers;
-    return true;
-  }
-  return false;
-}
+        IndexType GetIndex() const {
+            return static_cast<IndexType>(index_and_count_ >> kCountBits);
+        }
 
-// split the string
-std::vector<std::string> Split(const std::string& input, char delimiter) {
-  std::istringstream stream(input);
-  std::string field;
-  std::vector<std::string> fields;
-  while (std::getline(stream, field, delimiter)) {
-    fields.push_back(field);
-  }
-  return fields;
-}
+        void ShiftIndex(IndexType offset) {
+            assert(GetIndex() + offset < (1 << kIndexBits));
+            index_and_count_ += offset << kCountBits;
+        }
 
-// round a floating point number to an integer
-template <typename IntType>
-IntType Round(double value) {
-  return static_cast<IntType>(std::floor(value + 0.5));
-}
+        IndexType GetCount() const {
+            return static_cast<IndexType>(index_and_count_ & ((1 << kCountBits) - 1));
+        }
 
-// make_shared with alignment
-template <typename T, typename... ArgumentTypes>
-std::shared_ptr<T> MakeAlignedSharedPtr(ArgumentTypes&&... arguments) {
-  const auto ptr = new(std_aligned_alloc(alignof(T), sizeof(T)))
-      T(std::forward<ArgumentTypes>(arguments)...);
-  return std::shared_ptr<T>(ptr, AlignedDeleter<T>());
-}
+        bool operator<(const TrainingFeature& other) const {
+            return index_and_count_ < other.index_and_count_;
+        }
 
-}  // namespace NNUE
+    private:
+        StorageType index_and_count_;
+    };
 
-}  // namespace Eval
+    // Structure that represents one sample of training data
+    struct Example {
+        std::vector<TrainingFeature> training_features[2];
+        Learner::PackedSfenValue psv;
+        int sign;
+        double weight;
+    };
+
+    // Message used for setting hyperparameters
+    struct Message {
+        Message(const std::string& message_name, const std::string& message_value = "") :
+            name(message_name), value(message_value), num_peekers(0), num_receivers(0)
+        {
+        }
+
+        const std::string name;
+        const std::string value;
+        std::uint32_t num_peekers;
+        std::uint32_t num_receivers;
+    };
+
+    // determine whether to accept the message
+    bool ReceiveMessage(const std::string& name, Message* message) {
+        const auto subscript = "[" + std::to_string(message->num_peekers) + "]";
+
+        if (message->name.substr(0, name.size() + 1) == name + "[") {
+            ++message->num_peekers;
+        }
+
+        if (message->name == name || message->name == name + subscript) {
+            ++message->num_receivers;
+            return true;
+        }
+
+        return false;
+    }
+
+    // split the string
+    std::vector<std::string> Split(const std::string& input, char delimiter) {
+        std::istringstream stream(input);
+        std::string field;
+        std::vector<std::string> fields;
+
+        while (std::getline(stream, field, delimiter)) {
+            fields.push_back(field);
+        }
+
+        return fields;
+    }
+
+    // round a floating point number to an integer
+    template <typename IntType>
+    IntType Round(double value) {
+        return static_cast<IntType>(std::floor(value + 0.5));
+    }
+
+    // make_shared with alignment
+    template <typename T, typename... ArgumentTypes>
+    std::shared_ptr<T> MakeAlignedSharedPtr(ArgumentTypes&&... arguments) {
+        const auto ptr = new(std_aligned_alloc(alignof(T), sizeof(T)))
+            T(std::forward<ArgumentTypes>(arguments)...);
+
+        return std::shared_ptr<T>(ptr, AlignedDeleter<T>());
+    }
+
+}  // namespace Eval::NNUE
 
 #endif

--- a/src/nnue/trainer/trainer.h
+++ b/src/nnue/trainer/trainer.h
@@ -37,22 +37,22 @@ namespace Eval::NNUE {
         }
 
         TrainingFeature& operator+=(const TrainingFeature& other) {
-            assert(other.GetIndex() == GetIndex());
-            assert(other.GetCount() + GetCount() < (1 << kCountBits));
-            index_and_count_ += other.GetCount();
+            assert(other.get_index() == get_index());
+            assert(other.get_index() + get_count() < (1 << kCountBits));
+            index_and_count_ += other.get_count();
             return *this;
         }
 
-        IndexType GetIndex() const {
+        IndexType get_index() const {
             return static_cast<IndexType>(index_and_count_ >> kCountBits);
         }
 
-        void ShiftIndex(IndexType offset) {
-            assert(GetIndex() + offset < (1 << kIndexBits));
+        void shift_index(IndexType offset) {
+            assert(get_index() + offset < (1 << kIndexBits));
             index_and_count_ += offset << kCountBits;
         }
 
-        IndexType GetCount() const {
+        IndexType get_count() const {
             return static_cast<IndexType>(index_and_count_ & ((1 << kCountBits) - 1));
         }
 
@@ -86,7 +86,7 @@ namespace Eval::NNUE {
     };
 
     // determine whether to accept the message
-    bool ReceiveMessage(const std::string& name, Message* message) {
+    bool receive_message(const std::string& name, Message* message) {
         const auto subscript = "[" + std::to_string(message->num_peekers) + "]";
 
         if (message->name.substr(0, name.size() + 1) == name + "[") {
@@ -101,28 +101,15 @@ namespace Eval::NNUE {
         return false;
     }
 
-    // split the string
-    std::vector<std::string> Split(const std::string& input, char delimiter) {
-        std::istringstream stream(input);
-        std::string field;
-        std::vector<std::string> fields;
-
-        while (std::getline(stream, field, delimiter)) {
-            fields.push_back(field);
-        }
-
-        return fields;
-    }
-
     // round a floating point number to an integer
     template <typename IntType>
-    IntType Round(double value) {
+    IntType round(double value) {
         return static_cast<IntType>(std::floor(value + 0.5));
     }
 
     // make_shared with alignment
     template <typename T, typename... ArgumentTypes>
-    std::shared_ptr<T> MakeAlignedSharedPtr(ArgumentTypes&&... arguments) {
+    std::shared_ptr<T> make_aligned_shared_ptr(ArgumentTypes&&... arguments) {
         const auto ptr = new(std_aligned_alloc(alignof(T), sizeof(T)))
             T(std::forward<ArgumentTypes>(arguments)...);
 

--- a/src/nnue/trainer/trainer_affine_transform.h
+++ b/src/nnue/trainer/trainer_affine_transform.h
@@ -1,297 +1,329 @@
-﻿// Specialization of NNUE evaluation function learning class template for AffineTransform
-
-#ifndef _NNUE_TRAINER_AFFINE_TRANSFORM_H_
+﻿#ifndef _NNUE_TRAINER_AFFINE_TRANSFORM_H_
 #define _NNUE_TRAINER_AFFINE_TRANSFORM_H_
 
-#include "../../learn/learn.h"
-#include "../layers/affine_transform.h"
 #include "trainer.h"
+
+#include "learn/learn.h"
+
+#include "nnue/layers/affine_transform.h"
 
 #include <random>
 
-namespace Eval {
+// Specialization of NNUE evaluation function learning class template for AffineTransform
+namespace Eval::NNUE {
 
-namespace NNUE {
+    // Learning: Affine transformation layer
+    template <typename PreviousLayer, IndexType OutputDimensions>
+    class Trainer<Layers::AffineTransform<PreviousLayer, OutputDimensions>> {
+    private:
+        // Type of layer to learn
+        using LayerType = Layers::AffineTransform<PreviousLayer, OutputDimensions>;
 
-// Learning: Affine transformation layer
-template <typename PreviousLayer, IndexType OutputDimensions>
-class Trainer<Layers::AffineTransform<PreviousLayer, OutputDimensions>> {
- private:
-  // Type of layer to learn
-  using LayerType = Layers::AffineTransform<PreviousLayer, OutputDimensions>;
+    public:
+        // factory function
+        static std::shared_ptr<Trainer> Create(
+            LayerType* target_layer, FeatureTransformer* ft) {
 
- public:
-  // factory function
-  static std::shared_ptr<Trainer> Create(
-      LayerType* target_layer, FeatureTransformer* ft) {
-    return std::shared_ptr<Trainer>(
-        new Trainer(target_layer, ft));
-  }
-
-  // Set options such as hyperparameters
-  void SendMessage(Message* message) {
-    previous_layer_trainer_->SendMessage(message);
-    if (ReceiveMessage("momentum", message)) {
-      momentum_ = static_cast<LearnFloatType>(std::stod(message->value));
-    }
-    if (ReceiveMessage("learning_rate_scale", message)) {
-      learning_rate_scale_ =
-          static_cast<LearnFloatType>(std::stod(message->value));
-    }
-    if (ReceiveMessage("reset", message)) {
-      DequantizeParameters();
-    }
-    if (ReceiveMessage("quantize_parameters", message)) {
-      QuantizeParameters();
-    }
-  }
-
-  // Initialize the parameters with random numbers
-  template <typename RNG>
-  void Initialize(RNG& rng) {
-    previous_layer_trainer_->Initialize(rng);
-    if (kIsOutputLayer) {
-      // Initialize output layer with 0
-      std::fill(std::begin(biases_), std::end(biases_),
-                static_cast<LearnFloatType>(0.0));
-      std::fill(std::begin(weights_), std::end(weights_),
-                static_cast<LearnFloatType>(0.0));
-    } else {
-      // Assuming that the input distribution is unit-mean 0.5, equal variance,
-      // Initialize the output distribution so that each unit has a mean of 0.5 and the same variance as the input
-      const double kSigma = 1.0 / std::sqrt(kInputDimensions);
-      auto distribution = std::normal_distribution<double>(0.0, kSigma);
-      for (IndexType i = 0; i < kOutputDimensions; ++i) {
-        double sum = 0.0;
-        for (IndexType j = 0; j < kInputDimensions; ++j) {
-          const auto weight = static_cast<LearnFloatType>(distribution(rng));
-          weights_[kInputDimensions * i + j] = weight;
-          sum += weight;
+            return std::shared_ptr<Trainer>(
+                new Trainer(target_layer, ft));
         }
-        biases_[i] = static_cast<LearnFloatType>(0.5 - 0.5 * sum);
-      }
-    }
-    QuantizeParameters();
-  }
 
-  // forward propagation
-  const LearnFloatType* Propagate(const std::vector<Example>& batch) {
-    if (output_.size() < kOutputDimensions * batch.size()) {
-      output_.resize(kOutputDimensions * batch.size());
-      gradients_.resize(kInputDimensions * batch.size());
-    }
-    batch_size_ = static_cast<IndexType>(batch.size());
-    batch_input_ = previous_layer_trainer_->Propagate(batch);
+        // Set options such as hyperparameters
+        void SendMessage(Message* message) {
+            previous_layer_trainer_->SendMessage(message);
+
+            if (ReceiveMessage("momentum", message)) {
+                momentum_ = static_cast<LearnFloatType>(std::stod(message->value));
+            }
+
+            if (ReceiveMessage("learning_rate_scale", message)) {
+                learning_rate_scale_ =
+                    static_cast<LearnFloatType>(std::stod(message->value));
+            }
+
+            if (ReceiveMessage("reset", message)) {
+                DequantizeParameters();
+            }
+
+            if (ReceiveMessage("quantize_parameters", message)) {
+                QuantizeParameters();
+            }
+        }
+
+        // Initialize the parameters with random numbers
+        template <typename RNG>
+        void Initialize(RNG& rng) {
+            previous_layer_trainer_->Initialize(rng);
+
+            if (kIsOutputLayer) {
+                // Initialize output layer with 0
+                std::fill(std::begin(biases_), std::end(biases_),
+                          static_cast<LearnFloatType>(0.0));
+                std::fill(std::begin(weights_), std::end(weights_),
+                          static_cast<LearnFloatType>(0.0));
+            }
+            else {
+                // Assuming that the input distribution is unit-mean 0.5, equal variance,
+                // Initialize the output distribution so that each unit has a mean of 0.5 and the same variance as the input
+                const double kSigma = 1.0 / std::sqrt(kInputDimensions);
+                auto distribution = std::normal_distribution<double>(0.0, kSigma);
+
+                for (IndexType i = 0; i < kOutputDimensions; ++i) {
+                    double sum = 0.0;
+                      for (IndexType j = 0; j < kInputDimensions; ++j) {
+                          const auto weight = static_cast<LearnFloatType>(distribution(rng));
+                          weights_[kInputDimensions * i + j] = weight;
+                          sum += weight;
+                      }
+
+                    biases_[i] = static_cast<LearnFloatType>(0.5 - 0.5 * sum);
+                }
+            }
+
+            QuantizeParameters();
+        }
+
+        // forward propagation
+        const LearnFloatType* Propagate(const std::vector<Example>& batch) {
+            if (output_.size() < kOutputDimensions * batch.size()) {
+                output_.resize(kOutputDimensions * batch.size());
+                gradients_.resize(kInputDimensions * batch.size());
+            }
+
+            batch_size_ = static_cast<IndexType>(batch.size());
+            batch_input_ = previous_layer_trainer_->Propagate(batch);
 #if defined(USE_BLAS)
-    for (IndexType b = 0; b < batch_size_; ++b) {
-      const IndexType batch_offset = kOutputDimensions * b;
-      cblas_scopy(kOutputDimensions, biases_, 1, &output_[batch_offset], 1);
-    }
-    cblas_sgemm(CblasColMajor, CblasTrans, CblasNoTrans,
-                kOutputDimensions, batch_size_, kInputDimensions, 1.0,
-                weights_, kInputDimensions,
-                batch_input_, kInputDimensions,
-                1.0, &output_[0], kOutputDimensions);
-#else
-    for (IndexType b = 0; b < batch_size_; ++b) {
-      const IndexType input_batch_offset = kInputDimensions * b;
-      const IndexType output_batch_offset = kOutputDimensions * b;
-      for (IndexType i = 0; i < kOutputDimensions; ++i) {
-        double sum = biases_[i];
-        for (IndexType j = 0; j < kInputDimensions; ++j) {
-          const IndexType index = kInputDimensions * i + j;
-          sum += weights_[index] * batch_input_[input_batch_offset + j];
-        }
-        output_[output_batch_offset + i] = static_cast<LearnFloatType>(sum);
-      }
-    }
-#endif
-    return output_.data();
-  }
+            for (IndexType b = 0; b < batch_size_; ++b) {
+                const IndexType batch_offset = kOutputDimensions * b;
+                cblas_scopy(kOutputDimensions, biases_, 1, &output_[batch_offset], 1);
+            }
 
-  // backpropagation
-  void Backpropagate(const LearnFloatType* gradients,
-                     LearnFloatType learning_rate) {
-    const LearnFloatType local_learning_rate =
-        learning_rate * learning_rate_scale_;
+            cblas_sgemm(CblasColMajor, CblasTrans, CblasNoTrans,
+                        kOutputDimensions, batch_size_, kInputDimensions, 1.0,
+                        weights_, kInputDimensions,
+                        batch_input_, kInputDimensions,
+                        1.0, &output_[0], kOutputDimensions);
+#else
+            for (IndexType b = 0; b < batch_size_; ++b) {
+                const IndexType input_batch_offset = kInputDimensions * b;
+                const IndexType output_batch_offset = kOutputDimensions * b;
+                for (IndexType i = 0; i < kOutputDimensions; ++i) {
+                    double sum = biases_[i];
+                    for (IndexType j = 0; j < kInputDimensions; ++j) {
+                        const IndexType index = kInputDimensions * i + j;
+                        sum += weights_[index] * batch_input_[input_batch_offset + j];
+                    }
+
+                    output_[output_batch_offset + i] = static_cast<LearnFloatType>(sum);
+                }
+            }
+
+#endif
+            return output_.data();
+        }
+
+        // backpropagation
+        void Backpropagate(const LearnFloatType* gradients,
+                           LearnFloatType learning_rate) {
+
+            const LearnFloatType local_learning_rate =
+                learning_rate * learning_rate_scale_;
+
 #if defined(USE_BLAS)
-    // backpropagate
-    cblas_sgemm(CblasColMajor, CblasNoTrans, CblasNoTrans,
-                kInputDimensions, batch_size_, kOutputDimensions, 1.0,
-                weights_, kInputDimensions,
-                gradients, kOutputDimensions,
-                0.0, &gradients_[0], kInputDimensions);
-    // update
-    cblas_sscal(kOutputDimensions, momentum_, biases_diff_, 1);
-    for (IndexType b = 0; b < batch_size_; ++b) {
-      const IndexType batch_offset = kOutputDimensions * b;
-      cblas_saxpy(kOutputDimensions, 1.0,
-                  &gradients[batch_offset], 1, biases_diff_, 1);
-    }
-    cblas_saxpy(kOutputDimensions, -local_learning_rate,
-                biases_diff_, 1, biases_, 1);
-    cblas_sgemm(CblasRowMajor, CblasTrans, CblasNoTrans,
-                kOutputDimensions, kInputDimensions, batch_size_, 1.0,
-                gradients, kOutputDimensions,
-                batch_input_, kInputDimensions,
-                momentum_, weights_diff_, kInputDimensions);
-    cblas_saxpy(kOutputDimensions * kInputDimensions, -local_learning_rate,
-                weights_diff_, 1, weights_, 1);
+            // backpropagate
+            cblas_sgemm(CblasColMajor, CblasNoTrans, CblasNoTrans,
+                        kInputDimensions, batch_size_, kOutputDimensions, 1.0,
+                        weights_, kInputDimensions,
+                        gradients, kOutputDimensions,
+                        0.0, &gradients_[0], kInputDimensions);
+
+            // update
+            cblas_sscal(kOutputDimensions, momentum_, biases_diff_, 1);
+            for (IndexType b = 0; b < batch_size_; ++b) {
+                const IndexType batch_offset = kOutputDimensions * b;
+                cblas_saxpy(kOutputDimensions, 1.0,
+                          &gradients[batch_offset], 1, biases_diff_, 1);
+            }
+
+            cblas_saxpy(kOutputDimensions, -local_learning_rate,
+                        biases_diff_, 1, biases_, 1);
+
+            cblas_sgemm(CblasRowMajor, CblasTrans, CblasNoTrans,
+                        kOutputDimensions, kInputDimensions, batch_size_, 1.0,
+                        gradients, kOutputDimensions,
+                        batch_input_, kInputDimensions,
+                        momentum_, weights_diff_, kInputDimensions);
+            cblas_saxpy(kOutputDimensions * kInputDimensions, -local_learning_rate,
+                        weights_diff_, 1, weights_, 1);
+
 #else
-    // backpropagate
-    for (IndexType b = 0; b < batch_size_; ++b) {
-      const IndexType input_batch_offset = kInputDimensions * b;
-      const IndexType output_batch_offset = kOutputDimensions * b;
-      for (IndexType j = 0; j < kInputDimensions; ++j) {
-        double sum = 0.0;
-        for (IndexType i = 0; i < kOutputDimensions; ++i) {
-          const IndexType index = kInputDimensions * i + j;
-          sum += weights_[index] * gradients[output_batch_offset + i];
-        }
-        gradients_[input_batch_offset + j] = static_cast<LearnFloatType>(sum);
-      }
-    }
-    // update
-    for (IndexType i = 0; i < kOutputDimensions; ++i) {
-      biases_diff_[i] *= momentum_;
-    }
-    for (IndexType i = 0; i < kOutputDimensions * kInputDimensions; ++i) {
-      weights_diff_[i] *= momentum_;
-    }
-    for (IndexType b = 0; b < batch_size_; ++b) {
-      const IndexType input_batch_offset = kInputDimensions * b;
-      const IndexType output_batch_offset = kOutputDimensions * b;
-      for (IndexType i = 0; i < kOutputDimensions; ++i) {
-        biases_diff_[i] += gradients[output_batch_offset + i];
-      }
-      for (IndexType i = 0; i < kOutputDimensions; ++i) {
-        for (IndexType j = 0; j < kInputDimensions; ++j) {
-          const IndexType index = kInputDimensions * i + j;
-          weights_diff_[index] += gradients[output_batch_offset + i] *
-              batch_input_[input_batch_offset + j];
-        }
-      }
-    }
-    for (IndexType i = 0; i < kOutputDimensions; ++i) {
-      biases_[i] -= local_learning_rate * biases_diff_[i];
-    }
-    for (IndexType i = 0; i < kOutputDimensions * kInputDimensions; ++i) {
-      weights_[i] -= local_learning_rate * weights_diff_[i];
-    }
+            // backpropagate
+            for (IndexType b = 0; b < batch_size_; ++b) {
+                const IndexType input_batch_offset = kInputDimensions * b;
+                const IndexType output_batch_offset = kOutputDimensions * b;
+                for (IndexType j = 0; j < kInputDimensions; ++j) {
+                    double sum = 0.0;
+                    for (IndexType i = 0; i < kOutputDimensions; ++i) {
+                        const IndexType index = kInputDimensions * i + j;
+                        sum += weights_[index] * gradients[output_batch_offset + i];
+                    }
+                    gradients_[input_batch_offset + j] = static_cast<LearnFloatType>(sum);
+                }
+            }
+
+            // update
+            for (IndexType i = 0; i < kOutputDimensions; ++i) {
+                biases_diff_[i] *= momentum_;
+            }
+
+            for (IndexType i = 0; i < kOutputDimensions * kInputDimensions; ++i) {
+                weights_diff_[i] *= momentum_;
+            }
+
+            for (IndexType b = 0; b < batch_size_; ++b) {
+                const IndexType input_batch_offset = kInputDimensions * b;
+                const IndexType output_batch_offset = kOutputDimensions * b;
+
+                for (IndexType i = 0; i < kOutputDimensions; ++i) {
+                    biases_diff_[i] += gradients[output_batch_offset + i];
+                }
+
+                for (IndexType i = 0; i < kOutputDimensions; ++i) {
+                    for (IndexType j = 0; j < kInputDimensions; ++j) {
+                        const IndexType index = kInputDimensions * i + j;
+                        weights_diff_[index] += gradients[output_batch_offset + i] *
+                            batch_input_[input_batch_offset + j];
+                    }
+                }
+            }
+
+            for (IndexType i = 0; i < kOutputDimensions; ++i) {
+                biases_[i] -= local_learning_rate * biases_diff_[i];
+            }
+
+            for (IndexType i = 0; i < kOutputDimensions * kInputDimensions; ++i) {
+                weights_[i] -= local_learning_rate * weights_diff_[i];
+            }
+
 #endif
-    previous_layer_trainer_->Backpropagate(gradients_.data(), learning_rate);
-  }
+            previous_layer_trainer_->Backpropagate(gradients_.data(), learning_rate);
+        }
 
- private:
-  // constructor
-  Trainer(LayerType* target_layer, FeatureTransformer* ft) :
-      batch_size_(0),
-      batch_input_(nullptr),
-      previous_layer_trainer_(Trainer<PreviousLayer>::Create(
-          &target_layer->previous_layer_, ft)),
-      target_layer_(target_layer),
-      biases_(),
-      weights_(),
-      biases_diff_(),
-      weights_diff_(),
-      momentum_(0.2),
-      learning_rate_scale_(1.0) {
-    DequantizeParameters();
-  }
+    private:
+        // constructor
+        Trainer(LayerType* target_layer, FeatureTransformer* ft) :
+            batch_size_(0),
+            batch_input_(nullptr),
+            previous_layer_trainer_(Trainer<PreviousLayer>::Create(
+                &target_layer->previous_layer_, ft)),
+            target_layer_(target_layer),
+            biases_(),
+            weights_(),
+            biases_diff_(),
+            weights_diff_(),
+            momentum_(0.2),
+            learning_rate_scale_(1.0) {
 
-  // Weight saturation and parameterization
-  void QuantizeParameters() {
-    for (IndexType i = 0; i < kOutputDimensions * kInputDimensions; ++i) {
-      weights_[i] = std::max(-kMaxWeightMagnitude,
-                             std::min(+kMaxWeightMagnitude, weights_[i]));
-    }
-    for (IndexType i = 0; i < kOutputDimensions; ++i) {
-      target_layer_->biases_[i] =
-          Round<typename LayerType::BiasType>(biases_[i] * kBiasScale);
-    }
-    for (IndexType i = 0; i < kOutputDimensions; ++i) {
-      const auto offset = kInputDimensions * i;
-      const auto padded_offset = LayerType::kPaddedInputDimensions * i;
-      for (IndexType j = 0; j < kInputDimensions; ++j) {
-        target_layer_->weights_[padded_offset + j] =
-            Round<typename LayerType::WeightType>(
-                weights_[offset + j] * kWeightScale);
-      }
-    }
-  }
+            DequantizeParameters();
+        }
 
-  // read parameterized integer
-  void DequantizeParameters() {
-    for (IndexType i = 0; i < kOutputDimensions; ++i) {
-      biases_[i] = static_cast<LearnFloatType>(
-          target_layer_->biases_[i] / kBiasScale);
-    }
-    for (IndexType i = 0; i < kOutputDimensions; ++i) {
-      const auto offset = kInputDimensions * i;
-      const auto padded_offset = LayerType::kPaddedInputDimensions * i;
-      for (IndexType j = 0; j < kInputDimensions; ++j) {
-        weights_[offset + j] = static_cast<LearnFloatType>(
-            target_layer_->weights_[padded_offset + j] / kWeightScale);
-      }
-    }
-    std::fill(std::begin(biases_diff_), std::end(biases_diff_),
-              static_cast<LearnFloatType>(0.0));
-    std::fill(std::begin(weights_diff_), std::end(weights_diff_),
-              static_cast<LearnFloatType>(0.0));
-  }
+        // Weight saturation and parameterization
+        void QuantizeParameters() {
+            for (IndexType i = 0; i < kOutputDimensions * kInputDimensions; ++i) {
+                weights_[i] = std::max(-kMaxWeightMagnitude,
+                                       std::min(+kMaxWeightMagnitude, weights_[i]));
+            }
 
-  // number of input/output dimensions
-  static constexpr IndexType kInputDimensions = LayerType::kInputDimensions;
-  static constexpr IndexType kOutputDimensions = LayerType::kOutputDimensions;
+            for (IndexType i = 0; i < kOutputDimensions; ++i) {
+                target_layer_->biases_[i] =
+                    Round<typename LayerType::BiasType>(biases_[i] * kBiasScale);
+            }
 
-  // If the output dimensionality is 1, the output layer
-  static constexpr bool kIsOutputLayer = kOutputDimensions == 1;
+            for (IndexType i = 0; i < kOutputDimensions; ++i) {
+                const auto offset = kInputDimensions * i;
+                const auto padded_offset = LayerType::kPaddedInputDimensions * i;
+                for (IndexType j = 0; j < kInputDimensions; ++j) {
+                    target_layer_->weights_[padded_offset + j] =
+                        Round<typename LayerType::WeightType>(
+                            weights_[offset + j] * kWeightScale);
+                }
+            }
+        }
 
-  // Coefficient used for parameterization
-  static constexpr LearnFloatType kActivationScale =
-      std::numeric_limits<std::int8_t>::max();
-  static constexpr LearnFloatType kBiasScale = kIsOutputLayer ?
-      (kPonanzaConstant * FV_SCALE) :
-      ((1 << kWeightScaleBits) * kActivationScale);
-  static constexpr LearnFloatType kWeightScale = kBiasScale / kActivationScale;
+        // read parameterized integer
+        void DequantizeParameters() {
+            for (IndexType i = 0; i < kOutputDimensions; ++i) {
+                biases_[i] = static_cast<LearnFloatType>(
+                    target_layer_->biases_[i] / kBiasScale);
+            }
 
-  // Upper limit of absolute value of weight used to prevent overflow when parameterizing integers
-  static constexpr LearnFloatType kMaxWeightMagnitude =
-      std::numeric_limits<typename LayerType::WeightType>::max() / kWeightScale;
+            for (IndexType i = 0; i < kOutputDimensions; ++i) {
+                const auto offset = kInputDimensions * i;
+                const auto padded_offset = LayerType::kPaddedInputDimensions * i;
+                for (IndexType j = 0; j < kInputDimensions; ++j) {
+                    weights_[offset + j] = static_cast<LearnFloatType>(
+                        target_layer_->weights_[padded_offset + j] / kWeightScale);
+                }
+            }
 
-  // number of samples in mini-batch
-  IndexType batch_size_;
+            std::fill(std::begin(biases_diff_), std::end(biases_diff_),
+                      static_cast<LearnFloatType>(0.0));
+            std::fill(std::begin(weights_diff_), std::end(weights_diff_),
+                      static_cast<LearnFloatType>(0.0));
+        }
 
-  // Input mini batch
-  const LearnFloatType* batch_input_;
+        // number of input/output dimensions
+        static constexpr IndexType kInputDimensions = LayerType::kInputDimensions;
+        static constexpr IndexType kOutputDimensions = LayerType::kOutputDimensions;
 
-  // Trainer of the previous layer
-  const std::shared_ptr<Trainer<PreviousLayer>> previous_layer_trainer_;
+        // If the output dimensionality is 1, the output layer
+        static constexpr bool kIsOutputLayer = kOutputDimensions == 1;
 
-  // layer to learn
-  LayerType* const target_layer_;
+        // Coefficient used for parameterization
+        static constexpr LearnFloatType kActivationScale =
+            std::numeric_limits<std::int8_t>::max();
 
-  // parameter
-  LearnFloatType biases_[kOutputDimensions];
-  LearnFloatType weights_[kOutputDimensions * kInputDimensions];
+        static constexpr LearnFloatType kBiasScale = kIsOutputLayer ?
+            (kPonanzaConstant * FV_SCALE) :
+            ((1 << kWeightScaleBits) * kActivationScale);
 
-  // Buffer used for updating parameters
-  LearnFloatType biases_diff_[kOutputDimensions];
-  LearnFloatType weights_diff_[kOutputDimensions * kInputDimensions];
+        static constexpr LearnFloatType kWeightScale = kBiasScale / kActivationScale;
 
-  // Forward propagation buffer
-  std::vector<LearnFloatType> output_;
+        // Upper limit of absolute value of weight used to prevent overflow when parameterizing integers
+        static constexpr LearnFloatType kMaxWeightMagnitude =
+            std::numeric_limits<typename LayerType::WeightType>::max() / kWeightScale;
 
-  // buffer for back propagation
-  std::vector<LearnFloatType> gradients_;
+        // number of samples in mini-batch
+        IndexType batch_size_;
 
-  // hyper parameter
-  LearnFloatType momentum_;
-  LearnFloatType learning_rate_scale_;
-};
+        // Input mini batch
+        const LearnFloatType* batch_input_;
 
-}  // namespace NNUE
+        // Trainer of the previous layer
+        const std::shared_ptr<Trainer<PreviousLayer>> previous_layer_trainer_;
 
-}  // namespace Eval
+        // layer to learn
+        LayerType* const target_layer_;
+
+        // parameter
+        LearnFloatType biases_[kOutputDimensions];
+        LearnFloatType weights_[kOutputDimensions * kInputDimensions];
+
+        // Buffer used for updating parameters
+        LearnFloatType biases_diff_[kOutputDimensions];
+        LearnFloatType weights_diff_[kOutputDimensions * kInputDimensions];
+
+        // Forward propagation buffer
+        std::vector<LearnFloatType> output_;
+
+        // buffer for back propagation
+        std::vector<LearnFloatType> gradients_;
+
+        // hyper parameter
+        LearnFloatType momentum_;
+        LearnFloatType learning_rate_scale_;
+    };
+
+}  // namespace Eval::NNUE
 
 #endif

--- a/src/nnue/trainer/trainer_clipped_relu.h
+++ b/src/nnue/trainer/trainer_clipped_relu.h
@@ -19,7 +19,7 @@ namespace Eval::NNUE {
 
     public:
         // factory function
-        static std::shared_ptr<Trainer> Create(
+        static std::shared_ptr<Trainer> create(
             LayerType* target_layer, FeatureTransformer* ft) {
 
             return std::shared_ptr<Trainer>(
@@ -27,27 +27,27 @@ namespace Eval::NNUE {
         }
 
         // Set options such as hyperparameters
-        void SendMessage(Message* message) {
-            previous_layer_trainer_->SendMessage(message);
-            if (ReceiveMessage("check_health", message)) {
-                CheckHealth();
+        void send_message(Message* message) {
+            previous_layer_trainer_->send_message(message);
+            if (receive_message("check_health", message)) {
+                check_health();
             }
         }
 
         // Initialize the parameters with random numbers
         template <typename RNG>
-        void Initialize(RNG& rng) {
-            previous_layer_trainer_->Initialize(rng);
+        void initialize(RNG& rng) {
+            previous_layer_trainer_->initialize(rng);
         }
 
         // forward propagation
-        const LearnFloatType* Propagate(const std::vector<Example>& batch) {
+        const LearnFloatType* propagate(const std::vector<Example>& batch) {
             if (output_.size() < kOutputDimensions * batch.size()) {
               output_.resize(kOutputDimensions * batch.size());
               gradients_.resize(kInputDimensions * batch.size());
             }
 
-            const auto input = previous_layer_trainer_->Propagate(batch);
+            const auto input = previous_layer_trainer_->propagate(batch);
             batch_size_ = static_cast<IndexType>(batch.size());
             for (IndexType b = 0; b < batch_size_; ++b) {
                 const IndexType batch_offset = kOutputDimensions * b;
@@ -63,7 +63,7 @@ namespace Eval::NNUE {
         }
 
         // backpropagation
-        void Backpropagate(const LearnFloatType* gradients,
+        void backpropagate(const LearnFloatType* gradients,
                            LearnFloatType learning_rate) {
 
             for (IndexType b = 0; b < batch_size_; ++b) {
@@ -75,14 +75,14 @@ namespace Eval::NNUE {
                 }
             }
 
-            previous_layer_trainer_->Backpropagate(gradients_.data(), learning_rate);
+            previous_layer_trainer_->backpropagate(gradients_.data(), learning_rate);
         }
 
     private:
         // constructor
         Trainer(LayerType* target_layer, FeatureTransformer* ft) :
             batch_size_(0),
-            previous_layer_trainer_(Trainer<PreviousLayer>::Create(
+            previous_layer_trainer_(Trainer<PreviousLayer>::create(
                 &target_layer->previous_layer_, ft)),
             target_layer_(target_layer) {
 
@@ -93,7 +93,7 @@ namespace Eval::NNUE {
         }
 
         // Check if there are any problems with learning
-        void CheckHealth() {
+        void check_health() {
             const auto largest_min_activation = *std::max_element(
                 std::begin(min_activations_), std::end(min_activations_));
             const auto smallest_max_activation = *std::min_element(

--- a/src/nnue/trainer/trainer_clipped_relu.h
+++ b/src/nnue/trainer/trainer_clipped_relu.h
@@ -1,138 +1,142 @@
-﻿// Specialization of NNUE evaluation function learning class template for ClippedReLU
-
-#ifndef _NNUE_TRAINER_CLIPPED_RELU_H_
+﻿#ifndef _NNUE_TRAINER_CLIPPED_RELU_H_
 #define _NNUE_TRAINER_CLIPPED_RELU_H_
 
-#include "../../learn/learn.h"
-#include "../layers/clipped_relu.h"
 #include "trainer.h"
 
-namespace Eval {
+#include "learn/learn.h"
 
-namespace NNUE {
+#include "nnue/layers/clipped_relu.h"
 
-// Learning: Affine transformation layer
-template <typename PreviousLayer>
-class Trainer<Layers::ClippedReLU<PreviousLayer>> {
- private:
-  // Type of layer to learn
-  using LayerType = Layers::ClippedReLU<PreviousLayer>;
+// Specialization of NNUE evaluation function learning class template for ClippedReLU
+namespace Eval::NNUE {
 
- public:
-  // factory function
-  static std::shared_ptr<Trainer> Create(
-      LayerType* target_layer, FeatureTransformer* ft) {
-    return std::shared_ptr<Trainer>(
-        new Trainer(target_layer, ft));
-  }
+    // Learning: Affine transformation layer
+    template <typename PreviousLayer>
+    class Trainer<Layers::ClippedReLU<PreviousLayer>> {
+    private:
+        // Type of layer to learn
+        using LayerType = Layers::ClippedReLU<PreviousLayer>;
 
-  // Set options such as hyperparameters
-  void SendMessage(Message* message) {
-    previous_layer_trainer_->SendMessage(message);
-    if (ReceiveMessage("check_health", message)) {
-      CheckHealth();
-    }
-  }
+    public:
+        // factory function
+        static std::shared_ptr<Trainer> Create(
+            LayerType* target_layer, FeatureTransformer* ft) {
 
-  // Initialize the parameters with random numbers
-  template <typename RNG>
-  void Initialize(RNG& rng) {
-    previous_layer_trainer_->Initialize(rng);
-  }
+            return std::shared_ptr<Trainer>(
+                new Trainer(target_layer, ft));
+        }
 
-  // forward propagation
-  const LearnFloatType* Propagate(const std::vector<Example>& batch) {
-    if (output_.size() < kOutputDimensions * batch.size()) {
-      output_.resize(kOutputDimensions * batch.size());
-      gradients_.resize(kInputDimensions * batch.size());
-    }
-    const auto input = previous_layer_trainer_->Propagate(batch);
-    batch_size_ = static_cast<IndexType>(batch.size());
-    for (IndexType b = 0; b < batch_size_; ++b) {
-      const IndexType batch_offset = kOutputDimensions * b;
-      for (IndexType i = 0; i < kOutputDimensions; ++i) {
-        const IndexType index = batch_offset + i;
-        output_[index] = std::max(+kZero, std::min(+kOne, input[index]));
-        min_activations_[i] = std::min(min_activations_[i], output_[index]);
-        max_activations_[i] = std::max(max_activations_[i], output_[index]);
-      }
-    }
-    return output_.data();
-  }
+        // Set options such as hyperparameters
+        void SendMessage(Message* message) {
+            previous_layer_trainer_->SendMessage(message);
+            if (ReceiveMessage("check_health", message)) {
+                CheckHealth();
+            }
+        }
 
-  // backpropagation
-  void Backpropagate(const LearnFloatType* gradients,
-                     LearnFloatType learning_rate) {
-    for (IndexType b = 0; b < batch_size_; ++b) {
-      const IndexType batch_offset = kOutputDimensions * b;
-      for (IndexType i = 0; i < kOutputDimensions; ++i) {
-        const IndexType index = batch_offset + i;
-        gradients_[index] = gradients[index] *
-            (output_[index] > kZero) * (output_[index] < kOne);
-      }
-    }
-    previous_layer_trainer_->Backpropagate(gradients_.data(), learning_rate);
-  }
+        // Initialize the parameters with random numbers
+        template <typename RNG>
+        void Initialize(RNG& rng) {
+            previous_layer_trainer_->Initialize(rng);
+        }
 
- private:
-  // constructor
-  Trainer(LayerType* target_layer, FeatureTransformer* ft) :
-      batch_size_(0),
-      previous_layer_trainer_(Trainer<PreviousLayer>::Create(
-          &target_layer->previous_layer_, ft)),
-      target_layer_(target_layer) {
-    std::fill(std::begin(min_activations_), std::end(min_activations_),
-              std::numeric_limits<LearnFloatType>::max());
-    std::fill(std::begin(max_activations_), std::end(max_activations_),
-              std::numeric_limits<LearnFloatType>::lowest());
-  }
+        // forward propagation
+        const LearnFloatType* Propagate(const std::vector<Example>& batch) {
+            if (output_.size() < kOutputDimensions * batch.size()) {
+              output_.resize(kOutputDimensions * batch.size());
+              gradients_.resize(kInputDimensions * batch.size());
+            }
 
-  // Check if there are any problems with learning
-  void CheckHealth() {
-    const auto largest_min_activation = *std::max_element(
-        std::begin(min_activations_), std::end(min_activations_));
-    const auto smallest_max_activation = *std::min_element(
-        std::begin(max_activations_), std::end(max_activations_));
-    std::cout << "INFO: largest min activation = " << largest_min_activation
-              << ", smallest max activation = " << smallest_max_activation
-              << std::endl;
+            const auto input = previous_layer_trainer_->Propagate(batch);
+            batch_size_ = static_cast<IndexType>(batch.size());
+            for (IndexType b = 0; b < batch_size_; ++b) {
+                const IndexType batch_offset = kOutputDimensions * b;
+                for (IndexType i = 0; i < kOutputDimensions; ++i) {
+                    const IndexType index = batch_offset + i;
+                    output_[index] = std::max(+kZero, std::min(+kOne, input[index]));
+                    min_activations_[i] = std::min(min_activations_[i], output_[index]);
+                    max_activations_[i] = std::max(max_activations_[i], output_[index]);
+                }
+            }
 
-    std::fill(std::begin(min_activations_), std::end(min_activations_),
-              std::numeric_limits<LearnFloatType>::max());
-    std::fill(std::begin(max_activations_), std::end(max_activations_),
-              std::numeric_limits<LearnFloatType>::lowest());
-  }
+            return output_.data();
+        }
 
-  // number of input/output dimensions
-  static constexpr IndexType kInputDimensions = LayerType::kOutputDimensions;
-  static constexpr IndexType kOutputDimensions = LayerType::kOutputDimensions;
+        // backpropagation
+        void Backpropagate(const LearnFloatType* gradients,
+                           LearnFloatType learning_rate) {
 
-  // LearnFloatType constant
-  static constexpr LearnFloatType kZero = static_cast<LearnFloatType>(0.0);
-  static constexpr LearnFloatType kOne = static_cast<LearnFloatType>(1.0);
+            for (IndexType b = 0; b < batch_size_; ++b) {
+                const IndexType batch_offset = kOutputDimensions * b;
+                for (IndexType i = 0; i < kOutputDimensions; ++i) {
+                    const IndexType index = batch_offset + i;
+                    gradients_[index] = gradients[index] *
+                        (output_[index] > kZero) * (output_[index] < kOne);
+                }
+            }
 
-  // number of samples in mini-batch
-  IndexType batch_size_;
+            previous_layer_trainer_->Backpropagate(gradients_.data(), learning_rate);
+        }
 
-  // Trainer of the previous layer
-  const std::shared_ptr<Trainer<PreviousLayer>> previous_layer_trainer_;
+    private:
+        // constructor
+        Trainer(LayerType* target_layer, FeatureTransformer* ft) :
+            batch_size_(0),
+            previous_layer_trainer_(Trainer<PreviousLayer>::Create(
+                &target_layer->previous_layer_, ft)),
+            target_layer_(target_layer) {
 
-  // layer to learn
-  LayerType* const target_layer_;
+            std::fill(std::begin(min_activations_), std::end(min_activations_),
+                      std::numeric_limits<LearnFloatType>::max());
+            std::fill(std::begin(max_activations_), std::end(max_activations_),
+                      std::numeric_limits<LearnFloatType>::lowest());
+        }
 
-  // Forward propagation buffer
-  std::vector<LearnFloatType> output_;
+        // Check if there are any problems with learning
+        void CheckHealth() {
+            const auto largest_min_activation = *std::max_element(
+                std::begin(min_activations_), std::end(min_activations_));
+            const auto smallest_max_activation = *std::min_element(
+                std::begin(max_activations_), std::end(max_activations_));
 
-  // buffer for back propagation
-  std::vector<LearnFloatType> gradients_;
+            std::cout << "INFO: largest min activation = " << largest_min_activation
+                      << ", smallest max activation = " << smallest_max_activation
+                      << std::endl;
 
-  // Health check statistics
-  LearnFloatType min_activations_[kOutputDimensions];
-  LearnFloatType max_activations_[kOutputDimensions];
-};
+            std::fill(std::begin(min_activations_), std::end(min_activations_),
+                      std::numeric_limits<LearnFloatType>::max());
+            std::fill(std::begin(max_activations_), std::end(max_activations_),
+                      std::numeric_limits<LearnFloatType>::lowest());
+        }
 
-}  // namespace NNUE
+        // number of input/output dimensions
+        static constexpr IndexType kInputDimensions = LayerType::kOutputDimensions;
+        static constexpr IndexType kOutputDimensions = LayerType::kOutputDimensions;
 
-}  // namespace Eval
+        // LearnFloatType constant
+        static constexpr LearnFloatType kZero = static_cast<LearnFloatType>(0.0);
+        static constexpr LearnFloatType kOne = static_cast<LearnFloatType>(1.0);
+
+        // number of samples in mini-batch
+        IndexType batch_size_;
+
+        // Trainer of the previous layer
+        const std::shared_ptr<Trainer<PreviousLayer>> previous_layer_trainer_;
+
+        // layer to learn
+        LayerType* const target_layer_;
+
+        // Forward propagation buffer
+        std::vector<LearnFloatType> output_;
+
+        // buffer for back propagation
+        std::vector<LearnFloatType> gradients_;
+
+        // Health check statistics
+        LearnFloatType min_activations_[kOutputDimensions];
+        LearnFloatType max_activations_[kOutputDimensions];
+    };
+
+}  // namespace Eval::NNUE
 
 #endif

--- a/src/nnue/trainer/trainer_feature_transformer.h
+++ b/src/nnue/trainer/trainer_feature_transformer.h
@@ -1,12 +1,13 @@
-﻿// Specialization for feature transformer of learning class template of NNUE evaluation function
-
-#ifndef _NNUE_TRAINER_FEATURE_TRANSFORMER_H_
+﻿#ifndef _NNUE_TRAINER_FEATURE_TRANSFORMER_H_
 #define _NNUE_TRAINER_FEATURE_TRANSFORMER_H_
 
-#include "../../learn/learn.h"
-#include "../nnue_feature_transformer.h"
 #include "trainer.h"
+
 #include "features/factorizer_feature_set.h"
+
+#include "learn/learn.h"
+
+#include "nnue/nnue_feature_transformer.h"
 
 #include <array>
 #include <bitset>
@@ -18,356 +19,392 @@
 #include <omp.h>
 #endif
 
-namespace Eval {
+// Specialization for feature transformer of learning class template of NNUE evaluation function
+namespace Eval::NNUE {
 
-namespace NNUE {
+    // Learning: Input feature converter
+    template <>
+    class Trainer<FeatureTransformer> {
+    private:
+        // Type of layer to learn
+        using LayerType = FeatureTransformer;
 
-// Learning: Input feature converter
-template <>
-class Trainer<FeatureTransformer> {
- private:
-  // Type of layer to learn
-  using LayerType = FeatureTransformer;
+    public:
+        template <typename T>
+        friend struct AlignedDeleter;
 
- public:
-  template <typename T>
-  friend struct AlignedDeleter;
-  template <typename T, typename... ArgumentTypes>
-  friend std::shared_ptr<T> MakeAlignedSharedPtr(ArgumentTypes&&... arguments);
+        template <typename T, typename... ArgumentTypes>
+        friend std::shared_ptr<T> MakeAlignedSharedPtr(ArgumentTypes&&... arguments);
 
-  // factory function
-  static std::shared_ptr<Trainer> Create(LayerType* target_layer) {
-    return MakeAlignedSharedPtr<Trainer>(target_layer);
-  }
+        // factory function
+        static std::shared_ptr<Trainer> Create(LayerType* target_layer) {
+            return MakeAlignedSharedPtr<Trainer>(target_layer);
+        }
 
-  // Set options such as hyperparameters
-  void SendMessage(Message* message) {
-    if (ReceiveMessage("momentum", message)) {
-      momentum_ = static_cast<LearnFloatType>(std::stod(message->value));
-    }
-    if (ReceiveMessage("learning_rate_scale", message)) {
-      learning_rate_scale_ =
-          static_cast<LearnFloatType>(std::stod(message->value));
-    }
-    if (ReceiveMessage("reset", message)) {
-      DequantizeParameters();
-    }
-    if (ReceiveMessage("quantize_parameters", message)) {
-      QuantizeParameters();
-    }
-    if (ReceiveMessage("clear_unobserved_feature_weights", message)) {
-      ClearUnobservedFeatureWeights();
-    }
-    if (ReceiveMessage("check_health", message)) {
-      CheckHealth();
-    }
-  }
+        // Set options such as hyperparameters
+        void SendMessage(Message* message) {
+            if (ReceiveMessage("momentum", message)) {
+                momentum_ = static_cast<LearnFloatType>(std::stod(message->value));
+            }
 
-  // Initialize the parameters with random numbers
-  template <typename RNG>
-  void Initialize(RNG& rng) {
-    std::fill(std::begin(weights_), std::end(weights_), +kZero);
-    const double kSigma = 0.1 / std::sqrt(RawFeatures::kMaxActiveDimensions);
-    auto distribution = std::normal_distribution<double>(0.0, kSigma);
-    for (IndexType i = 0; i < kHalfDimensions * RawFeatures::kDimensions; ++i) {
-      const auto weight = static_cast<LearnFloatType>(distribution(rng));
-      weights_[i] = weight;
-    }
-    for (IndexType i = 0; i < kHalfDimensions; ++i) {
-      biases_[i] = static_cast<LearnFloatType>(0.5);
-    }
-    QuantizeParameters();
-  }
+            if (ReceiveMessage("learning_rate_scale", message)) {
+                learning_rate_scale_ =
+                    static_cast<LearnFloatType>(std::stod(message->value));
+            }
 
-  // forward propagation
-  const LearnFloatType* Propagate(const std::vector<Example>& batch) {
-    if (output_.size() < kOutputDimensions * batch.size()) {
-      output_.resize(kOutputDimensions * batch.size());
-      gradients_.resize(kOutputDimensions * batch.size());
-    }
-    batch_ = &batch;
-    // affine transform
+            if (ReceiveMessage("reset", message)) {
+                DequantizeParameters();
+            }
+
+            if (ReceiveMessage("quantize_parameters", message)) {
+                QuantizeParameters();
+            }
+
+            if (ReceiveMessage("clear_unobserved_feature_weights", message)) {
+                ClearUnobservedFeatureWeights();
+            }
+
+            if (ReceiveMessage("check_health", message)) {
+                CheckHealth();
+            }
+        }
+
+        // Initialize the parameters with random numbers
+        template <typename RNG>
+        void Initialize(RNG& rng) {
+            std::fill(std::begin(weights_), std::end(weights_), +kZero);
+
+            const double kSigma = 0.1 / std::sqrt(RawFeatures::kMaxActiveDimensions);
+            auto distribution = std::normal_distribution<double>(0.0, kSigma);
+
+            for (IndexType i = 0; i < kHalfDimensions * RawFeatures::kDimensions; ++i) {
+                const auto weight = static_cast<LearnFloatType>(distribution(rng));
+                weights_[i] = weight;
+            }
+
+            for (IndexType i = 0; i < kHalfDimensions; ++i) {
+                biases_[i] = static_cast<LearnFloatType>(0.5);
+            }
+
+            QuantizeParameters();
+        }
+
+        // forward propagation
+        const LearnFloatType* Propagate(const std::vector<Example>& batch) {
+            if (output_.size() < kOutputDimensions * batch.size()) {
+                output_.resize(kOutputDimensions * batch.size());
+                gradients_.resize(kOutputDimensions * batch.size());
+            }
+
+            batch_ = &batch;
+            // affine transform
 #pragma omp parallel for
-    for (IndexType b = 0; b < batch.size(); ++b) {
-      const IndexType batch_offset = kOutputDimensions * b;
-      for (IndexType c = 0; c < 2; ++c) {
-        const IndexType output_offset = batch_offset + kHalfDimensions * c;
+            for (IndexType b = 0; b < batch.size(); ++b) {
+                const IndexType batch_offset = kOutputDimensions * b;
+                for (IndexType c = 0; c < 2; ++c) {
+                    const IndexType output_offset = batch_offset + kHalfDimensions * c;
 #if defined(USE_BLAS)
-        cblas_scopy(kHalfDimensions, biases_, 1, &output_[output_offset], 1);
-        for (const auto& feature : batch[b].training_features[c]) {
-          const IndexType weights_offset = kHalfDimensions * feature.GetIndex();
-          cblas_saxpy(kHalfDimensions, (float)feature.GetCount(),
-                      &weights_[weights_offset], 1, &output_[output_offset], 1);
-        }
+                    cblas_scopy(kHalfDimensions, biases_, 1, &output_[output_offset], 1);
+                    for (const auto& feature : batch[b].training_features[c]) {
+                        const IndexType weights_offset = kHalfDimensions * feature.GetIndex();
+                        cblas_saxpy(kHalfDimensions, (float)feature.GetCount(),
+                                    &weights_[weights_offset], 1, &output_[output_offset], 1);
+                    }
 #else
-        for (IndexType i = 0; i < kHalfDimensions; ++i) {
-          output_[output_offset + i] = biases_[i];
-        }
-        for (const auto& feature : batch[b].training_features[c]) {
-          const IndexType weights_offset = kHalfDimensions * feature.GetIndex();
-          for (IndexType i = 0; i < kHalfDimensions; ++i) {
-            output_[output_offset + i] +=
-                feature.GetCount() * weights_[weights_offset + i];
-          }
-        }
+                    for (IndexType i = 0; i < kHalfDimensions; ++i) {
+                        output_[output_offset + i] = biases_[i];
+                    }
+                    for (const auto& feature : batch[b].training_features[c]) {
+                        const IndexType weights_offset = kHalfDimensions * feature.GetIndex();
+                        for (IndexType i = 0; i < kHalfDimensions; ++i) {
+                            output_[output_offset + i] +=
+                                feature.GetCount() * weights_[weights_offset + i];
+                        }
+                    }
 #endif
-      }
-    }
-    // clipped ReLU
-    for (IndexType b = 0; b < batch.size(); ++b) {
-      const IndexType batch_offset = kOutputDimensions * b;
-      for (IndexType i = 0; i < kOutputDimensions; ++i) {
-        const IndexType index = batch_offset + i;
-        min_pre_activation_ = std::min(min_pre_activation_, output_[index]);
-        max_pre_activation_ = std::max(max_pre_activation_, output_[index]);
-        output_[index] = std::max(+kZero, std::min(+kOne, output_[index]));
-        const IndexType t = i % kHalfDimensions;
-        min_activations_[t] = std::min(min_activations_[t], output_[index]);
-        max_activations_[t] = std::max(max_activations_[t], output_[index]);
-      }
-    }
-    return output_.data();
-  }
+                }
+            }
 
-  // backpropagation
-  void Backpropagate(const LearnFloatType* gradients,
-                     LearnFloatType learning_rate) {
-    const LearnFloatType local_learning_rate =
-        learning_rate * learning_rate_scale_;
-    for (IndexType b = 0; b < batch_->size(); ++b) {
-      const IndexType batch_offset = kOutputDimensions * b;
-      for (IndexType i = 0; i < kOutputDimensions; ++i) {
-        const IndexType index = batch_offset + i;
-        gradients_[index] = gradients[index] *
-            ((output_[index] > kZero) * (output_[index] < kOne));
-      }
-    }
-    // Since the weight matrix updates only the columns corresponding to the features that appeared in the input,
-    // Correct the learning rate and adjust the scale without using momentum
-    const LearnFloatType effective_learning_rate =
-        static_cast<LearnFloatType>(local_learning_rate / (1.0 - momentum_));
+            // clipped ReLU
+            for (IndexType b = 0; b < batch.size(); ++b) {
+                const IndexType batch_offset = kOutputDimensions * b;
+                for (IndexType i = 0; i < kOutputDimensions; ++i) {
+                    const IndexType index = batch_offset + i;
+                    min_pre_activation_ = std::min(min_pre_activation_, output_[index]);
+                    max_pre_activation_ = std::max(max_pre_activation_, output_[index]);
+                    output_[index] = std::max(+kZero, std::min(+kOne, output_[index]));
+                    const IndexType t = i % kHalfDimensions;
+                    min_activations_[t] = std::min(min_activations_[t], output_[index]);
+                    max_activations_[t] = std::max(max_activations_[t], output_[index]);
+                }
+            }
+
+            return output_.data();
+        }
+
+        // backpropagation
+        void Backpropagate(const LearnFloatType* gradients,
+                           LearnFloatType learning_rate) {
+
+            const LearnFloatType local_learning_rate =
+                learning_rate * learning_rate_scale_;
+
+            for (IndexType b = 0; b < batch_->size(); ++b) {
+                const IndexType batch_offset = kOutputDimensions * b;
+                for (IndexType i = 0; i < kOutputDimensions; ++i) {
+                    const IndexType index = batch_offset + i;
+                    gradients_[index] = gradients[index] *
+                        ((output_[index] > kZero) * (output_[index] < kOne));
+                }
+            }
+
+            // Since the weight matrix updates only the columns corresponding to the features that appeared in the input,
+            // Correct the learning rate and adjust the scale without using momentum
+            const LearnFloatType effective_learning_rate =
+                static_cast<LearnFloatType>(local_learning_rate / (1.0 - momentum_));
 #if defined(USE_BLAS)
-    cblas_sscal(kHalfDimensions, momentum_, biases_diff_, 1);
-    for (IndexType b = 0; b < batch_->size(); ++b) {
-      const IndexType batch_offset = kOutputDimensions * b;
-      for (IndexType c = 0; c < 2; ++c) {
-        const IndexType output_offset = batch_offset + kHalfDimensions * c;
-        cblas_saxpy(kHalfDimensions, 1.0,
-                    &gradients_[output_offset], 1, biases_diff_, 1);
-      }
-    }
-    cblas_saxpy(kHalfDimensions, -local_learning_rate,
-                biases_diff_, 1, biases_, 1);
+            cblas_sscal(kHalfDimensions, momentum_, biases_diff_, 1);
+            for (IndexType b = 0; b < batch_->size(); ++b) {
+                const IndexType batch_offset = kOutputDimensions * b;
+                for (IndexType c = 0; c < 2; ++c) {
+                    const IndexType output_offset = batch_offset + kHalfDimensions * c;
+                    cblas_saxpy(kHalfDimensions, 1.0,
+                                &gradients_[output_offset], 1, biases_diff_, 1);
+                }
+            }
+
+            cblas_saxpy(kHalfDimensions, -local_learning_rate,
+                        biases_diff_, 1, biases_, 1);
+
 #pragma omp parallel
-    {
+            {
 #if defined(_OPENMP)
-      const IndexType num_threads = omp_get_num_threads();
-      const IndexType thread_index = omp_get_thread_num();
+                const IndexType num_threads = omp_get_num_threads();
+                const IndexType thread_index = omp_get_thread_num();
 #endif
-      for (IndexType b = 0; b < batch_->size(); ++b) {
-        const IndexType batch_offset = kOutputDimensions * b;
-        for (IndexType c = 0; c < 2; ++c) {
-          const IndexType output_offset = batch_offset + kHalfDimensions * c;
-          for (const auto& feature : (*batch_)[b].training_features[c]) {
+                for (IndexType b = 0; b < batch_->size(); ++b) {
+                    const IndexType batch_offset = kOutputDimensions * b;
+                    for (IndexType c = 0; c < 2; ++c) {
+                        const IndexType output_offset = batch_offset + kHalfDimensions * c;
+                        for (const auto& feature : (*batch_)[b].training_features[c]) {
 #if defined(_OPENMP)
-            if (feature.GetIndex() % num_threads != thread_index) continue;
+                            if (feature.GetIndex() % num_threads != thread_index)
+                                continue;
 #endif
-            const IndexType weights_offset =
-                kHalfDimensions * feature.GetIndex();
-            const auto scale = static_cast<LearnFloatType>(
-                effective_learning_rate / feature.GetCount());
-            cblas_saxpy(kHalfDimensions, -scale,
-                        &gradients_[output_offset], 1,
-                        &weights_[weights_offset], 1);
-          }
-        }
-      }
-    }
+                            const IndexType weights_offset =
+                                kHalfDimensions * feature.GetIndex();
+                            const auto scale = static_cast<LearnFloatType>(
+                                effective_learning_rate / feature.GetCount());
+
+                            cblas_saxpy(kHalfDimensions, -scale,
+                                        &gradients_[output_offset], 1,
+                                        &weights_[weights_offset], 1);
+                        }
+                    }
+                }
+            }
+
 #else
-    for (IndexType i = 0; i < kHalfDimensions; ++i) {
-      biases_diff_[i] *= momentum_;
-    }
-    for (IndexType b = 0; b < batch_->size(); ++b) {
-      const IndexType batch_offset = kOutputDimensions * b;
-      for (IndexType c = 0; c < 2; ++c) {
-        const IndexType output_offset = batch_offset + kHalfDimensions * c;
-        for (IndexType i = 0; i < kHalfDimensions; ++i) {
-          biases_diff_[i] += gradients_[output_offset + i];
-        }
-      }
-    }
-    for (IndexType i = 0; i < kHalfDimensions; ++i) {
-      biases_[i] -= local_learning_rate * biases_diff_[i];
-    }
-    for (IndexType b = 0; b < batch_->size(); ++b) {
-      const IndexType batch_offset = kOutputDimensions * b;
-      for (IndexType c = 0; c < 2; ++c) {
-        const IndexType output_offset = batch_offset + kHalfDimensions * c;
-        for (const auto& feature : (*batch_)[b].training_features[c]) {
-          const IndexType weights_offset = kHalfDimensions * feature.GetIndex();
-          const auto scale = static_cast<LearnFloatType>(
-              effective_learning_rate / feature.GetCount());
-          for (IndexType i = 0; i < kHalfDimensions; ++i) {
-            weights_[weights_offset + i] -=
-                scale * gradients_[output_offset + i];
-          }
-        }
-      }
-    }
+            for (IndexType i = 0; i < kHalfDimensions; ++i) {
+                biases_diff_[i] *= momentum_;
+            }
+
+            for (IndexType b = 0; b < batch_->size(); ++b) {
+                const IndexType batch_offset = kOutputDimensions * b;
+                for (IndexType c = 0; c < 2; ++c) {
+                    const IndexType output_offset = batch_offset + kHalfDimensions * c;
+                    for (IndexType i = 0; i < kHalfDimensions; ++i) {
+                        biases_diff_[i] += gradients_[output_offset + i];
+                    }
+                }
+            }
+
+            for (IndexType i = 0; i < kHalfDimensions; ++i) {
+                biases_[i] -= local_learning_rate * biases_diff_[i];
+            }
+
+            for (IndexType b = 0; b < batch_->size(); ++b) {
+                const IndexType batch_offset = kOutputDimensions * b;
+                for (IndexType c = 0; c < 2; ++c) {
+                    const IndexType output_offset = batch_offset + kHalfDimensions * c;
+                    for (const auto& feature : (*batch_)[b].training_features[c]) {
+                        const IndexType weights_offset = kHalfDimensions * feature.GetIndex();
+                        const auto scale = static_cast<LearnFloatType>(
+                            effective_learning_rate / feature.GetCount());
+
+                        for (IndexType i = 0; i < kHalfDimensions; ++i) {
+                            weights_[weights_offset + i] -=
+                                scale * gradients_[output_offset + i];
+                        }
+                    }
+                }
+            }
+
 #endif
-    for (IndexType b = 0; b < batch_->size(); ++b) {
-      for (IndexType c = 0; c < 2; ++c) {
-        for (const auto& feature : (*batch_)[b].training_features[c]) {
-          observed_features.set(feature.GetIndex());
+            for (IndexType b = 0; b < batch_->size(); ++b) {
+                for (IndexType c = 0; c < 2; ++c) {
+                    for (const auto& feature : (*batch_)[b].training_features[c]) {
+                        observed_features.set(feature.GetIndex());
+                    }
+                }
+            }
         }
-      }
-    }
-  }
 
- private:
-  // constructor
-  Trainer(LayerType* target_layer) :
-      batch_(nullptr),
-      target_layer_(target_layer),
-      biases_(),
-      weights_(),
-      biases_diff_(),
-      momentum_(0.2),
-      learning_rate_scale_(1.0) {
-    min_pre_activation_ = std::numeric_limits<LearnFloatType>::max();
-    max_pre_activation_ = std::numeric_limits<LearnFloatType>::lowest();
-    std::fill(std::begin(min_activations_), std::end(min_activations_),
-              std::numeric_limits<LearnFloatType>::max());
-    std::fill(std::begin(max_activations_), std::end(max_activations_),
-              std::numeric_limits<LearnFloatType>::lowest());
-    DequantizeParameters();
-  }
+    private:
+        // constructor
+        Trainer(LayerType* target_layer) :
+            batch_(nullptr),
+            target_layer_(target_layer),
+            biases_(),
+            weights_(),
+            biases_diff_(),
+            momentum_(0.2),
+            learning_rate_scale_(1.0) {
 
-  // Weight saturation and parameterization
-  void QuantizeParameters() {
-    for (IndexType i = 0; i < kHalfDimensions; ++i) {
-      target_layer_->biases_[i] =
-          Round<typename LayerType::BiasType>(biases_[i] * kBiasScale);
-    }
-    std::vector<TrainingFeature> training_features;
+            min_pre_activation_ = std::numeric_limits<LearnFloatType>::max();
+            max_pre_activation_ = std::numeric_limits<LearnFloatType>::lowest();
+
+            std::fill(std::begin(min_activations_), std::end(min_activations_),
+                      std::numeric_limits<LearnFloatType>::max());
+            std::fill(std::begin(max_activations_), std::end(max_activations_),
+                      std::numeric_limits<LearnFloatType>::lowest());
+
+            DequantizeParameters();
+        }
+
+        // Weight saturation and parameterization
+        void QuantizeParameters() {
+            for (IndexType i = 0; i < kHalfDimensions; ++i) {
+                target_layer_->biases_[i] =
+                    Round<typename LayerType::BiasType>(biases_[i] * kBiasScale);
+            }
+
+            std::vector<TrainingFeature> training_features;
+
 #pragma omp parallel for private(training_features)
-    for (IndexType j = 0; j < RawFeatures::kDimensions; ++j) {
-      training_features.clear();
-      Features::Factorizer<RawFeatures>::AppendTrainingFeatures(
-          j, &training_features);
-      for (IndexType i = 0; i < kHalfDimensions; ++i) {
-        double sum = 0.0;
-        for (const auto& feature : training_features) {
-          sum += weights_[kHalfDimensions * feature.GetIndex() + i];
+            for (IndexType j = 0; j < RawFeatures::kDimensions; ++j) {
+                training_features.clear();
+                Features::Factorizer<RawFeatures>::AppendTrainingFeatures(
+                    j, &training_features);
+
+                for (IndexType i = 0; i < kHalfDimensions; ++i) {
+                    double sum = 0.0;
+                    for (const auto& feature : training_features) {
+                        sum += weights_[kHalfDimensions * feature.GetIndex() + i];
+                    }
+
+                    target_layer_->weights_[kHalfDimensions * j + i] =
+                        Round<typename LayerType::WeightType>(sum * kWeightScale);
+                }
+            }
         }
-        target_layer_->weights_[kHalfDimensions * j + i] =
-            Round<typename LayerType::WeightType>(sum * kWeightScale);
-      }
-    }
-  }
 
-  // read parameterized integer
-  void DequantizeParameters() {
-    for (IndexType i = 0; i < kHalfDimensions; ++i) {
-      biases_[i] = static_cast<LearnFloatType>(
-          target_layer_->biases_[i] / kBiasScale);
-    }
-    std::fill(std::begin(weights_), std::end(weights_), +kZero);
-    for (IndexType i = 0; i < kHalfDimensions * RawFeatures::kDimensions; ++i) {
-      weights_[i] = static_cast<LearnFloatType>(
-          target_layer_->weights_[i] / kWeightScale);
-    }
-    std::fill(std::begin(biases_diff_), std::end(biases_diff_), +kZero);
-  }
+        // read parameterized integer
+        void DequantizeParameters() {
+            for (IndexType i = 0; i < kHalfDimensions; ++i) {
+                biases_[i] = static_cast<LearnFloatType>(
+                    target_layer_->biases_[i] / kBiasScale);
+            }
 
-  // Set the weight corresponding to the feature that does not appear in the learning data to 0
-  void ClearUnobservedFeatureWeights() {
-    for (IndexType i = 0; i < kInputDimensions; ++i) {
-      if (!observed_features.test(i)) {
-        std::fill(std::begin(weights_) + kHalfDimensions * i,
-                  std::begin(weights_) + kHalfDimensions * (i + 1), +kZero);
-      }
-    }
-    QuantizeParameters();
-  }
+            std::fill(std::begin(weights_), std::end(weights_), +kZero);
 
-  // Check if there are any problems with learning
-  void CheckHealth() {
-    std::cout << "INFO: observed " << observed_features.count()
-              << " (out of " << kInputDimensions << ") features" << std::endl;
+            for (IndexType i = 0; i < kHalfDimensions * RawFeatures::kDimensions; ++i) {
+                weights_[i] = static_cast<LearnFloatType>(
+                    target_layer_->weights_[i] / kWeightScale);
+            }
 
-    constexpr LearnFloatType kPreActivationLimit =
-        std::numeric_limits<typename LayerType::WeightType>::max() /
-        kWeightScale;
-    std::cout << "INFO: (min, max) of pre-activations = "
-              << min_pre_activation_ << ", "
-              << max_pre_activation_ << " (limit = "
-              << kPreActivationLimit << ")" << std::endl;
+            std::fill(std::begin(biases_diff_), std::end(biases_diff_), +kZero);
+        }
 
-    const auto largest_min_activation = *std::max_element(
-        std::begin(min_activations_), std::end(min_activations_));
-    const auto smallest_max_activation = *std::min_element(
-        std::begin(max_activations_), std::end(max_activations_));
-    std::cout << "INFO: largest min activation = " << largest_min_activation
-              << ", smallest max activation = " << smallest_max_activation
-              << std::endl;
+        // Set the weight corresponding to the feature that does not appear in the learning data to 0
+        void ClearUnobservedFeatureWeights() {
+            for (IndexType i = 0; i < kInputDimensions; ++i) {
+                if (!observed_features.test(i)) {
+                    std::fill(std::begin(weights_) + kHalfDimensions * i,
+                              std::begin(weights_) + kHalfDimensions * (i + 1), +kZero);
+                }
+            }
 
-    std::fill(std::begin(min_activations_), std::end(min_activations_),
-              std::numeric_limits<LearnFloatType>::max());
-    std::fill(std::begin(max_activations_), std::end(max_activations_),
-              std::numeric_limits<LearnFloatType>::lowest());
-  }
+            QuantizeParameters();
+        }
 
-  // number of input/output dimensions
-  static constexpr IndexType kInputDimensions =
-      Features::Factorizer<RawFeatures>::GetDimensions();
-  static constexpr IndexType kOutputDimensions = LayerType::kOutputDimensions;
-  static constexpr IndexType kHalfDimensions = LayerType::kHalfDimensions;
+        // Check if there are any problems with learning
+        void CheckHealth() {
+            std::cout << "INFO: observed " << observed_features.count()
+                      << " (out of " << kInputDimensions << ") features" << std::endl;
 
-  // Coefficient used for parameterization
-  static constexpr LearnFloatType kActivationScale =
-      std::numeric_limits<std::int8_t>::max();
-  static constexpr LearnFloatType kBiasScale = kActivationScale;
-  static constexpr LearnFloatType kWeightScale = kActivationScale;
+            constexpr LearnFloatType kPreActivationLimit =
+                std::numeric_limits<typename LayerType::WeightType>::max() /
+                kWeightScale;
 
-  // LearnFloatType constant
-  static constexpr LearnFloatType kZero = static_cast<LearnFloatType>(0.0);
-  static constexpr LearnFloatType kOne = static_cast<LearnFloatType>(1.0);
+            std::cout << "INFO: (min, max) of pre-activations = "
+                      << min_pre_activation_ << ", "
+                      << max_pre_activation_ << " (limit = "
+                      << kPreActivationLimit << ")" << std::endl;
 
-  // mini batch
-  const std::vector<Example>* batch_;
+            const auto largest_min_activation = *std::max_element(
+                std::begin(min_activations_), std::end(min_activations_));
+            const auto smallest_max_activation = *std::min_element(
+                std::begin(max_activations_), std::end(max_activations_));
 
-  // layer to learn
-  LayerType* const target_layer_;
+            std::cout << "INFO: largest min activation = " << largest_min_activation
+                      << ", smallest max activation = " << smallest_max_activation
+                      << std::endl;
 
-  // parameter
-  alignas(kCacheLineSize) LearnFloatType biases_[kHalfDimensions];
-  alignas(kCacheLineSize)
-      LearnFloatType weights_[kHalfDimensions * kInputDimensions];
+            std::fill(std::begin(min_activations_), std::end(min_activations_),
+                      std::numeric_limits<LearnFloatType>::max());
+            std::fill(std::begin(max_activations_), std::end(max_activations_),
+                      std::numeric_limits<LearnFloatType>::lowest());
+        }
 
-  // Buffer used for updating parameters
-  LearnFloatType biases_diff_[kHalfDimensions];
-  std::vector<LearnFloatType> gradients_;
+        // number of input/output dimensions
+        static constexpr IndexType kInputDimensions =
+            Features::Factorizer<RawFeatures>::GetDimensions();
+        static constexpr IndexType kOutputDimensions = LayerType::kOutputDimensions;
+        static constexpr IndexType kHalfDimensions = LayerType::kHalfDimensions;
 
-  // Forward propagation buffer
-  std::vector<LearnFloatType> output_;
+        // Coefficient used for parameterization
+        static constexpr LearnFloatType kActivationScale =
+            std::numeric_limits<std::int8_t>::max();
+        static constexpr LearnFloatType kBiasScale = kActivationScale;
+        static constexpr LearnFloatType kWeightScale = kActivationScale;
 
-  // Features that appeared in the training data
-  std::bitset<kInputDimensions> observed_features;
+        // LearnFloatType constant
+        static constexpr LearnFloatType kZero = static_cast<LearnFloatType>(0.0);
+        static constexpr LearnFloatType kOne = static_cast<LearnFloatType>(1.0);
 
-  // hyper parameter
-  LearnFloatType momentum_;
-  LearnFloatType learning_rate_scale_;
+        // mini batch
+        const std::vector<Example>* batch_;
 
-  // Health check statistics
-  LearnFloatType min_pre_activation_;
-  LearnFloatType max_pre_activation_;
-  LearnFloatType min_activations_[kHalfDimensions];
-  LearnFloatType max_activations_[kHalfDimensions];
-};
+        // layer to learn
+        LayerType* const target_layer_;
 
-}  // namespace NNUE
+        // parameter
+        alignas(kCacheLineSize) LearnFloatType biases_[kHalfDimensions];
+        alignas(kCacheLineSize)
+            LearnFloatType weights_[kHalfDimensions * kInputDimensions];
 
-}  // namespace Eval
+        // Buffer used for updating parameters
+        LearnFloatType biases_diff_[kHalfDimensions];
+        std::vector<LearnFloatType> gradients_;
+
+        // Forward propagation buffer
+        std::vector<LearnFloatType> output_;
+
+        // Features that appeared in the training data
+        std::bitset<kInputDimensions> observed_features;
+
+        // hyper parameter
+        LearnFloatType momentum_;
+        LearnFloatType learning_rate_scale_;
+
+        // Health check statistics
+        LearnFloatType min_pre_activation_;
+        LearnFloatType max_pre_activation_;
+        LearnFloatType min_activations_[kHalfDimensions];
+        LearnFloatType max_activations_[kHalfDimensions];
+    };
+
+}  // namespace Eval::NNUE
 
 #endif

--- a/src/nnue/trainer/trainer_feature_transformer.h
+++ b/src/nnue/trainer/trainer_feature_transformer.h
@@ -349,7 +349,7 @@ namespace Eval::NNUE {
 
             std::cout << "INFO: largest min activation = " << largest_min_activation
                       << ", smallest max activation = " << smallest_max_activation
-                      << std::endl;
+                      << std::endl << std::endl;
 
             std::fill(std::begin(min_activations_), std::end(min_activations_),
                       std::numeric_limits<LearnFloatType>::max());

--- a/src/nnue/trainer/trainer_sum.h
+++ b/src/nnue/trainer/trainer_sum.h
@@ -1,9 +1,11 @@
 ﻿#ifndef _NNUE_TRAINER_SUM_H_
 #define _NNUE_TRAINER_SUM_H_
 
-#include "../../learn/learn.h"
-#include "../layers/sum.h"
 #include "trainer.h"
+
+#include "learn/learn.h"
+
+#include "nnue/layers/sum.h"
 
 // Specialization of NNUE evaluation function learning class template for Sum
 namespace Eval::NNUE {

--- a/src/nnue/trainer/trainer_sum.h
+++ b/src/nnue/trainer/trainer_sum.h
@@ -1,186 +1,190 @@
-﻿// Specialization of NNUE evaluation function learning class template for Sum
-
-#ifndef _NNUE_TRAINER_SUM_H_
+﻿#ifndef _NNUE_TRAINER_SUM_H_
 #define _NNUE_TRAINER_SUM_H_
 
 #include "../../learn/learn.h"
 #include "../layers/sum.h"
 #include "trainer.h"
 
-namespace Eval {
+// Specialization of NNUE evaluation function learning class template for Sum
+namespace Eval::NNUE {
 
-namespace NNUE {
+    // Learning: A layer that sums the outputs of multiple layers
+    template <typename FirstPreviousLayer, typename... RemainingPreviousLayers>
+    class Trainer<Layers::Sum<FirstPreviousLayer, RemainingPreviousLayers...>> :
+          Trainer<Layers::Sum<RemainingPreviousLayers...>> {
+    private:
+        // Type of layer to learn
+        using LayerType = Layers::Sum<FirstPreviousLayer, RemainingPreviousLayers...>;
+        using Tail = Trainer<Layers::Sum<RemainingPreviousLayers...>>;
 
-// Learning: A layer that sums the outputs of multiple layers
-template <typename FirstPreviousLayer, typename... RemainingPreviousLayers>
-class Trainer<Layers::Sum<FirstPreviousLayer, RemainingPreviousLayers...>> :
-      Trainer<Layers::Sum<RemainingPreviousLayers...>> {
- private:
-  // Type of layer to learn
-  using LayerType = Layers::Sum<FirstPreviousLayer, RemainingPreviousLayers...>;
-  using Tail = Trainer<Layers::Sum<RemainingPreviousLayers...>>;
+    public:
+        // factory function
+        static std::shared_ptr<Trainer> Create(
+            LayerType* target_layer, FeatureTransformer* ft) {
 
- public:
-  // factory function
-  static std::shared_ptr<Trainer> Create(
-      LayerType* target_layer, FeatureTransformer* ft) {
-    return std::shared_ptr<Trainer>(
-        new Trainer(target_layer, ft));
-  }
+            return std::shared_ptr<Trainer>(
+                new Trainer(target_layer, ft));
+        }
 
-  // Set options such as hyperparameters
-  void SendMessage(Message* message) {
-    // The results of other member functions do not depend on the processing order, so
-    // Tail is processed first for the purpose of simplifying the implementation, but
-    // SendMessage processes Head first to make it easier to understand subscript correspondence
-    previous_layer_trainer_->SendMessage(message);
-    Tail::SendMessage(message);
-  }
+        // Set options such as hyperparameters
+        void SendMessage(Message* message) {
+            // The results of other member functions do not depend on the processing order, so
+            // Tail is processed first for the purpose of simplifying the implementation, but
+            // SendMessage processes Head first to make it easier to understand subscript correspondence
+            previous_layer_trainer_->SendMessage(message);
+            Tail::SendMessage(message);
+        }
 
-  // Initialize the parameters with random numbers
-  template <typename RNG>
-  void Initialize(RNG& rng) {
-    Tail::Initialize(rng);
-    previous_layer_trainer_->Initialize(rng);
-  }
+        // Initialize the parameters with random numbers
+        template <typename RNG>
+        void Initialize(RNG& rng) {
+            Tail::Initialize(rng);
+            previous_layer_trainer_->Initialize(rng);
+        }
 
-  // forward propagation
-  /*const*/ LearnFloatType* Propagate(const std::vector<Example>& batch) {
-    batch_size_ = static_cast<IndexType>(batch.size());
-    auto output = Tail::Propagate(batch);
-    const auto head_output = previous_layer_trainer_->Propagate(batch);
+        // forward propagation
+        /*const*/ LearnFloatType* Propagate(const std::vector<Example>& batch) {
+            batch_size_ = static_cast<IndexType>(batch.size());
+            auto output = Tail::Propagate(batch);
+            const auto head_output = previous_layer_trainer_->Propagate(batch);
+
 #if defined(USE_BLAS)
-    cblas_saxpy(kOutputDimensions * batch_size_, 1.0,
-                head_output, 1, output, 1);
+            cblas_saxpy(kOutputDimensions * batch_size_, 1.0,
+                        head_output, 1, output, 1);
 #else
-    for (IndexType b = 0; b < batch_size_; ++b) {
-      const IndexType batch_offset = kOutputDimensions * b;
-      for (IndexType i = 0; i < kOutputDimensions; ++i) {
-        output[batch_offset + i] += head_output[batch_offset + i];
-      }
-    }
+            for (IndexType b = 0; b < batch_size_; ++b) {
+                const IndexType batch_offset = kOutputDimensions * b;
+                for (IndexType i = 0; i < kOutputDimensions; ++i) {
+                    output[batch_offset + i] += head_output[batch_offset + i];
+                }
+            }
+
 #endif
-    return output;
-  }
+            return output;
+        }
 
-  // backpropagation
-  void Backpropagate(const LearnFloatType* gradients,
-                     LearnFloatType learning_rate) {
-    Tail::Backpropagate(gradients, learning_rate);
-    previous_layer_trainer_->Backpropagate(gradients, learning_rate);
-  }
+        // backpropagation
+        void Backpropagate(const LearnFloatType* gradients,
+                           LearnFloatType learning_rate) {
 
- private:
-  // constructor
-  Trainer(LayerType* target_layer, FeatureTransformer* ft):
-      Tail(target_layer, ft),
-      batch_size_(0),
-      previous_layer_trainer_(Trainer<FirstPreviousLayer>::Create(
-          &target_layer->previous_layer_, ft)),
-      target_layer_(target_layer) {
-  }
+            Tail::Backpropagate(gradients, learning_rate);
+            previous_layer_trainer_->Backpropagate(gradients, learning_rate);
+        }
 
-  // number of input/output dimensions
-  static constexpr IndexType kOutputDimensions = LayerType::kOutputDimensions;
+    private:
+        // constructor
+        Trainer(LayerType* target_layer, FeatureTransformer* ft):
+            Tail(target_layer, ft),
+            batch_size_(0),
+            previous_layer_trainer_(Trainer<FirstPreviousLayer>::Create(
+                &target_layer->previous_layer_, ft)),
+            target_layer_(target_layer) {
+        }
 
-  // make subclass friend
-  template <typename SumLayer>
-  friend class Trainer;
+        // number of input/output dimensions
+        static constexpr IndexType kOutputDimensions = LayerType::kOutputDimensions;
 
-  // number of samples in mini-batch
-  IndexType batch_size_;
+        // make subclass friend
+        template <typename SumLayer>
+        friend class Trainer;
 
-  // Trainer of the previous layer
-  const std::shared_ptr<Trainer<FirstPreviousLayer>> previous_layer_trainer_;
+        // number of samples in mini-batch
+        IndexType batch_size_;
 
-  // layer to learn
-  LayerType* const target_layer_;
-};
+        // Trainer of the previous layer
+        const std::shared_ptr<Trainer<FirstPreviousLayer>> previous_layer_trainer_;
+
+        // layer to learn
+        LayerType* const target_layer_;
+    };
 
 
-// Learning: Layer that takes the sum of the outputs of multiple layers (when there is one template argument)
-template <typename PreviousLayer>
-class Trainer<Layers::Sum<PreviousLayer>> {
- private:
-  // Type of layer to learn
-  using LayerType = Layers::Sum<PreviousLayer>;
+    // Learning: Layer that takes the sum of the outputs of multiple layers (when there is one template argument)
+    template <typename PreviousLayer>
+    class Trainer<Layers::Sum<PreviousLayer>> {
+    private:
+        // Type of layer to learn
+        using LayerType = Layers::Sum<PreviousLayer>;
 
- public:
-  // factory function
-  static std::shared_ptr<Trainer> Create(
-      LayerType* target_layer, FeatureTransformer* ft) {
-    return std::shared_ptr<Trainer>(
-        new Trainer(target_layer, ft));
-  }
+    public:
+        // factory function
+        static std::shared_ptr<Trainer> Create(
+            LayerType* target_layer, FeatureTransformer* ft) {
 
-  // Set options such as hyperparameters
-  void SendMessage(Message* message) {
-    previous_layer_trainer_->SendMessage(message);
-  }
+            return std::shared_ptr<Trainer>(
+                new Trainer(target_layer, ft));
+        }
 
-  // Initialize the parameters with random numbers
-  template <typename RNG>
-  void Initialize(RNG& rng) {
-    previous_layer_trainer_->Initialize(rng);
-  }
+        // Set options such as hyperparameters
+        void SendMessage(Message* message) {
+            previous_layer_trainer_->SendMessage(message);
+        }
 
-  // forward propagation
-  /*const*/ LearnFloatType* Propagate(const std::vector<Example>& batch) {
-    if (output_.size() < kOutputDimensions * batch.size()) {
-      output_.resize(kOutputDimensions * batch.size());
-    }
-    batch_size_ = static_cast<IndexType>(batch.size());
-    const auto output = previous_layer_trainer_->Propagate(batch);
+        // Initialize the parameters with random numbers
+        template <typename RNG>
+        void Initialize(RNG& rng) {
+            previous_layer_trainer_->Initialize(rng);
+        }
+
+        // forward propagation
+        /*const*/ LearnFloatType* Propagate(const std::vector<Example>& batch) {
+            if (output_.size() < kOutputDimensions * batch.size()) {
+                output_.resize(kOutputDimensions * batch.size());
+            }
+
+            batch_size_ = static_cast<IndexType>(batch.size());
+            const auto output = previous_layer_trainer_->Propagate(batch);
+
 #if defined(USE_BLAS)
-    cblas_scopy(kOutputDimensions * batch_size_, output, 1, &output_[0], 1);
+            cblas_scopy(kOutputDimensions * batch_size_, output, 1, &output_[0], 1);
 #else
-    for (IndexType b = 0; b < batch_size_; ++b) {
-      const IndexType batch_offset = kOutputDimensions * b;
-      for (IndexType i = 0; i < kOutputDimensions; ++i) {
-        output_[batch_offset + i] = output[batch_offset + i];
-      }
-    }
+            for (IndexType b = 0; b < batch_size_; ++b) {
+                const IndexType batch_offset = kOutputDimensions * b;
+                for (IndexType i = 0; i < kOutputDimensions; ++i) {
+                    output_[batch_offset + i] = output[batch_offset + i];
+                }
+            }
+
 #endif
-    return output_.data();
-  }
+            return output_.data();
+        }
 
-  // backpropagation
-  void Backpropagate(const LearnFloatType* gradients,
-                     LearnFloatType learning_rate) {
-    previous_layer_trainer_->Backpropagate(gradients, learning_rate);
-  }
+        // backpropagation
+        void Backpropagate(const LearnFloatType* gradients,
+                           LearnFloatType learning_rate) {
 
- private:
-  // constructor
-  Trainer(LayerType* target_layer, FeatureTransformer* ft) :
-      batch_size_(0),
-      previous_layer_trainer_(Trainer<PreviousLayer>::Create(
-          &target_layer->previous_layer_, ft)),
-      target_layer_(target_layer) {
-  }
+            previous_layer_trainer_->Backpropagate(gradients, learning_rate);
+        }
 
-  // number of input/output dimensions
-  static constexpr IndexType kOutputDimensions = LayerType::kOutputDimensions;
+    private:
+        // constructor
+        Trainer(LayerType* target_layer, FeatureTransformer* ft) :
+            batch_size_(0),
+            previous_layer_trainer_(Trainer<PreviousLayer>::Create(
+                &target_layer->previous_layer_, ft)),
+            target_layer_(target_layer) {
+        }
 
-  // make subclass friend
-  template <typename SumLayer>
-  friend class Trainer;
+        // number of input/output dimensions
+        static constexpr IndexType kOutputDimensions = LayerType::kOutputDimensions;
 
-  // number of samples in mini-batch
-  IndexType batch_size_;
+        // make subclass friend
+        template <typename SumLayer>
+        friend class Trainer;
 
-  // Trainer of the previous layer
-  const std::shared_ptr<Trainer<PreviousLayer>> previous_layer_trainer_;
+        // number of samples in mini-batch
+        IndexType batch_size_;
 
-  // layer to learn
-  LayerType* const target_layer_;
+        // Trainer of the previous layer
+        const std::shared_ptr<Trainer<PreviousLayer>> previous_layer_trainer_;
 
-  // Forward propagation buffer
-  std::vector<LearnFloatType> output_;
-};
+        // layer to learn
+        LayerType* const target_layer_;
 
-}  // namespace NNUE
+        // Forward propagation buffer
+        std::vector<LearnFloatType> output_;
+    };
 
-}  // namespace Eval
+}  // namespace Eval::NNUE
 
 #endif

--- a/src/nnue/trainer/trainer_sum.h
+++ b/src/nnue/trainer/trainer_sum.h
@@ -21,7 +21,7 @@ namespace Eval::NNUE {
 
     public:
         // factory function
-        static std::shared_ptr<Trainer> Create(
+        static std::shared_ptr<Trainer> create(
             LayerType* target_layer, FeatureTransformer* ft) {
 
             return std::shared_ptr<Trainer>(
@@ -29,26 +29,26 @@ namespace Eval::NNUE {
         }
 
         // Set options such as hyperparameters
-        void SendMessage(Message* message) {
+        void send_message(Message* message) {
             // The results of other member functions do not depend on the processing order, so
             // Tail is processed first for the purpose of simplifying the implementation, but
             // SendMessage processes Head first to make it easier to understand subscript correspondence
-            previous_layer_trainer_->SendMessage(message);
-            Tail::SendMessage(message);
+            previous_layer_trainer_->send_message(message);
+            Tail::send_message(message);
         }
 
         // Initialize the parameters with random numbers
         template <typename RNG>
-        void Initialize(RNG& rng) {
-            Tail::Initialize(rng);
-            previous_layer_trainer_->Initialize(rng);
+        void initialize(RNG& rng) {
+            Tail::initialize(rng);
+            previous_layer_trainer_->initialize(rng);
         }
 
         // forward propagation
-        /*const*/ LearnFloatType* Propagate(const std::vector<Example>& batch) {
+        /*const*/ LearnFloatType* propagate(const std::vector<Example>& batch) {
             batch_size_ = static_cast<IndexType>(batch.size());
-            auto output = Tail::Propagate(batch);
-            const auto head_output = previous_layer_trainer_->Propagate(batch);
+            auto output = Tail::propagate(batch);
+            const auto head_output = previous_layer_trainer_->propagate(batch);
 
 #if defined(USE_BLAS)
             cblas_saxpy(kOutputDimensions * batch_size_, 1.0,
@@ -66,11 +66,11 @@ namespace Eval::NNUE {
         }
 
         // backpropagation
-        void Backpropagate(const LearnFloatType* gradients,
+        void backpropagate(const LearnFloatType* gradients,
                            LearnFloatType learning_rate) {
 
-            Tail::Backpropagate(gradients, learning_rate);
-            previous_layer_trainer_->Backpropagate(gradients, learning_rate);
+            Tail::backpropagate(gradients, learning_rate);
+            previous_layer_trainer_->backpropagate(gradients, learning_rate);
         }
 
     private:
@@ -78,7 +78,7 @@ namespace Eval::NNUE {
         Trainer(LayerType* target_layer, FeatureTransformer* ft):
             Tail(target_layer, ft),
             batch_size_(0),
-            previous_layer_trainer_(Trainer<FirstPreviousLayer>::Create(
+            previous_layer_trainer_(Trainer<FirstPreviousLayer>::create(
                 &target_layer->previous_layer_, ft)),
             target_layer_(target_layer) {
         }
@@ -110,7 +110,7 @@ namespace Eval::NNUE {
 
     public:
         // factory function
-        static std::shared_ptr<Trainer> Create(
+        static std::shared_ptr<Trainer> create(
             LayerType* target_layer, FeatureTransformer* ft) {
 
             return std::shared_ptr<Trainer>(
@@ -118,24 +118,24 @@ namespace Eval::NNUE {
         }
 
         // Set options such as hyperparameters
-        void SendMessage(Message* message) {
-            previous_layer_trainer_->SendMessage(message);
+        void send_message(Message* message) {
+            previous_layer_trainer_->send_message(message);
         }
 
         // Initialize the parameters with random numbers
         template <typename RNG>
-        void Initialize(RNG& rng) {
-            previous_layer_trainer_->Initialize(rng);
+        void initialize(RNG& rng) {
+            previous_layer_trainer_->initialize(rng);
         }
 
         // forward propagation
-        /*const*/ LearnFloatType* Propagate(const std::vector<Example>& batch) {
+        /*const*/ LearnFloatType* propagate(const std::vector<Example>& batch) {
             if (output_.size() < kOutputDimensions * batch.size()) {
                 output_.resize(kOutputDimensions * batch.size());
             }
 
             batch_size_ = static_cast<IndexType>(batch.size());
-            const auto output = previous_layer_trainer_->Propagate(batch);
+            const auto output = previous_layer_trainer_->propagate(batch);
 
 #if defined(USE_BLAS)
             cblas_scopy(kOutputDimensions * batch_size_, output, 1, &output_[0], 1);
@@ -152,17 +152,17 @@ namespace Eval::NNUE {
         }
 
         // backpropagation
-        void Backpropagate(const LearnFloatType* gradients,
+        void backpropagate(const LearnFloatType* gradients,
                            LearnFloatType learning_rate) {
 
-            previous_layer_trainer_->Backpropagate(gradients, learning_rate);
+            previous_layer_trainer_->backpropagate(gradients, learning_rate);
         }
 
     private:
         // constructor
         Trainer(LayerType* target_layer, FeatureTransformer* ft) :
             batch_size_(0),
-            previous_layer_trainer_(Trainer<PreviousLayer>::Create(
+            previous_layer_trainer_(Trainer<PreviousLayer>::create(
                 &target_layer->previous_layer_, ft)),
             target_layer_(target_layer) {
         }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -23,6 +23,8 @@
 #include <iomanip>
 #include <sstream>
 
+#include "nnue/evaluate_nnue.h"
+
 #include "bitboard.h"
 #include "misc.h"
 #include "movegen.h"
@@ -757,7 +759,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       else
           st->nonPawnMaterial[them] -= PieceValue[MG][captured];
 
-      if (Eval::useNNUE != Eval::UseNNUEMode::False)
+      if (Eval::NNUE::useNNUE != Eval::NNUE::UseNNUEMode::False)
       {
           dp.dirty_num = 2;  // 1 piece moved, 1 piece captured
           dp.piece[1] = captured;
@@ -801,7 +803,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   // Move the piece. The tricky Chess960 castling is handled earlier
   if (type_of(m) != CASTLING)
   {
-      if (Eval::useNNUE != Eval::UseNNUEMode::False)
+      if (Eval::NNUE::useNNUE != Eval::NNUE::UseNNUEMode::False)
       {
           dp.piece[0] = pc;
           dp.from[0] = from;
@@ -832,7 +834,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
           remove_piece(to);
           put_piece(promotion, to);
 
-          if (Eval::useNNUE != Eval::UseNNUEMode::False)
+          if (Eval::NNUE::useNNUE != Eval::NNUE::UseNNUEMode::False)
           {
               // Promoting pawn to SQ_NONE, promoted piece from SQ_NONE
               dp.to[0] = SQ_NONE;
@@ -970,7 +972,7 @@ void Position::do_castling(Color us, Square from, Square& to, Square& rfrom, Squ
   rto = relative_square(us, kingSide ? SQ_F1 : SQ_D1);
   to = relative_square(us, kingSide ? SQ_G1 : SQ_C1);
 
-  if (Do && Eval::useNNUE != Eval::UseNNUEMode::False)
+  if (Do && Eval::NNUE::useNNUE != Eval::NNUE::UseNNUEMode::False)
   {
       auto& dp = st->dirtyPiece;
       dp.piece[0] = make_piece(us, KING);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -219,7 +219,7 @@ void MainThread::search() {
   Time.init(Limits, us, rootPos.game_ply());
   TT.new_search();
 
-  Eval::NNUE::verify();
+  Eval::NNUE::verify_eval_file_loaded();
 
   if (rootMoves.empty())
   {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -23,6 +23,8 @@
 #include <iostream>
 #include <sstream>
 
+#include "nnue/evaluate_nnue.h"
+
 #include "evaluate.h"
 #include "misc.h"
 #include "movegen.h"

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1968,9 +1968,7 @@ void Tablebases::rank_root_moves(Position& pos, Search::RootMoves& rootMoves) {
 }
 
 // --- expose the functions such as fixed depth search used for learning to the outside
-
-
-namespace Learner
+namespace Search
 {
   // For learning, prepare a stub that can call search,qsearch() from one thread.
   // From now on, it is better to have a Searcher and prepare a substitution table for each thread like Apery.
@@ -1978,7 +1976,7 @@ namespace Learner
 
   // Initialization for learning.
   // Called from Learner::search(),Learner::qsearch().
-  void init_for_search(Position& pos, Stack* ss)
+  static void init_for_search(Position& pos, Stack* ss)
   {
 
     // RootNode requires ss->ply == 0.
@@ -2045,9 +2043,6 @@ namespace Learner
       Tablebases::rank_root_moves(pos, rootMoves);
     }
   }
-
-  // A pair of reader and evaluation value. Returned by Learner::search(),Learner::qsearch().
-  typedef std::pair<Value, std::vector<Move> > ValueAndPV;
 
   // Stationary search.
   //

--- a/src/search.h
+++ b/src/search.h
@@ -110,15 +110,12 @@ extern LimitsType Limits;
 void init();
 void clear();
 
-} // namespace Search
+// A pair of reader and evaluation value. Returned by Learner::search(),Learner::qsearch().
+using ValueAndPV = std::pair<Value, std::vector<Move>>;
 
-namespace Learner {
+ValueAndPV qsearch(Position& pos);
+ValueAndPV search(Position& pos, int depth_, size_t multiPV = 1, uint64_t nodesLimit = 0);
 
-  // A pair of reader and evaluation value. Returned by Learner::search(),Learner::qsearch().
-  using ValueAndPV = std::pair<Value, std::vector<Move>>;
-
-  ValueAndPV qsearch(Position& pos);
-  ValueAndPV search(Position& pos, int depth_, size_t multiPV = 1, uint64_t nodesLimit = 0);
 }
 
 #endif // #ifndef SEARCH_H_INCLUDED

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -28,12 +28,12 @@
 #include <type_traits>
 #include <mutex>
 
-#include "../bitboard.h"
-#include "../movegen.h"
-#include "../position.h"
-#include "../search.h"
-#include "../types.h"
-#include "../uci.h"
+#include "bitboard.h"
+#include "movegen.h"
+#include "position.h"
+#include "search.h"
+#include "types.h"
+#include "uci.h"
 
 #include "tbprobe.h"
 

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -21,7 +21,7 @@
 
 #include <ostream>
 
-#include "../search.h"
+#include "search.h"
 
 namespace Tablebases {
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -53,7 +53,7 @@ void test_cmd(Position& pos, istringstream& is)
     std::string param;
     is >> param;
 
-    if (param == "nnue") Eval::NNUE::TestCommand(pos, is);
+    if (param == "nnue") Eval::NNUE::test_command(pos, is);
 }
 
 namespace {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -101,7 +101,7 @@ namespace {
     Position p;
     p.set(pos.fen(), Options["UCI_Chess960"], &states->back(), Threads.main());
 
-    Eval::NNUE::verify();
+    Eval::NNUE::verify_eval_file_loaded();
 
     sync_cout << "\n" << Eval::trace(p) << sync_endl;
   }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <string>
 
+#include "nnue/evaluate_nnue.h"
 #include "evaluate.h"
 #include "movegen.h"
 #include "nnue/nnue_test_command.h"

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -254,7 +254,7 @@ double UCI::win_rate_model_double(double v, int ply) {
 void qsearch_cmd(Position& pos)
 {
   cout << "qsearch : ";
-  auto pv = Learner::qsearch(pos);
+  auto pv = Search::qsearch(pos);
   cout << "Value = " << pv.first << " , " << UCI::value(pv.first) << " , PV = ";
   for (auto m : pv.second)
     cout << UCI::move(m, false) << " ";
@@ -275,7 +275,7 @@ void search_cmd(Position& pos, istringstream& is)
   }
 
   cout << "search depth = " << depth << " , multi_pv = " << multi_pv << " : ";
-  auto pv = Learner::search(pos, depth, multi_pv);
+  auto pv = Search::search(pos, depth, multi_pv);
   cout << "Value = " << pv.first << " , " << UCI::value(pv.first) << " , PV = ";
   for (auto m : pv.second)
     cout << UCI::move(m, false) << " ";

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,6 +21,7 @@
 #include <ostream>
 #include <sstream>
 
+#include "nnue/evaluate_nnue.h"
 #include "evaluate.h"
 #include "misc.h"
 #include "search.h"


### PR DESCRIPTION
This PR performs many cosmetic changes, mostly on the previously untouched parts of the code. In particular:

- moved nnue evaluation related code from evaluate.h to nnue/evaluate_nnue.h
- change namespace of the public search routines from Learner to Search
- move sfen input/output stream code into a separate file
- adjust indentation to match the rest of the learner code.
- rename "hirate eval" to "startpos eval"
- increase spacing between training progress health output
- show a message to the user when there's no net loaded during learning
- more empty lines in the nnue code for increased readability
- aligned all preprocessor directives to the left
- removed ".." from include paths
- merged nested namespaces
- changed PascalCase function names to snake_case to match the rest of the codebase