### PR TITLE
Change training length from loops over data to the number of epochs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ setoption name SkipLoadingEval value true
 setoption name Use NNUE value pure
 setoption name Threads value x
 isready
-learn targetdir trainingdata loop 100 batchsize 1000000 use_draw_in_training 1 use_draw_in_validation 1 lr 1 lambda 1 eval_limit 32000 nn_batch_size 1000 newbob_decay 0.5 eval_save_interval 250000000 loss_output_interval 1000000 validation_set_file_name validationdata\val.binpack
+learn targetdir trainingdata epochs 10000 batchsize 1000000 use_draw_in_training 1 use_draw_in_validation 1 lr 1 lambda 1 eval_limit 32000 nn_batch_size 1000 newbob_decay 0.5 eval_save_interval 250000000 loss_output_interval 1000000 validation_set_file_name validationdata\val.binpack
 ```
 
 This will utilize training data files in the "trainingdata" directory and validation data from file "validationdata\val.bin". Produced nets are saved in the "evalsave" folder.

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -20,7 +20,7 @@ Currently the following options are available:
 
 `targetdir` - path to the direction from which training data will be read. All files in this directory are read sequentially. If not specified then only the list of files from positional arguments will be used. If specified then files from the given directory will be used after the explicitly specified files.
 
-`loop` - the number of times to loop over all training data.
+`epochs` - the number of weight update cycles (epochs) to train the network for. One such cycle is `batchsize` positions. If not specified then the training will loop forever.
 
 `basedir` - the base directory for the paths. Default: "" (current directory)
 

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -74,6 +74,10 @@ Currently the following options are available:
 
 `validation_set_file_name` - path to the file with training data to be used for validation (loss computation and move accuracy)
 
+`sfen_read_size` - the number of sfens to always keep in the buffer. Default: 10000000 (10M)
+
+`thread_buffer_size` - the number of sfens to copy at once to each thread requesting more sfens for learning. Default: 10000
+
 `seed` - seed for the PRNG. Can be either a number or a string. If it's a string then its hash will be used. If not specified then the current time will be used.
 
 ## Legacy subcommands and parameters

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -502,8 +502,6 @@ namespace Learner
                 << "Error reading sfen_for_mse. Read " << sfen_for_mse.size()
                 << " out of " << sfen_for_mse_size << '\n';
 
-            sr.stop();
-
             return;
         }
 
@@ -540,8 +538,6 @@ namespace Learner
             if (stop_flag)
                 break;
         }
-
-        sr.stop();
 
         Eval::NNUE::finalize_net();
 

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -383,11 +383,12 @@ namespace Learner
 
         LearnerThink(
             const std::vector<std::string>& filenames,
+            bool shuffle,
             uint64_t thread_num,
             const std::string& seed
         ) :
             prng(seed),
-            sr(filenames, SfenReaderMode::Cyclic, thread_num, std::to_string(prng.next_random_seed())),
+            sr(filenames, shuffle, SfenReaderMode::Cyclic, thread_num, std::to_string(prng.next_random_seed())),
             learn_loss_sum{}
         {
             save_only_once = false;
@@ -401,11 +402,6 @@ namespace Learner
             latest_loss_sum = 0.0;
             latest_loss_count = 0;
             total_done = 0;
-        }
-
-        void set_do_shuffle(bool v)
-        {
-            sr.set_do_shuffle(v);
         }
 
         void learn(uint64_t epochs);
@@ -1150,7 +1146,7 @@ namespace Learner
         Eval::NNUE::set_batch_size(nn_batch_size);
         Eval::NNUE::set_options(nn_options);
 
-        LearnerThink learn_think(filenames, thread_num, seed);
+        LearnerThink learn_think(filenames, !no_shuffle, thread_num, seed);
 
         if (newbob_decay != 1.0 && !Options["SkipLoadingEval"]) {
             // Save the current net to [EvalSaveDir]\original.
@@ -1165,7 +1161,6 @@ namespace Learner
         // Reflect other option settings.
         learn_think.eval_limit = eval_limit;
         learn_think.save_only_once = save_only_once;
-        learn_think.set_do_shuffle(!no_shuffle);
         learn_think.reduction_gameply = reduction_gameply;
 
         learn_think.newbob_decay = newbob_decay;

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -490,9 +490,6 @@ namespace Learner
 
         Eval::NNUE::verify_any_net_loaded();
 
-        // Start a thread that loads the training data in the background
-        sr.start_file_read_worker();
-
         const PSVector sfen_for_mse =
             validation_set_file_name.empty()
             ? sr.read_for_mse(sfen_for_mse_size)

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -922,7 +922,7 @@ namespace Learner
         auto mini_batch_size = LEARN_MINI_BATCH_SIZE;
 
         // Number of epochs
-        uint64_t epochs = 1;
+        uint64_t epochs = std::numeric_limits<uint64_t>::max();
 
         // Game file storage folder (get game file with relative path from here)
         string base_dir;

--- a/src/learn/learn.h
+++ b/src/learn/learn.h
@@ -54,12 +54,6 @@ namespace Learner
 
     constexpr std::size_t LEARN_MINI_BATCH_SIZE = 1000 * 1000 * 1;
 
-    // The number of phases to read from the file at one time. After reading this much, shuffle.
-    // It is better to have a certain size, but this number x 40 bytes x 3 times as much memory is consumed. 400MB*3 is consumed in the 10M phase.
-    // Must be a multiple of THREAD_BUFFER_SIZE(=10000).
-
-    constexpr std::size_t LEARN_SFEN_READ_SIZE = 1000 * 1000 * 10;
-
     // Saving interval of evaluation function at learning. Save each time you learn this number of phases.
     // Needless to say, the longer the saving interval, the shorter the learning time.
     // Folder name is incremented for each save like 0/, 1/, 2/...

--- a/src/learn/sfen_reader.h
+++ b/src/learn/sfen_reader.h
@@ -53,6 +53,10 @@ namespace Learner{
             end_of_files = false;
             shuffle = true;
             stop_flag = false;
+
+            file_worker_thread = std::thread([&] {
+                this->file_read_worker();
+            });
         }
 
         ~SfenReader()
@@ -174,14 +178,6 @@ namespace Learner{
                 sleep(1);
             }
 
-        }
-
-        // Start a thread that loads the phase file in the background.
-        void start_file_read_worker()
-        {
-            file_worker_thread = std::thread([&] {
-                this->file_read_worker();
-                });
         }
 
         void file_read_worker()

--- a/src/learn/sfen_reader.h
+++ b/src/learn/sfen_reader.h
@@ -40,6 +40,7 @@ namespace Learner{
         // Because it always the same integers on MinGW.
         SfenReader(
             const std::vector<std::string>& filenames_,
+            bool do_shuffle,
             SfenReaderMode mode_,
             int thread_num,
             const std::string& seed
@@ -51,7 +52,7 @@ namespace Learner{
             packed_sfens.resize(thread_num);
             total_read = 0;
             end_of_files = false;
-            shuffle = true;
+            shuffle = do_shuffle;
             stop_flag = false;
 
             file_worker_thread = std::thread([&] {
@@ -310,11 +311,6 @@ namespace Learner{
                         packed_sfens_pool.emplace_back(std::move(buf));
                 }
             }
-        }
-
-        void set_do_shuffle(bool v)
-        {
-            shuffle = v;
         }
 
     protected:

--- a/src/learn/sfen_reader.h
+++ b/src/learn/sfen_reader.h
@@ -61,6 +61,8 @@ namespace Learner{
 
         ~SfenReader()
         {
+            stop_flag = true;
+
             if (file_worker_thread.joinable())
                 file_worker_thread.join();
         }
@@ -308,11 +310,6 @@ namespace Learner{
                         packed_sfens_pool.emplace_back(std::move(buf));
                 }
             }
-        }
-
-        void stop()
-        {
-            stop_flag = true;
         }
 
         void set_do_shuffle(bool v)

--- a/tests/instrumented_learn.sh
+++ b/tests/instrumented_learn.sh
@@ -127,7 +127,7 @@ cat << EOF > learn01.exp
  send "setoption name Use NNUE value true\n"
  send "setoption name Threads value $threads\n"
  send "isready\n"
- send "learn targetdir training_data loop 2 batchsize 100 use_draw_in_training 1 use_draw_in_validation 1 lr 1 eval_limit 32000 nn_batch_size 30 newbob_decay 0.5 eval_save_interval 30 loss_output_interval 10 validation_set_file_name validation_data/validation_data.bin\n"
+ send "learn targetdir training_data epochs 1 batchsize 100 use_draw_in_training 1 use_draw_in_validation 1 lr 1 eval_limit 32000 nn_batch_size 30 newbob_decay 0.5 eval_save_interval 30 loss_output_interval 10 validation_set_file_name validation_data/validation_data.bin\n"
 
  expect "save_eval() finished."
 

--- a/tests/instrumented_learn.sh
+++ b/tests/instrumented_learn.sh
@@ -80,7 +80,7 @@ cat << EOF > gensfen01.exp
  send "isready\n"
  send "gensfen depth 3 loop 100 use_draw_in_training_data_generation 1 eval_limit 32000 output_file_name training_data/training_data.bin sfen_format bin\n"
  expect "gensfen finished."
- send "learn training_data/training_data.bin convert_plain output_file_name training_data.txt\n"
+ send "convert_plain targetfile training_data/training_data.bin output_file_name training_data.txt\n"
  expect "all done"
  send "gensfen depth 3 loop 100 use_draw_in_training_data_generation 1 eval_limit 32000 output_file_name training_data/training_data.binpack sfen_format binpack\n"
  expect "gensfen finished."
@@ -127,7 +127,7 @@ cat << EOF > learn01.exp
  send "setoption name Use NNUE value true\n"
  send "setoption name Threads value $threads\n"
  send "isready\n"
- send "learn targetdir training_data epochs 1 batchsize 100 use_draw_in_training 1 use_draw_in_validation 1 lr 1 eval_limit 32000 nn_batch_size 30 newbob_decay 0.5 eval_save_interval 30 loss_output_interval 10 validation_set_file_name validation_data/validation_data.bin\n"
+ send "learn targetdir training_data epochs 1 sfen_read_size 100 thread_buffer_size 10 batchsize 100 use_draw_in_training 1 use_draw_in_validation 1 lr 1 eval_limit 32000 nn_batch_size 30 newbob_decay 0.5 eval_save_interval 30 loss_output_interval 10 validation_set_file_name validation_data/validation_data.bin\n"
 
  expect "save_eval() finished."
 


### PR DESCRIPTION
This PR removes the `loop` parameter from training and adds an `epochs` parameter that controls for how many weight update cycles the training should last. It has the following advantages:

- no need to append the files `loop` times
- the sfen reader for learning now works in cyclic mode (sequential is still available) and loops indefinitely over the provided files
    - this allows it to handle small amounts of data, previously end of files would be reached when filling the buffers and it was no clear how much data is needed to even start training (to start training one needed more data than for one iteration)
    - files that don't contain any data are still removed from the file queue so it won't loop forever on nothing and still reach end of files
    - it allows finishing the anticipated amount of sfens even if some sfens are ignored due to errors if the training would be cut short due to "end of files".

Also the following `learn` options are introduced to control the sfen reader:
- `sfen_read_size` - the number of sfens to always keep in the buffer. Default: 10000000 (10M)
- `thread_buffer_size` - the number of sfens to copy at once to each thread requesting more sfens for learning. Default: 10000

They are for example used in instrumented_learn.sh to keep the amount of data loaded by the sfen reader small. Otherwise the small file is loaded a huge amount of times to fill 10 million sfens which is the default sfen_read_size. (It also means that previously there was no learning taking place in the CI because the sfen reader was just exiting with error. Whoopse!)