### PR TITLE
Move the old convert stuff from learn to their own commands.

### DIFF
--- a/src/learn/convert.h
+++ b/src/learn/convert.h
@@ -6,30 +6,13 @@
 #include <sstream>
 
 namespace Learner {
-    void convert_bin_from_pgn_extract(
-        const std::vector<std::string>& filenames,
-        const std::string& output_file_name,
-        const bool pgn_eval_side_to_move,
-        const bool convert_no_eval_fens_as_score_zero);
-
-    void convert_bin(
-        const std::vector<std::string>& filenames,
-        const std::string& output_file_name,
-        const int ply_minimum,
-        const int ply_maximum,
-        const int interpolate_eval,
-        const int src_score_min_value,
-        const int src_score_max_value,
-        const int dest_score_min_value,
-        const int dest_score_max_value,
-        const bool check_invalid_fen,
-        const bool check_illegal_move);
-
-    void convert_plain(
-        const std::vector<std::string>& filenames,
-        const std::string& output_file_name);
-
     void convert(std::istringstream& is);
+
+    void convert_bin_from_pgn_extract(std::istringstream& is);
+
+    void convert_bin(std::istringstream& is);
+
+    void convert_plain(std::istringstream& is);
 }
 
 #endif

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -19,7 +19,6 @@
 
 #include "learn.h"
 
-#include "convert.h"
 #include "sfen_reader.h"
 
 #include "misc.h"
@@ -940,28 +939,7 @@ namespace Learner
 
         // Game file storage folder (get game file with relative path from here)
         string base_dir;
-
         string target_dir;
-
-        // --- Function that only shuffles the teacher aspect
-
-        // normal shuffle
-        // Conversion of packed sfen. In plain, it consists of sfen(string),
-        // evaluation value (integer), move (eg 7g7f, string), result (loss-1, win 1, draw 0)
-        bool use_convert_plain = false;
-        // convert plain format teacher to Yaneura King's bin
-        bool use_convert_bin = false;
-        int ply_minimum = 0;
-        int ply_maximum = 114514;
-        bool interpolate_eval = 0;
-        bool check_invalid_fen = false;
-        bool check_illegal_move = false;
-        // convert teacher in pgn-extract format to Yaneura King's bin
-        bool use_convert_bin_from_pgn_extract = false;
-        bool pgn_eval_side_to_move = false;
-        bool convert_no_eval_fens_as_score_zero = false;
-        // File name to write in those cases (default is "shuffled_sfen.bin")
-        string output_file_name = "shuffled_sfen.bin";
 
         // If the absolute value of the evaluation value
         // in the deep search of the teacher phase exceeds this value,
@@ -1079,19 +1057,11 @@ namespace Learner
             else if (option == "loss_output_interval") is >> loss_output_interval;
             else if (option == "validation_set_file_name") is >> validation_set_file_name;
 
-            // Rabbit convert related
-            else if (option == "convert_plain") use_convert_plain = true;
-            else if (option == "convert_bin") use_convert_bin = true;
-            else if (option == "interpolate_eval") is >> interpolate_eval;
-            else if (option == "check_invalid_fen") is >> check_invalid_fen;
-            else if (option == "check_illegal_move") is >> check_illegal_move;
-            else if (option == "convert_bin_from_pgn-extract") use_convert_bin_from_pgn_extract = true;
-            else if (option == "pgn_eval_side_to_move") is >> pgn_eval_side_to_move;
-            else if (option == "convert_no_eval_fens_as_score_zero") is >> convert_no_eval_fens_as_score_zero;
             else if (option == "src_score_min_value") is >> src_score_min_value;
             else if (option == "src_score_max_value") is >> src_score_max_value;
             else if (option == "dest_score_min_value") is >> dest_score_min_value;
             else if (option == "dest_score_max_value") is >> dest_score_max_value;
