### PR TITLE
Improve diagnostic messages during learn

### DIFF
--- a/docs/learn.md
+++ b/docs/learn.md
@@ -80,6 +80,8 @@ Currently the following options are available:
 
 `seed` - seed for the PRNG. Can be either a number or a string. If it's a string then its hash will be used. If not specified then the current time will be used.
 
+`verbose` - this is a modifier, not a parameter. When used there will be more detailed output during training.
+
 ## Legacy subcommands and parameters
 
 ### Convert

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -141,7 +141,7 @@ namespace Learner
             void print(const std::string& prefix, ostream& s) const
             {
                 s
-                    << "INFO: "
+                    << "--> "
                     << prefix << "_cross_entropy_eval = " << cross_entropy_eval / count
                     << " , " << prefix << "_cross_entropy_win = " << cross_entropy_win / count
                     << " , " << prefix << "_entropy_eval = " << entropy_eval / count
@@ -722,7 +722,7 @@ namespace Learner
 
         if (psv.size() && test_loss_sum.count > 0.0)
         {
-            cout << "INFO: norm = " << sum_norm
+            cout << "--> norm = " << sum_norm
                 << " , move accuracy = " << (move_accord_count * 100.0 / psv.size()) << "%"
                 << endl;
 

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -599,19 +599,16 @@ namespace Learner
                 // Evaluation value of deep search
                 const auto deep_value = (Value)ps.score;
 
-                const Value shallow_value =
-                    (rootColor == pos.side_to_move())
-                    ? Eval::evaluate(pos)
-                    : -Eval::evaluate(pos);
+                const Value shallow_value = Eval::evaluate(pos);
 
                 const auto loss = calc_cross_entropy(
                     deep_value,
-                    shallow_value,
+                    (rootColor == pos.side_to_move()) ? shallow_value : -shallow_value,
                     ps);
 
                 local_loss_sum += loss;
 
-                Eval::NNUE::add_example(pos, rootColor, ps, 1.0);
+                Eval::NNUE::add_example(pos, rootColor, shallow_value, ps, 1.0);
             };
 
             if (!pos.pseudo_legal((Move)ps.move) || !pos.legal((Move)ps.move))

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -140,15 +140,12 @@ namespace Learner
 
             void print(const std::string& prefix, ostream& s) const
             {
-                s
-                    << "--> "
-                    << prefix << "_cross_entropy_eval = " << cross_entropy_eval / count
-                    << " , " << prefix << "_cross_entropy_win = " << cross_entropy_win / count
-                    << " , " << prefix << "_entropy_eval = " << entropy_eval / count
-                    << " , " << prefix << "_entropy_win = " << entropy_win / count
-                    << " , " << prefix << "_cross_entropy = " << cross_entropy / count
-                    << " , " << prefix << "_entropy = " << entropy / count
-                    << endl;
+                s << "==> " << prefix << "_cross_entropy_eval = " << cross_entropy_eval / count << endl;
+                s << "==> " << prefix << "_cross_entropy_win  = " << cross_entropy_win / count << endl;
+                s << "==> " << prefix << "_entropy_eval       = " << entropy_eval / count << endl;
+                s << "==> " << prefix << "_entropy_win        = " << entropy_win / count << endl;
+                s << "==> " << prefix << "_cross_entropy      = " << cross_entropy / count << endl;
+                s << "==> " << prefix << "_entropy            = " << entropy / count << endl;
             }
         };
     }
@@ -678,11 +675,13 @@ namespace Learner
         TimePoint elapsed = now() - Search::Limits.startTime + 1;
 
         cout << "\n";
-        cout << "PROGRESS (calc_loss): " << now_string() << ", ";
-        cout << total_done << " sfens, ";
-        cout << total_done * 1000 / elapsed  << " sfens/second";
-        cout << ", iteration " << epoch;
-        cout << ", learning rate = " << global_learning_rate << ", ";
+        cout << "PROGRESS (calc_loss): " << now_string()
+             << ", " << total_done << " sfens"
+             << ", " << total_done * 1000 / elapsed  << " sfens/second"
+             << ", epoch " << epoch
+             << endl;
+
+        cout << "==> learning rate = " << global_learning_rate << endl;
 
         // For calculation of verification data loss
         AtomicLoss test_loss_sum{};
@@ -699,7 +698,7 @@ namespace Learner
             auto& pos = th.rootPos;
             StateInfo si;
             pos.set(StartFEN, false, &si, &th);
-            cout << "startpos eval = " << Eval::evaluate(pos) << endl;
+            cout << "==> startpos eval = " << Eval::evaluate(pos) << endl;
         });
         mainThread->wait_for_worker_finished();
 
