### PR TITLE
Make learner work on top of stockfish's thread pool instead of MultiThink.

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -128,6 +128,18 @@ public:
 
   void set_seed(uint64_t seed) { s = seed; }
 
+  uint64_t next_random_seed()
+  {
+    uint64_t seed = 0;
+    for(int i = 0; i < 64; ++i)
+    {
+      const auto off = rand64() % 64;
+      seed |= (rand64() & (uint64_t(1) << off)) >> off;
+      seed <<= 1;
+    }
+    return seed;
+  }
+
   void set_seed_from_time()
   {
       set_seed(std::chrono::system_clock::now().time_since_epoch().count());


### PR DESCRIPTION
This is a rewrite (restructuring) of the learner code so that it uses the newly added feature that allows execution of arbitrary tasks on stockfish's thread pool. In particular it:
- removes many parts of the code that were previously required for synchronization and task scheduling. 
- provides clearer distinction between single and multithreaded execution contexts
- makes the control flow more linear
- decouples SfenReader from LearnerThink
- removes [no longer] used parts of the learner
- removed old misleading comments and replaced them with new ones where necessary.
- adds `Entropy` struct to make passing and summing all the entropy statistics around the code easier

As this is a more or less a complete rewrite the diff is kinda hard to read, best to compare whole files side by side. If you think this should be split further I can try, but in my opinion looking at this in its final stage is easier to compare than looking at intermediate steps in isolation.

As a side effect it may have [partially] fixed #164.