### PR TITLE
Improve handling of input files for learn.

### DIFF
--- a/src/extra/nnue_data_binpack_format.h
+++ b/src/extra/nnue_data_binpack_format.h
@@ -6141,6 +6141,11 @@ namespace binpack
 
         [[nodiscard]] bool hasNextChunk()
         {
+            if (!m_file)
+            {
+                return false;
+            }
+
             m_file.peek();
             return !m_file.eof();
         }

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -1245,6 +1245,12 @@ namespace Learner
 
             // Specify the folder in which the game record is stored and make it the rooting target.
             else if (option == "targetdir") is >> target_dir;
+            else if (option == "targetfile")
+            {
+                std::string filename;
+                is >> filename;
+                filenames.push_back(filename);
+            }
 
             // Specify the number of loops
             else if (option == "loop")      is >> loop;
@@ -1333,9 +1339,10 @@ namespace Learner
                 UCI::setoption("PruneAtShallowDepth", "false");
                 UCI::setoption("EnableTranspositionTable", "false");
             }
-            // Otherwise, it's a filename.
             else
-                filenames.push_back(option);
+            {
+                cout << "Unknown option: " << option << ". Ignoring.\n";
+            }
         }
 
         if (loss_output_interval == 0)

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -157,6 +157,32 @@ namespace Learner
     using Loss = Detail::Loss<false>;
     using AtomicLoss = Detail::Loss<true>;
 
+    static void append_files_from_dir(
+        std::vector<std::string>& filenames,
+        const std::string& base_dir,
+        const std::string& target_dir)
+    {
+        string kif_base_dir = Path::combine(base_dir, target_dir);
+
+        namespace sys = std::filesystem;
+        sys::path p(kif_base_dir); // Origin of enumeration
+        std::for_each(sys::directory_iterator(p), sys::directory_iterator(),
+            [&](const sys::path& path) {
+                if (sys::is_regular_file(path))
+                    filenames.push_back(Path::combine(target_dir, path.filename().generic_string()));
+            });
+    }
+
+    static void rebase_files(
+        std::vector<std::string>& filenames,
+        const std::string& base_dir)
+    {
+        for (auto& file : filenames)
+        {
+            file = Path::combine(base_dir, file);
+        }
+    }
+
     // A function that converts the evaluation value to the winning rate [0,1]
     double winning_percentage(double value)
     {
@@ -1359,18 +1385,10 @@ namespace Learner
 
         LearnerThink learn_think(thread_num, seed);
 
-        // Display learning game file
-        if (target_dir != "")
+        rebase_files(filenames, base_dir);
+        if (!target_dir.empty())
         {
-            string kif_base_dir = Path::combine(base_dir, target_dir);
-
-            namespace sys = std::filesystem;
-            sys::path p(kif_base_dir); // Origin of enumeration
-            std::for_each(sys::directory_iterator(p), sys::directory_iterator(),
-                [&](const sys::path& path) {
-                    if (sys::is_regular_file(path))
-                        filenames.push_back(Path::combine(target_dir, path.filename().generic_string()));
-                });
+            append_files_from_dir(filenames, base_dir, target_dir);
         }
 
         cout << "learn from ";

--- a/src/learn/sfen_reader.h
+++ b/src/learn/sfen_reader.h
@@ -187,11 +187,25 @@ namespace Learner{
                     filenames.pop_front();
 
                     sfen_input_stream = open_sfen_input_file(filename);
-                    std::cout << "open filename = " << filename << std::endl;
 
-                    // in case the file is empty or was deleted.
-                    if (!sfen_input_stream->eof())
-                        return true;
+                    if (sfen_input_stream == nullptr)
+                    {
+                        std::cout << "File does not exist: " << filename << '\n';
+                    }
+                    else
+                    {
+                        std::cout << "Opened file for reading: " << filename << '\n';
+
+                        // in case the file is empty or was deleted.
+                        if (sfen_input_stream->eof())
+                        {
+                            std::cout << "File empty, nothing to read.\n";
+                        }
+                        else
+                        {
+                            return true;
+                        }
+                    }
                 }
             };
 

--- a/src/learn/sfen_stream.h
+++ b/src/learn/sfen_stream.h
@@ -191,7 +191,6 @@ namespace Learner {
         else if (has_extension(filename, BinpackSfenInputStream::extension))
             return std::make_unique<BinpackSfenInputStream>(filename);
 
-        assert(false);
         return nullptr;
     }
 


### PR DESCRIPTION
The following changes/bugfixes are made:

- Using an inexisting file is handled correctly and prints information in the console
- Unknown options are ignored instead of being treated as input file names
- Single input files can now be specified using the `targetfile <filename>` option.
- base_dir is now correctly applied to individual files.