@@ -722,16 +721,15 @@ namespace Learner
 
         if (psv.size() && test_loss_sum.count > 0.0)
         {
-            cout << "--> norm = " << sum_norm
-                << " , move accuracy = " << (move_accord_count * 100.0 / psv.size()) << "%"
-                << endl;
-
             test_loss_sum.print("test", cout);
 
             if (learn_loss_sum.count > 0.0)
             {
                 learn_loss_sum.print("learn", cout);
             }
+
+            cout << "==> norm = " << sum_norm << endl;
+            cout << "==> move accuracy = " << (move_accord_count * 100.0 / psv.size()) << "%" << endl;
         }
         else
         {
@@ -847,7 +845,8 @@ namespace Learner
                 const double latest_loss = latest_loss_sum / latest_loss_count;
                 latest_loss_sum = 0.0;
                 latest_loss_count = 0;
-                cout << "loss: " << latest_loss;
+                cout << "INFO (learning_rate):" << endl;
+                cout << "==> loss = " << latest_loss;
                 auto tot = total_done;
                 if (auto_lr_drop)
                 {
@@ -877,7 +876,7 @@ namespace Learner
                     if (--trials > 0 && !is_final)
                     {
                         cout
-                            << "reducing learning rate from " << global_learning_rate
+                            << "==> reducing learning rate from " << global_learning_rate
                             << " to " << (global_learning_rate * newbob_decay)
                             << " (" << trials << " more trials)" << endl;
 
@@ -887,7 +886,7 @@ namespace Learner
 
                 if (trials == 0)
                 {
-                    cout << "converged" << endl;
+                    cout << "==> converged" << endl;
                     return true;
                 }
             }

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -432,6 +432,8 @@ namespace Learner
         // If true, do not dig the folder.
         bool save_only_once;
 
+        bool verbose;
+
         double newbob_decay;
         int newbob_num_trials;
         uint64_t auto_lr_drop;
@@ -644,7 +646,7 @@ namespace Learner
         // should be no real issues happening since
         // the read/write phases are isolated.
         atomic_thread_fence(memory_order_seq_cst);
-        Eval::NNUE::update_parameters();
+        Eval::NNUE::update_parameters(epoch, verbose);
         atomic_thread_fence(memory_order_seq_cst);
 
         if (++save_count * mini_batch_size >= eval_save_interval)
@@ -943,6 +945,8 @@ namespace Learner
         // Turn on if you want to pass a pre-shuffled file.
         bool no_shuffle = false;
 
+        bool verbose = false;
+
         global_learning_rate = 1.0;
 
         // elmo lambda
@@ -1070,6 +1074,7 @@ namespace Learner
                 UCI::setoption("PruneAtShallowDepth", "false");
                 UCI::setoption("EnableTranspositionTable", "false");
             }
+            else if (option == "verbose") verbose = true;
             else
             {
                 cout << "Unknown option: " << option << ". Ignoring.\n";
@@ -1190,6 +1195,8 @@ namespace Learner
 
         learn_think.mini_batch_size = mini_batch_size;
         learn_think.validation_set_file_name = validation_set_file_name;
+
+        learn_think.verbose = verbose;
 
         cout << "init done." << endl;
 

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -677,7 +677,8 @@ namespace Learner
         TT.new_search();
         TimePoint elapsed = now() - Search::Limits.startTime + 1;
 
-        cout << "PROGRESS: " << now_string() << ", ";
+        cout << "\n";
+        cout << "PROGRESS (calc_loss): " << now_string() << ", ";
         cout << total_done << " sfens, ";
         cout << total_done * 1000 / elapsed  << " sfens/second";
         cout << ", iteration " << epoch;

--- a/src/learn/sfen_reader.h
+++ b/src/learn/sfen_reader.h
@@ -209,18 +209,19 @@ namespace Learner{
 
                     sfen_input_stream = open_sfen_input_file(currentFilename);
 
+                    auto out = sync_region_cout.new_region();
                     if (sfen_input_stream == nullptr)
                     {
-                        std::cout << "INFO (sfen_reader): File does not exist: " << currentFilename << '\n';
+                        out << "INFO (sfen_reader): File does not exist: " << currentFilename << '\n';
                     }
                     else
                     {
-                        std::cout << "INFO (sfen_reader): Opened file for reading: " << currentFilename << '\n';
+                        out << "INFO (sfen_reader): Opened file for reading: " << currentFilename << '\n';
 
                         // in case the file is empty or was deleted.
                         if (sfen_input_stream->eof())
                         {
-                            std::cout << "INFO (sfen_reader): File empty, nothing to read.\n";
+                            out << "==> File empty, nothing to read.\n";
                         }
                         else
                         {
@@ -232,7 +233,8 @@ namespace Learner{
 
             if (sfen_input_stream == nullptr && !open_next_file())
             {
-                std::cout << "INFO (sfen_reader): End of files." << std::endl;
+                auto out = sync_region_cout.new_region();
+                out << "INFO (sfen_reader): End of files." << std::endl;
                 end_of_files = true;
                 return;
             }
@@ -271,7 +273,8 @@ namespace Learner{
                         if(!open_next_file())
                         {
                             // There was no next file. Abort.
-                            std::cout << "INFO (sfen_reader): End of files." << std::endl;
+                            auto out = sync_region_cout.new_region();
+                            out << "INFO (sfen_reader): End of files." << std::endl;
                             end_of_files = true;
                             return;
                         }

--- a/src/learn/sfen_reader.h
+++ b/src/learn/sfen_reader.h
@@ -221,7 +221,7 @@ namespace Learner{
                         // in case the file is empty or was deleted.
                         if (sfen_input_stream->eof())
                         {
-                            out << "==> File empty, nothing to read.\n";
+                            out << "  - File empty, nothing to read.\n";
                         }
                         else
                         {

--- a/src/learn/sfen_reader.h
+++ b/src/learn/sfen_reader.h
@@ -83,7 +83,7 @@ namespace Learner{
                 PackedSfenValue ps;
                 if (!read_to_thread_buffer(0, ps))
                 {
-                    std::cout << "Error! read packed sfen , failed." << std::endl;
+                    std::cout << "ERROR (sfen_reader): Reading failed." << std::endl;
                     return sfen_for_mse;
                 }
 
@@ -211,16 +211,16 @@ namespace Learner{
 
                     if (sfen_input_stream == nullptr)
                     {
-                        std::cout << "File does not exist: " << currentFilename << '\n';
+                        std::cout << "INFO (sfen_reader): File does not exist: " << currentFilename << '\n';
                     }
                     else
                     {
-                        std::cout << "Opened file for reading: " << currentFilename << '\n';
+                        std::cout << "INFO (sfen_reader): Opened file for reading: " << currentFilename << '\n';
 
                         // in case the file is empty or was deleted.
                         if (sfen_input_stream->eof())
                         {
-                            std::cout << "File empty, nothing to read.\n";
+                            std::cout << "INFO (sfen_reader): File empty, nothing to read.\n";
                         }
                         else
                         {
@@ -232,7 +232,7 @@ namespace Learner{
 
             if (sfen_input_stream == nullptr && !open_next_file())
             {
-                std::cout << "..end of files." << std::endl;
+                std::cout << "INFO (sfen_reader): End of files." << std::endl;
                 end_of_files = true;
                 return;
             }
@@ -271,7 +271,7 @@ namespace Learner{
                         if(!open_next_file())
                         {
                             // There was no next file. Abort.
-                            std::cout << "..end of files." << std::endl;
+                            std::cout << "INFO (sfen_reader): End of files." << std::endl;
                             end_of_files = true;
                             return;
                         }

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -61,6 +61,8 @@ typedef bool(*fun3_t)(HANDLE, CONST GROUP_AFFINITY*, PGROUP_AFFINITY);
 
 using namespace std;
 
+SynchronizedRegionLogger sync_region_cout(std::cout);
+
 namespace {
 
 /// Version number. If Version is left empty, then compile date in the format

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -71,6 +71,12 @@ namespace Eval::NNUE {
             ",Network=" + Network::get_structure_string();
     }
 
+    std::string get_layers_info() {
+        return
+            FeatureTransformer::get_layers_info()
+            + '\n' + Network::get_layers_info();
+    }
+
     UseNNUEMode useNNUE;
     std::string eval_file_loaded = "None";
 

--- a/src/nnue/evaluate_nnue.h
+++ b/src/nnue/evaluate_nnue.h
@@ -81,6 +81,8 @@ namespace Eval::NNUE {
     // Get a string that represents the structure of the evaluation function
     std::string get_architecture_string();
 
+    std::string get_layers_info();
+
     // read the header
     bool read_header(std::istream& stream,
         std::uint32_t* hash_value, std::string* architecture);

--- a/src/nnue/evaluate_nnue_learner.cpp
+++ b/src/nnue/evaluate_nnue_learner.cpp
@@ -245,7 +245,7 @@ namespace Eval::NNUE {
     // save merit function parameters to a file
     void save_eval(std::string dir_name) {
         auto eval_dir = Path::combine(Options["EvalSaveDir"], dir_name);
-        std::cout << "save_eval() start. folder = " << eval_dir << std::endl;
+        std::cout << "INFO (save_eval): Saving current evaluation file in " << eval_dir << std::endl;
 
         // mkdir() will fail if this folder already exists, but
         // Apart from that. If not, I just want you to make it.
@@ -261,7 +261,5 @@ namespace Eval::NNUE {
 #ifndef NDEBUG
         assert(result);
 #endif
-
-        std::cout << "save_eval() finished. folder = " << eval_dir << std::endl;
     }
 }  // namespace Eval::NNUE

--- a/src/nnue/evaluate_nnue_learner.cpp
+++ b/src/nnue/evaluate_nnue_learner.cpp
@@ -247,7 +247,10 @@ namespace Eval::NNUE {
     // save merit function parameters to a file
     void save_eval(std::string dir_name) {
         auto eval_dir = Path::combine(Options["EvalSaveDir"], dir_name);
-        std::cout << "INFO (save_eval): Saving current evaluation file in " << eval_dir << std::endl;
+
+        auto out = sync_region_cout.new_region();
+
+        out << "INFO (save_eval): Saving current evaluation file in " << eval_dir << std::endl;
 
         // mkdir() will fail if this folder already exists, but
         // Apart from that. If not, I just want you to make it.
@@ -263,5 +266,6 @@ namespace Eval::NNUE {
 #ifndef NDEBUG
         assert(result);
 #endif
+        out << "INFO (save_eval): Saving current evaluation file in " << eval_dir << std::endl;
     }
 }  // namespace Eval::NNUE

--- a/src/nnue/evaluate_nnue_learner.cpp
+++ b/src/nnue/evaluate_nnue_learner.cpp
@@ -224,7 +224,9 @@ namespace Eval::NNUE {
             const double avg_abs_eval_diff = abs_eval_diff_sum / batch_size;
             const double avg_abs_discrete_eval = abs_discrete_eval_sum / batch_size;
 
-            std::cout << "INFO (update_parameters):"
+            auto out = sync_region_cout.new_region();
+
+            out << "INFO (update_parameters):"
                 << " epoch = " << epoch
                 << " , avg_abs(trainer_eval-nnue_eval) = " << avg_abs_eval_diff
                 << " , avg_abs(nnue_eval) = " << avg_abs_discrete_eval

--- a/src/nnue/evaluate_nnue_learner.cpp
+++ b/src/nnue/evaluate_nnue_learner.cpp
@@ -58,6 +58,13 @@ namespace Eval::NNUE {
         std::cout << "Initializing NN training for "
                   << get_architecture_string() << std::endl;
 
+        std::cout << std::endl;
+
+        std::cout << "Layers:\n"
+                  << get_layers_info() << std::endl;
+
+        std::cout << std::endl;
+
         assert(feature_transformer);
         assert(network);
         trainer = Trainer<Network>::create(network.get(), feature_transformer.get());

--- a/src/nnue/evaluate_nnue_learner.cpp
+++ b/src/nnue/evaluate_nnue_learner.cpp
@@ -54,23 +54,28 @@ namespace Eval::NNUE {
     }  // namespace
 
     // Initialize learning
-    void initialize_training(const std::string& seed) {
-        std::cout << "Initializing NN training for "
-                  << get_architecture_string() << std::endl;
+    void initialize_training(
+        const std::string& seed,
+        SynchronizedRegionLogger::Region& out) {
 
-        std::cout << std::endl;
+        out << "INFO (initialize_training): Initializing NN training for "
+            << get_architecture_string() << std::endl;
 
-        std::cout << "Layers:\n"
-                  << get_layers_info() << std::endl;
+        out << std::endl;
 
-        std::cout << std::endl;
+        out << "Layers:\n"
+            << get_layers_info() << std::endl;
+
+        out << std::endl;
 
         assert(feature_transformer);
         assert(network);
+
         trainer = Trainer<Network>::create(network.get(), feature_transformer.get());
         rng.seed(PRNG(seed).rand<uint64_t>());
 
         if (Options["SkipLoadingEval"]) {
+            out << "INFO (initialize_training): Performing random net initialization.\n";
             trainer->initialize(rng);
         }
     }

--- a/src/nnue/evaluate_nnue_learner.h
+++ b/src/nnue/evaluate_nnue_learner.h
@@ -27,7 +27,7 @@ namespace Eval::NNUE {
         double weight);
 
     // update the evaluation function parameters
-    void update_parameters();
+    void update_parameters(uint64_t epoch, bool verbose);
 
     // Check if there are any problems with learning
     void check_health();

--- a/src/nnue/evaluate_nnue_learner.h
+++ b/src/nnue/evaluate_nnue_learner.h
@@ -22,6 +22,7 @@ namespace Eval::NNUE {
     void add_example(
         Position& pos,
         Color rootColor,
+        Value discrete_nn_eval,
     	const Learner::PackedSfenValue& psv,
         double weight);
 

--- a/src/nnue/evaluate_nnue_learner.h
+++ b/src/nnue/evaluate_nnue_learner.h
@@ -3,11 +3,15 @@
 
 #include "learn/learn.h"
 
+#include "misc.h"
+
 // Interface used for learning NNUE evaluation function
 namespace Eval::NNUE {
 
     // Initialize learning
-    void initialize_training(const std::string& seed);
+    void initialize_training(
+        const std::string& seed,
+        SynchronizedRegionLogger::Region& out);
 
     // set the number of samples in the mini-batch
     void set_batch_size(uint64_t size);

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -57,6 +57,8 @@ namespace Eval::NNUE::Layers {
         static constexpr std::size_t kBufferSize =
             PreviousLayer::kBufferSize + kSelfBufferSize;
 
+        static constexpr int kLayerIndex = PreviousLayer::kLayerIndex + 1;
+
         // Hash value embedded in the evaluation file
         static constexpr std::uint32_t get_hash_value() {
             std::uint32_t hash_value = 0xCC03DAE4u;
@@ -66,12 +68,25 @@ namespace Eval::NNUE::Layers {
             return hash_value;
         }
 
-        // A string that represents the structure from the input layer to this layer
-        static std::string get_structure_string() {
+        static std::string get_name() {
             return "AffineTransform[" +
                 std::to_string(kOutputDimensions) + "<-" +
-                std::to_string(kInputDimensions) + "](" +
+                std::to_string(kInputDimensions) + "]";
+        }
+
+        // A string that represents the structure from the input layer to this layer
+        static std::string get_structure_string() {
+            return get_name() + "(" +
                 PreviousLayer::get_structure_string() + ")";
+        }
+
+        static std::string get_layers_info() {
+            std::string info = PreviousLayer::get_layers_info();
+            info += '\n';
+            info += std::to_string(kLayerIndex);
+            info += ": ";
+            info += get_name();
+            return info;
         }
 
        // Read network parameters

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -82,9 +82,9 @@ namespace Eval::NNUE::Layers {
 
         static std::string get_layers_info() {
             std::string info = PreviousLayer::get_layers_info();
-            info += '\n';
+            info += "\n  - ";
             info += std::to_string(kLayerIndex);
-            info += ": ";
+            info += " - ";
             info += get_name();
             return info;
         }

--- a/src/nnue/layers/clipped_relu.h
+++ b/src/nnue/layers/clipped_relu.h
@@ -76,9 +76,9 @@ namespace Eval::NNUE::Layers {
 
         static std::string get_layers_info() {
             std::string info = PreviousLayer::get_layers_info();
-            info += '\n';
+            info += "\n  - ";
             info += std::to_string(kLayerIndex);
-            info += ": ";
+            info += " - ";
             info += get_name();
             return info;
         }

--- a/src/nnue/layers/clipped_relu.h
+++ b/src/nnue/layers/clipped_relu.h
@@ -54,6 +54,8 @@ namespace Eval::NNUE::Layers {
         static constexpr std::size_t kBufferSize =
             PreviousLayer::kBufferSize + kSelfBufferSize;
 
+        static constexpr int kLayerIndex = PreviousLayer::kLayerIndex + 1;
+
         // Hash value embedded in the evaluation file
         static constexpr std::uint32_t get_hash_value() {
             std::uint32_t hash_value = 0x538D24C7u;
@@ -61,11 +63,24 @@ namespace Eval::NNUE::Layers {
             return hash_value;
         }
 
+        static std::string get_name() {
+            return "ClippedReLU[" +
+                std::to_string(kOutputDimensions) + "]";
+        }
+
         // A string that represents the structure from the input layer to this layer
         static std::string get_structure_string() {
-            return "ClippedReLU[" +
-                std::to_string(kOutputDimensions) + "](" +
+            return get_name() + "(" +
                 PreviousLayer::get_structure_string() + ")";
+        }
+
+        static std::string get_layers_info() {
+            std::string info = PreviousLayer::get_layers_info();
+            info += '\n';
+            info += std::to_string(kLayerIndex);
+            info += ": ";
+            info += get_name();
+            return info;
         }
 
         // Read network parameters

--- a/src/nnue/layers/input_slice.h
+++ b/src/nnue/layers/input_slice.h
@@ -65,8 +65,9 @@ namespace Eval::NNUE::Layers {
         }
 
         static std::string get_layers_info() {
-            std::string info = std::to_string(kLayerIndex);
-            info += ": ";
+            std::string info = "  - ";
+            info += std::to_string(kLayerIndex);
+            info += " - ";
             info += get_name();
             return info;
         }

--- a/src/nnue/layers/input_slice.h
+++ b/src/nnue/layers/input_slice.h
@@ -28,56 +28,69 @@
 
 namespace Eval::NNUE::Layers {
 
-  // Input layer
-  template <IndexType OutputDimensions, IndexType Offset = 0>
-  class InputSlice {
-  public:
-      // Need to maintain alignment
-      static_assert(Offset % kMaxSimdWidth == 0, "");
+    // Input layer
+    template <IndexType OutputDimensions, IndexType Offset = 0>
+    class InputSlice {
+    public:
+        // Need to maintain alignment
+        static_assert(Offset % kMaxSimdWidth == 0, "");
 
-      // Output type
-      using OutputType = TransformedFeatureType;
+        // Output type
+        using OutputType = TransformedFeatureType;
 
-      // Output dimensionality
-      static constexpr IndexType kOutputDimensions = OutputDimensions;
+        // Output dimensionality
+        static constexpr IndexType kOutputDimensions = OutputDimensions;
 
-      // Size of forward propagation buffer used from the input layer to this layer
-      static constexpr std::size_t kBufferSize = 0;
+        // Size of forward propagation buffer used from the input layer to this layer
+        static constexpr std::size_t kBufferSize = 0;
 
-      // Hash value embedded in the evaluation file
-      static constexpr std::uint32_t get_hash_value() {
-          std::uint32_t hash_value = 0xEC42E90Du;
-          hash_value ^= kOutputDimensions ^ (Offset << 10);
-          return hash_value;
-      }
+        static constexpr int kLayerIndex = 1;
 
-      // A string that represents the structure from the input layer to this layer
-      static std::string get_structure_string() {
-          return "InputSlice[" + std::to_string(kOutputDimensions) + "(" +
-              std::to_string(Offset) + ":" +
-              std::to_string(Offset + kOutputDimensions) + ")]";
-      }
+        // Hash value embedded in the evaluation file
+        static constexpr std::uint32_t get_hash_value() {
+            std::uint32_t hash_value = 0xEC42E90Du;
+            hash_value ^= kOutputDimensions ^ (Offset << 10);
+            return hash_value;
+        }
 
-      // Read network parameters
-      bool read_parameters(std::istream& /*stream*/) {
-          return true;
-      }
+        static std::string get_name() {
+            return "InputSlice[" + std::to_string(kOutputDimensions) + "(" +
+                std::to_string(Offset) + ":" +
+                std::to_string(Offset + kOutputDimensions) + ")]";
+        }
 
-      // write parameters
-      bool write_parameters(std::ostream& /*stream*/) const {
-          return true;
-      }
+        // A string that represents the structure from the input layer to this layer
+        static std::string get_structure_string() {
+            return get_name();
+        }
 
-      // Forward propagation
-      const OutputType* propagate(
-          const TransformedFeatureType* transformed_features,
-          char* /*buffer*/) const {
+        static std::string get_layers_info() {
+            std::string info = std::to_string(kLayerIndex);
+            info += ": ";
+            info += get_name();
+            return info;
+        }
 
-          return transformed_features + Offset;
-      }
+        // Read network parameters
+        bool read_parameters(std::istream& /*stream*/) {
+            return true;
+        }
 
-  private:
-  };
+        // write parameters
+        bool write_parameters(std::ostream& /*stream*/) const {
+            return true;
+        }
+
+        // Forward propagation
+        const OutputType* propagate(
+            const TransformedFeatureType* transformed_features,
+            char* /*buffer*/) const {
+
+            return transformed_features + Offset;
+        }
+
+    private:
+    };
 
 }  // namespace Layers
 

--- a/src/nnue/layers/sum.h
+++ b/src/nnue/layers/sum.h
@@ -60,9 +60,9 @@ namespace Eval::NNUE::Layers {
 
         static std::string get_layers_info() {
             std::string info = Tail::get_layers_info();
-            info += '\n';
+            info += "\n  - ";
             info += std::to_string(kLayerIndex);
-            info += ": ";
+            info += " - ";
             info += get_name();
             return info;
         }

--- a/src/nnue/layers/sum.h
+++ b/src/nnue/layers/sum.h
@@ -36,6 +36,8 @@ namespace Eval::NNUE::Layers {
         static constexpr std::size_t kBufferSize =
             std::max(Head::kBufferSize + kSelfBufferSize, Tail::kBufferSize);
 
+        static constexpr int kLayerIndex = Tail::kLayerIndex + 1;
+
         // Hash value embedded in the evaluation function file
         static constexpr std::uint32_t get_hash_value() {
             std::uint32_t hash_value = 0xBCE400B4u;
@@ -46,10 +48,23 @@ namespace Eval::NNUE::Layers {
             return hash_value;
         }
 
+        static std::string get_name() {
+             return "Sum[" +
+                std::to_string(kOutputDimensions) + "]";
+        }
+
         // A string that represents the structure from the input layer to this layer
         static std::string get_structure_string() {
-            return "Sum[" +
-                std::to_string(kOutputDimensions) + "](" + get_summands_string() + ")";
+            return get_name() + "(" + get_summands_string() + ")";
+        }
+
+        static std::string get_layers_info() {
+            std::string info = Tail::get_layers_info();
+            info += '\n';
+            info += std::to_string(kLayerIndex);
+            info += ": ";
+            info += get_name();
+            return info;
         }
 
         // read parameters
@@ -117,6 +132,8 @@ namespace Eval::NNUE::Layers {
         // Size of the forward propagation buffer used from the input layer to this layer
         static constexpr std::size_t kBufferSize = PreviousLayer::kBufferSize;
 
+        static constexpr int kLayerIndex = PreviousLayer::kLayerIndex + 1;
+
         // Hash value embedded in the evaluation function file
         static constexpr std::uint32_t get_hash_value() {
             std::uint32_t hash_value = 0xBCE400B4u;
@@ -125,10 +142,23 @@ namespace Eval::NNUE::Layers {
             return hash_value;
         }
 
+        static std::string get_name() {
+             return "Sum[" +
+                std::to_string(kOutputDimensions) + "]";
+        }
+
         // A string that represents the structure from the input layer to this layer
         static std::string get_structure_string() {
-            return "Sum[" +
-                std::to_string(kOutputDimensions) + "](" + get_summands_string() + ")";
+            return get_name() + "(" + get_summands_string() + ")";
+        }
+
+        static std::string get_layers_info() {
+            std::string info = PreviousLayer::get_layers_info();
+            info += '\n';
+            info += std::to_string(kLayerIndex);
+            info += ": ";
+            info += get_name();
+            return info;
         }
 
         // read parameters

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -130,8 +130,9 @@ namespace Eval::NNUE {
         }
 
         static std::string get_layers_info() {
-            std::string info = std::to_string(kLayerIndex);
-            info += ": ";
+            std::string info = "  - ";
+            info += std::to_string(kLayerIndex);
+            info += " - ";
             info += get_name();
             return info;
         }

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -110,17 +110,30 @@ namespace Eval::NNUE {
         static constexpr std::size_t kBufferSize =
             kOutputDimensions * sizeof(OutputType);
 
+        static constexpr int kLayerIndex = 0;
+
         // Hash value embedded in the evaluation file
         static constexpr std::uint32_t get_hash_value() {
 
             return RawFeatures::kHashValue ^ kOutputDimensions;
         }
 
-        // a string representing the structure
-        static std::string get_structure_string() {
+        static std::string get_name() {
             return RawFeatures::get_name() + "[" +
                 std::to_string(kInputDimensions) + "->" +
                 std::to_string(kHalfDimensions) + "x2]";
+        }
+
+        // a string representing the structure
+        static std::string get_structure_string() {
+            return get_name();
+        }
+
+        static std::string get_layers_info() {
+            std::string info = std::to_string(kLayerIndex);
+            info += ": ";
+            info += get_name();
+            return info;
         }
 
         // Read network parameters

--- a/src/nnue/trainer/trainer.h
+++ b/src/nnue/trainer/trainer.h
@@ -68,6 +68,7 @@ namespace Eval::NNUE {
     struct Example {
         std::vector<TrainingFeature> training_features[2];
         Learner::PackedSfenValue psv;
+        Value discrete_nn_eval;
         int sign;
         double weight;
     };

--- a/src/nnue/trainer/trainer_affine_transform.h
+++ b/src/nnue/trainer/trainer_affine_transform.h
@@ -241,6 +241,15 @@ namespace Eval::NNUE {
 
         void check_health() {
 
+            double abs_bias_sum = 0.0;
+            double abs_weight_sum = 0.0;
+
+            for(auto b : biases_)
+                abs_bias_sum += std::abs(b);
+
+            for(auto w : weights_)
+                abs_weight_sum += std::abs(w);
+
             auto out = sync_region_cout.new_region();
 
             out << "INFO (check_health):"
@@ -248,7 +257,9 @@ namespace Eval::NNUE {
                 << " - " << LayerType::get_name()
                 << std::endl;
 
+            out << "  - avg_abs_bias        = " << abs_bias_sum / std::size(biases_) << std::endl;
             out << "  - avg_abs_bias_diff   = " << abs_biases_diff_sum_ / num_biases_diffs_ << std::endl;
+            out << "  - avg_abs_weight      = " << abs_weight_sum / std::size(weights_) << std::endl;
             out << "  - avg_abs_weight_diff = " << abs_weights_diff_sum_ / num_weights_diffs_ << std::endl;
 
             out.unlock();

--- a/src/nnue/trainer/trainer_clipped_relu.h
+++ b/src/nnue/trainer/trainer_clipped_relu.h
@@ -99,8 +99,13 @@ namespace Eval::NNUE {
             const auto smallest_max_activation = *std::min_element(
                 std::begin(max_activations_), std::end(max_activations_));
 
-            std::cout << "INFO: largest min activation = " << largest_min_activation
-                      << ", smallest max activation = " << smallest_max_activation
+            std::cout << "INFO (check_health):"
+                      << " layer = " << LayerType::kLayerIndex
+                      << " , name = " << LayerType::get_name()
+                      << std::endl;
+
+            std::cout << "--> largest min activation = " << largest_min_activation
+                      << " , smallest max activation = " << smallest_max_activation
                       << std::endl;
 
             std::fill(std::begin(min_activations_), std::end(min_activations_),

--- a/src/nnue/trainer/trainer_clipped_relu.h
+++ b/src/nnue/trainer/trainer_clipped_relu.h
@@ -100,11 +100,11 @@ namespace Eval::NNUE {
                 std::begin(max_activations_), std::end(max_activations_));
 
             std::cout << "INFO (check_health):"
-                      << " layer = " << LayerType::kLayerIndex
-                      << " , name = " << LayerType::get_name()
+                      << " layer " << LayerType::kLayerIndex
+                      << " - " << LayerType::get_name()
                       << std::endl;
 
-            std::cout << "--> largest min activation = " << largest_min_activation
+            std::cout << "==> largest min activation = " << largest_min_activation
                       << " , smallest max activation = " << smallest_max_activation
                       << std::endl;
 

--- a/src/nnue/trainer/trainer_clipped_relu.h
+++ b/src/nnue/trainer/trainer_clipped_relu.h
@@ -94,19 +94,24 @@ namespace Eval::NNUE {
 
         // Check if there are any problems with learning
         void check_health() {
+
             const auto largest_min_activation = *std::max_element(
                 std::begin(min_activations_), std::end(min_activations_));
             const auto smallest_max_activation = *std::min_element(
                 std::begin(max_activations_), std::end(max_activations_));
 
-            std::cout << "INFO (check_health):"
-                      << " layer " << LayerType::kLayerIndex
-                      << " - " << LayerType::get_name()
-                      << std::endl;
+            auto out = sync_region_cout.new_region();
 
-            std::cout << "==> largest min activation = " << largest_min_activation
-                      << " , smallest max activation = " << smallest_max_activation
-                      << std::endl;
+            out << "INFO (check_health):"
+                << " layer " << LayerType::kLayerIndex
+                << " - " << LayerType::get_name()
+                << std::endl;
+
+            out << "==> largest min activation = " << largest_min_activation
+                << " , smallest max activation = " << smallest_max_activation
+                << std::endl;
+
+            out.unlock();
 
             std::fill(std::begin(min_activations_), std::end(min_activations_),
                       std::numeric_limits<LearnFloatType>::max());

--- a/src/nnue/trainer/trainer_clipped_relu.h
+++ b/src/nnue/trainer/trainer_clipped_relu.h
@@ -107,7 +107,7 @@ namespace Eval::NNUE {
                 << " - " << LayerType::get_name()
                 << std::endl;
 
-            out << "==> largest min activation = " << largest_min_activation
+            out << "  - largest min activation = " << largest_min_activation
                 << " , smallest max activation = " << smallest_max_activation
                 << std::endl;
 

--- a/src/nnue/trainer/trainer_feature_transformer.h
+++ b/src/nnue/trainer/trainer_feature_transformer.h
@@ -349,7 +349,7 @@ namespace Eval::NNUE {
 
             std::cout << "INFO: largest min activation = " << largest_min_activation
                       << ", smallest max activation = " << smallest_max_activation
-                      << std::endl << std::endl;
+                      << std::endl;
 
             std::fill(std::begin(min_activations_), std::end(min_activations_),
                       std::numeric_limits<LearnFloatType>::max());

--- a/src/nnue/trainer/trainer_feature_transformer.h
+++ b/src/nnue/trainer/trainer_feature_transformer.h
@@ -331,11 +331,11 @@ namespace Eval::NNUE {
         // Check if there are any problems with learning
         void check_health() {
             std::cout << "INFO (check_health):"
-                      << " layer = " << LayerType::kLayerIndex
-                      << " , name = " << LayerType::get_name()
+                      << " layer " << LayerType::kLayerIndex
+                      << " - " << LayerType::get_name()
                       << std::endl;
 
-            std::cout << "--> observed " << observed_features.count()
+            std::cout << "==> observed " << observed_features.count()
                       << " (out of " << kInputDimensions << ") features"
                       << std::endl;
 
@@ -343,7 +343,7 @@ namespace Eval::NNUE {
                 std::numeric_limits<typename LayerType::WeightType>::max() /
                 kWeightScale;
 
-            std::cout << "--> (min, max) of pre-activations = "
+            std::cout << "==> (min, max) of pre-activations = "
                       << min_pre_activation_ << ", "
                       << max_pre_activation_ << " (limit = "
                       << kPreActivationLimit << ")"
@@ -354,7 +354,7 @@ namespace Eval::NNUE {
             const auto smallest_max_activation = *std::min_element(
                 std::begin(max_activations_), std::end(max_activations_));
 
-            std::cout << "--> largest min activation = " << largest_min_activation
+            std::cout << "==> largest min activation = " << largest_min_activation
                       << " , smallest max activation = " << smallest_max_activation
                       << std::endl;
 

--- a/src/nnue/trainer/trainer_feature_transformer.h
+++ b/src/nnue/trainer/trainer_feature_transformer.h
@@ -347,17 +347,17 @@ namespace Eval::NNUE {
                 << " - " << LayerType::get_name()
                 << std::endl;
 
-            out << "==> observed " << observed_features.count()
+            out << "  - observed " << observed_features.count()
                 << " (out of " << kInputDimensions << ") features"
                 << std::endl;
 
-            out << "==> (min, max) of pre-activations = "
+            out << "  - (min, max) of pre-activations = "
                 << min_pre_activation_ << ", "
                 << max_pre_activation_ << " (limit = "
                 << kPreActivationLimit << ")"
                 << std::endl;
 
-            out << "==> largest min activation = " << largest_min_activation
+            out << "  - largest min activation = " << largest_min_activation
                 << " , smallest max activation = " << smallest_max_activation
                 << std::endl;
 

--- a/src/nnue/trainer/trainer_feature_transformer.h
+++ b/src/nnue/trainer/trainer_feature_transformer.h
@@ -330,25 +330,32 @@ namespace Eval::NNUE {
 
         // Check if there are any problems with learning
         void check_health() {
-            std::cout << "INFO: observed " << observed_features.count()
-                      << " (out of " << kInputDimensions << ") features" << std::endl;
+            std::cout << "INFO (check_health):"
+                      << " layer = " << LayerType::kLayerIndex
+                      << " , name = " << LayerType::get_name()
+                      << std::endl;
+
+            std::cout << "--> observed " << observed_features.count()
+                      << " (out of " << kInputDimensions << ") features"
+                      << std::endl;
 
             constexpr LearnFloatType kPreActivationLimit =
                 std::numeric_limits<typename LayerType::WeightType>::max() /
                 kWeightScale;
 
-            std::cout << "INFO: (min, max) of pre-activations = "
+            std::cout << "--> (min, max) of pre-activations = "
                       << min_pre_activation_ << ", "
                       << max_pre_activation_ << " (limit = "
-                      << kPreActivationLimit << ")" << std::endl;
+                      << kPreActivationLimit << ")"
+                      << std::endl;
 
             const auto largest_min_activation = *std::max_element(
                 std::begin(min_activations_), std::end(min_activations_));
             const auto smallest_max_activation = *std::min_element(
                 std::begin(max_activations_), std::end(max_activations_));
 
-            std::cout << "INFO: largest min activation = " << largest_min_activation
-                      << ", smallest max activation = " << smallest_max_activation
+            std::cout << "--> largest min activation = " << largest_min_activation
+                      << " , smallest max activation = " << smallest_max_activation
                       << std::endl;
 
             std::fill(std::begin(min_activations_), std::end(min_activations_),

--- a/src/nnue/trainer/trainer_feature_transformer.h
+++ b/src/nnue/trainer/trainer_feature_transformer.h
@@ -349,6 +349,15 @@ namespace Eval::NNUE {
             const auto smallest_max_activation = *std::min_element(
                 std::begin(max_activations_), std::end(max_activations_));
 
+            double abs_bias_sum = 0.0;
+            double abs_weight_sum = 0.0;
+
+            for(auto b : biases_)
+                abs_bias_sum += std::abs(b);
+
+            for(auto w : weights_)
+                abs_weight_sum += std::abs(w);
+
             auto out = sync_region_cout.new_region();
 
             out << "INFO (check_health):"
@@ -369,6 +378,9 @@ namespace Eval::NNUE {
             out << "  - largest min activation = " << largest_min_activation
                 << " , smallest max activation = " << smallest_max_activation
                 << std::endl;
+
+            out << "  - avg_abs_bias   = " << abs_bias_sum / std::size(biases_) << std::endl;
+            out << "  - avg_abs_weight = " << abs_weight_sum / std::size(weights_) << std::endl;
 
             out << "  - clipped " << static_cast<double>(num_clipped_) / num_total_ * 100.0 << "% of outputs"
                 << std::endl;

--- a/src/nnue/trainer/trainer_feature_transformer.h
+++ b/src/nnue/trainer/trainer_feature_transformer.h
@@ -330,33 +330,38 @@ namespace Eval::NNUE {
 
         // Check if there are any problems with learning
         void check_health() {
-            std::cout << "INFO (check_health):"
-                      << " layer " << LayerType::kLayerIndex
-                      << " - " << LayerType::get_name()
-                      << std::endl;
-
-            std::cout << "==> observed " << observed_features.count()
-                      << " (out of " << kInputDimensions << ") features"
-                      << std::endl;
 
             constexpr LearnFloatType kPreActivationLimit =
                 std::numeric_limits<typename LayerType::WeightType>::max() /
                 kWeightScale;
-
-            std::cout << "==> (min, max) of pre-activations = "
-                      << min_pre_activation_ << ", "
-                      << max_pre_activation_ << " (limit = "
-                      << kPreActivationLimit << ")"
-                      << std::endl;
 
             const auto largest_min_activation = *std::max_element(
                 std::begin(min_activations_), std::end(min_activations_));
             const auto smallest_max_activation = *std::min_element(
                 std::begin(max_activations_), std::end(max_activations_));
 
-            std::cout << "==> largest min activation = " << largest_min_activation
-                      << " , smallest max activation = " << smallest_max_activation
-                      << std::endl;
+            auto out = sync_region_cout.new_region();
+
+            out << "INFO (check_health):"
+                << " layer " << LayerType::kLayerIndex
+                << " - " << LayerType::get_name()
+                << std::endl;
+
+            out << "==> observed " << observed_features.count()
+                << " (out of " << kInputDimensions << ") features"
+                << std::endl;
+
+            out << "==> (min, max) of pre-activations = "
+                << min_pre_activation_ << ", "
+                << max_pre_activation_ << " (limit = "
+                << kPreActivationLimit << ")"
+                << std::endl;
+
+            out << "==> largest min activation = " << largest_min_activation
+                << " , smallest max activation = " << smallest_max_activation
+                << std::endl;
+
+            out.unlock();
 
             std::fill(std::begin(min_activations_), std::end(min_activations_),
                       std::numeric_limits<LearnFloatType>::max());

--- a/tests/instrumented_learn.sh
+++ b/tests/instrumented_learn.sh
@@ -129,7 +129,7 @@ cat << EOF > learn01.exp
  send "isready\n"
  send "learn targetdir training_data epochs 1 sfen_read_size 100 thread_buffer_size 10 batchsize 100 use_draw_in_training 1 use_draw_in_validation 1 lr 1 eval_limit 32000 nn_batch_size 30 newbob_decay 0.5 eval_save_interval 30 loss_output_interval 10 validation_set_file_name validation_data/validation_data.bin\n"
 
- expect "save_eval() finished."
+ expect "INFO (save_eval): Saving current evaluation file in"
 
  send "quit\n"
  expect eof


### PR DESCRIPTION
This PR improves the diagnostics during learn by the following means:

- unification of the message format
- a `verbose` flag for `learn` that can be used to enable more granular diagnostics
- in `update_parameters` when `verbose == true` there is additional output regarding the gradients and the differences between evaluation of the discretized net and the trained net (they should be relatively close, otherwise things are wrong)
- display of layers and their indices in forward order before learning.
- display of layer name for which `check_health` is performed
- `check_health` for affine transform layer with average biases, weights, and last changes to them
- `check_health` in clipped relu and feature transformer shows the % of clipped outputs
- `check_health` in the feature transformer shows the average abs bias and weight
- output is synchronized in regions in a non-blocking manner. So for example during calc_loss all outputs will be seen on the console without interleaving from other sources (like sfen reader), but the other sources will not need to wait for calc_loss completion during io.
- all `learn` parameters are printed

Sample output with `verbose`
```
Stockfish 241020 by the Stockfish developers (see AUTHORS file)
info string Loaded eval file nn-98a7585c85e9.nnue
setoption name SkipLoadingEval value true
setoption name Threads value 4
setoption name Use NNUE value pure
learn targetdir data_q epochs 400 batchsize 100000 use_draw_in_training 1 use_d
aw_in_validation 1 lr 1 lambda 1 eval_limit 32000 nn_batch_size 1000 newbob_dec
y 0.99 eval_save_interval 10000000 loss_output_interval 1000000 set_recommended
uci_options verbose
INFO: Executing learn command
INFO: Input files:
  - data_q/10m_d3_2.binpack
INFO: Parameters:
  - epochs                   : 400
  - epochs * minibatch size  : 40000000
  - eval_limit               : 32000
  - save_only_once           : false
  - shuffle on read          : true
  - Loss Function            : ELMO_METHOD(WCSC27)
  - minibatch size           : 100000
  - nn_batch_size            : 1000
  - nn_options               :
  - learning rate            : 1
  - use draws in training    : 1
  - use draws in validation  : 1
  - skip repeated positions  : 1
  - winning prob coeff       : 0.00276753
  - use_wdl                  : 0
  - src_score_min_value      : 0
  - src_score_max_value      : 1
  - dest_score_min_value     : 0
  - dest_score_max_value     : 1
  - reduction_gameply        : 1
  - LAMBDA                   : 1
  - LAMBDA2                  : 1
  - LAMBDA_LIMIT             : 32000
  - eval_save_interval       : 10000000 sfens
  - loss_output_interval     : 1000000 sfens
  - sfen_read_size           : 10000000
  - thread_buffer_size       : 10000
  - seed                     :
  - verbose                  : true
  - learning rate scheduling : newbob with decay
  - newbob_decay             : 0.99
  - newbob_num_trials        : 4

INFO: Started initialization.
INFO (initialize_training): Initializing NN training for Features=HalfKP(Friend
[41024->256x2],Network=AffineTransform[1<-32](ClippedReLU[32](AffineTransform[3
<-32](ClippedReLU[32](AffineTransform[32<-512](InputSlice[512(0:512)])))))

Layers:
  - 0 - HalfKP(Friend)[41024->256x2]
  - 1 - InputSlice[512(0:512)]
  - 2 - AffineTransform[32<-512]
  - 3 - ClippedReLU[32]
  - 4 - AffineTransform[32<-32]
  - 5 - ClippedReLU[32]
  - 6 - AffineTransform[1<-32]

INFO (initialize_training): Performing random net initialization.
Finished initialization.
info string NNUE evaluation using  enabled
INFO (sfen_reader): Opened file for reading: data_q/10m_d3_2.binpack

PROGRESS (calc_loss): Sun Oct 25 11:41:12 2020, 0 sfens, 0 sfens/second, epoch

  - learning rate = 1
  - startpos eval = 0
  - test_cross_entropy_eval = 0.693145
  - test_cross_entropy_win  = 0.693145
  - test_entropy_eval       = 0.242816
  - test_entropy_win        = 0.17987
  - test_cross_entropy      = 0.693145
  - test_entropy            = 0.242816
  - norm = 0
  - move accuracy = 8.2%
INFO (sfen_reader): Opened file for reading: data_q/10m_d3_2.binpack
INFO (learn): initial loss = 0.450329
INFO (update_parameters): epoch = 1 , avg_abs(trainer_eval-nnue_eval) = 0 , avg
abs(nnue_eval) = 0 , avg_relative_error = nan , batch_size = 1000 , grad_norm =
398.662
INFO (update_parameters): epoch = 2 , avg_abs(trainer_eval-nnue_eval) = 2.249 ,
avg_abs(nnue_eval) = 54.561 , avg_relative_error = 0.0412199 , batch_size = 100
 , grad_norm = 377.229
INFO (update_parameters): epoch = 3 , avg_abs(trainer_eval-nnue_eval) = 5.958 ,
avg_abs(nnue_eval) = 22.385 , avg_relative_error = 0.26616 , batch_size = 1000
 grad_norm = 387.942
INFO (update_parameters): epoch = 4 , avg_abs(trainer_eval-nnue_eval) = 0 , avg
abs(nnue_eval) = 85 , avg_relative_error = 0 , batch_size = 1000 , grad_norm =
85.77
INFO (update_parameters): epoch = 5 , avg_abs(trainer_eval-nnue_eval) = 0 , avg
abs(nnue_eval) = 89 , avg_relative_error = 0 , batch_size = 1000 , grad_norm =
83.685
INFO (update_parameters): epoch = 6 , avg_abs(trainer_eval-nnue_eval) = 1 , avg
abs(nnue_eval) = 66 , avg_relative_error = 0.0151515 , batch_size = 1000 , grad
norm = 386.288
INFO (update_parameters): epoch = 7 , avg_abs(trainer_eval-nnue_eval) = 1 , avg
abs(nnue_eval) = 90 , avg_relative_error = 0.0111111 , batch_size = 1000 , grad
norm = 387.619
INFO (update_parameters): epoch = 8 , avg_abs(trainer_eval-nnue_eval) = 1 , avg
abs(nnue_eval) = 112 , avg_relative_error = 0.00892857 , batch_size = 1000 , gr
d_norm = 384.495
INFO (update_parameters): epoch = 9 , avg_abs(trainer_eval-nnue_eval) = 0.999 ,
avg_abs(nnue_eval) = 86 , avg_relative_error = 0.0116163 , batch_size = 1000 ,
rad_norm = 383.212
INFO (update_parameters): epoch = 10 , avg_abs(trainer_eval-nnue_eval) = 0 , av
_abs(nnue_eval) = 68 , avg_relative_error = 0 , batch_size = 1000 , grad_norm =
386.544

PROGRESS (calc_loss): Sun Oct 25 11:42:09 2020, 1000000 sfens, 14627 sfens/seco
d, epoch 10
  - learning rate = 1
  - startpos eval = -90
  - test_cross_entropy_eval = 0.686913
  - test_cross_entropy_win  = 0.689483
  - test_entropy_eval       = 0.242816
  - test_entropy_win        = 0.17987
  - test_cross_entropy      = 0.686913
  - test_entropy            = 0.242816
  - learn_cross_entropy_eval = 0.684886
  - learn_cross_entropy_win  = 0.686634
  - learn_entropy_eval       = 0.24585
  - learn_entropy_win        = 0.179299
  - learn_cross_entropy      = 0.684886
  - learn_entropy            = 0.24585
  - norm = 179998
  - move accuracy = 15.45%
INFO (check_health): layer 0 - HalfKP(Friend)[41024->256x2]
  - observed 36765 (out of 43979) features
  - (min, max) of pre-activations = -0.51018, 1.26212 (limit = 258.008)
  - largest min activation = 0.194051 , smallest max activation = 0.777574
  - avg_abs_bias   = 0.489351
  - avg_abs_weight = 0.0136302
  - clipped 0.165504% of outputs
INFO (check_health): layer 2 - AffineTransform[32<-512]
  - avg_abs_bias        = 0.476143
  - avg_abs_bias_diff   = 9.44856e-05
  - avg_abs_weight      = 0.0369289
  - avg_abs_weight_diff = 4.5695e-05
INFO (check_health): layer 3 - ClippedReLU[32]
  - largest min activation = 0.270169 , smallest max activation = 0.707944
  - clipped 95.3126% of outputs
INFO (check_health): layer 4 - AffineTransform[32<-32]
  - avg_abs_bias        = 0.528737
  - avg_abs_bias_diff   = 0.000241153
  - avg_abs_weight      = 0.146225
  - avg_abs_weight_diff = 0.000136273
INFO (check_health): layer 5 - ClippedReLU[32]
  - largest min activation = 0 , smallest max activation = 0.699718
  - clipped 90.7555% of outputs
INFO (check_health): layer 6 - AffineTransform[1<-32]
  - avg_abs_bias        = 0.152287
  - avg_abs_bias_diff   = 0.0185096
  - avg_abs_weight      = 0.074096
  - avg_abs_weight_diff = 0.000941143
INFO (update_parameters): epoch = 11 , avg_abs(trainer_eval-nnue_eval) = 0.001
 avg_abs(nnue_eval) = 90 , avg_relative_error = 1.11111e-05 , batch_size = 1000
, grad_norm = 381.33
```