+
             else if (option == "seed") is >> seed;
             else if (option == "set_recommended_uci_options")
             {
@@ -1123,8 +1093,8 @@ namespace Learner
         cout << "Warning! OpenMP disabled." << endl;
 #endif
 
-        LearnerThink learn_think(thread_num, seed);
-
+        // Right now we only have the individual files.
+        // We need to apply base_dir here
         rebase_files(filenames, base_dir);
         if (!target_dir.empty())
         {
@@ -1143,48 +1113,6 @@ namespace Learner
 
         cout << "base dir        : " << base_dir << endl;
         cout << "target dir      : " << target_dir << endl;
-
-        if (use_convert_plain)
-        {
-            Eval::NNUE::init();
-            cout << "convert_plain.." << endl;
-            convert_plain(filenames, output_file_name);
-            return;
-        }
-
-        if (use_convert_bin)
-        {
-            Eval::NNUE::init();
-            cout << "convert_bin.." << endl;
-            convert_bin(
-                filenames,
-                output_file_name,
-                ply_minimum,
-                ply_maximum,
-                interpolate_eval,
-                src_score_min_value,
-                src_score_max_value,
-                dest_score_min_value,
-                dest_score_max_value,
-                check_invalid_fen,
-                check_illegal_move);
-
-            return;
-
-        }
-
-        if (use_convert_bin_from_pgn_extract)
-        {
-            Eval::NNUE::init();
-            cout << "convert_bin_from_pgn-extract.." << endl;
-            convert_bin_from_pgn_extract(
-                filenames,
-                output_file_name,
-                pgn_eval_side_to_move,
-                convert_no_eval_fens_as_score_zero);
-
-            return;
-        }
 
         cout << "loop              : " << loop << endl;
         cout << "eval_limit        : " << eval_limit << endl;
@@ -1226,6 +1154,8 @@ namespace Learner
 
         cout << "init.." << endl;
 
+        LearnerThink learn_think(thread_num, seed);
+
         Threads.main()->ponder = false;
 
         set_learning_search_limits();
@@ -1243,8 +1173,6 @@ namespace Learner
             learn_think.best_nn_directory =
                 Path::combine(Options["EvalSaveDir"], "original");
         }
-
-        cout << "init done." << endl;
 
         // Reflect other option settings.
         learn_think.eval_limit = eval_limit;
@@ -1270,6 +1198,8 @@ namespace Learner
                 learn_think.add_file(Path::combine(base_dir, file));
             }
         }
+
+        cout << "init done." << endl;
 
         // Start learning.
         learn_think.learn();

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -341,6 +341,9 @@ void UCI::loop(int argc, char* argv[]) {
       else if (token == "gensfen") Learner::gen_sfen(pos, is);
       else if (token == "learn") Learner::learn(pos, is);
       else if (token == "convert") Learner::convert(is);
+      else if (token == "convert_bin") Learner::convert_bin(is);
+      else if (token == "convert_plain") Learner::convert_plain(is);
+      else if (token == "convert_bin_from_pgn_extract") Learner::convert_bin_from_pgn_extract(is);
 
       // Command to call qsearch(),search() directly for testing
       else if (token == "qsearch") qsearch_cmd(pos);

--- a/tests/instrumented.sh
+++ b/tests/instrumented.sh
@@ -16,6 +16,9 @@ case $1 in
     exeprefix='valgrind --error-exitcode=42'
     postfix='1>/dev/null'
     threads="1"
+    bench_depth=5
+    go_depth=10
+    tt_size=16
   ;;
   --valgrind-thread)
     echo "valgrind-thread testing started"
@@ -23,6 +26,9 @@ case $1 in
     exeprefix='valgrind --fair-sched=try --error-exitcode=42'
     postfix='1>/dev/null'
     threads="2"
+    bench_depth=5
+    go_depth=10
+    tt_size=16
   ;;
   --sanitizer-undefined)
     echo "sanitizer-undefined testing started"
@@ -30,6 +36,9 @@ case $1 in
     exeprefix=''
     postfix='2>&1 | grep -A50 "runtime error:"'
     threads="1"
+    bench_depth=8
+    go_depth=20
+    tt_size=128
   ;;
   --sanitizer-thread)
     echo "sanitizer-thread testing started"
@@ -37,6 +46,9 @@ case $1 in
     exeprefix=''
     postfix='2>&1 | grep -A50 "WARNING: ThreadSanitizer:"'
     threads="2"
+    bench_depth=8
+    go_depth=20
+    tt_size=128
 
 cat << EOF > tsan.supp
 race:TTEntry::move
@@ -70,7 +82,7 @@ for args in "eval" \
             "go depth 10" \
             "go movetime 1000" \
             "go wtime 8000 btime 8000 winc 500 binc 500" \
-            "bench 128 $threads 8 default depth"
+            "bench $tt_size $threads $bench_depth default depth"
 do
 
    echo "$prefix $exeprefix ./stockfish $args $postfix"
@@ -98,7 +110,7 @@ cat << EOF > game.exp
  expect "bestmove"
 
  send "position fen 5rk1/1K4p1/8/8/3B4/8/8/8 b - - 0 1\n"
- send "go depth 20\n"
+ send "go depth $go_depth\n"
  expect "bestmove"
 
  send "quit\n"
@@ -121,7 +133,7 @@ cat << EOF > syzygy.exp
  send "uci\n"
  send "setoption name SyzygyPath value ../tests/syzygy/\n"
  expect "info string Found 35 tablebases" {} timeout {exit 1}
- send "bench 128 1 8 default depth\n"
+ send "bench $tt_size 1 $bench_depth default depth\n"
  send "quit\n"
  expect eof
 

--- a/tests/instrumented.sh
+++ b/tests/instrumented.sh
@@ -142,7 +142,7 @@ cat << EOF > syzygy.exp
  exit \$value
 EOF
 
-for exp in game.exp syzygy.exp
+for exp in game.exp
 do
 
   echo "$prefix expect $exp $postfix"


### PR DESCRIPTION
This PR moves the following legacy conversion commands from learn to dedicated uci commands:
- `convert_bin`
- `convert_plain`
- `convert_bin_from_pgn_extract`