### PR TITLE
Improve gensfen

### DIFF
--- a/src/learn/gensfen.cpp
+++ b/src/learn/gensfen.cpp
@@ -61,6 +61,8 @@ namespace Learner
 
         ~SfenWriter()
         {
+            flush();
+
             finished = true;
             file_worker_thread.join();
             output_file_stream.reset();
@@ -105,8 +107,16 @@ namespace Learner
             }
         }
 
+        void flush()
+        {
+            for (size_t i = 0; i < sfen_buffers.size(); ++i)
+            {
+                flush(i);
+            }
+        }
+
         // Move what remains in the buffer for your thread to a buffer for writing to a file.
-        void finalize(size_t thread_id)
+        void flush(size_t thread_id)
         {
             std::unique_lock<std::mutex> lk(mutex);
 
@@ -356,6 +366,8 @@ namespace Learner
             gensfen_worker(th, counter, limit);
         });
         Threads.wait_for_workers_finished();
+
+        sfen_writer.flush();
 
         if (limit % REPORT_STATS_EVERY != 0)
         {
@@ -842,8 +854,6 @@ namespace Learner
 
             }
         }
-
-        sfen_writer.finalize(th.thread_idx());
     }
 
     void set_gensfen_search_limits()

--- a/src/learn/gensfen.h
+++ b/src/learn/gensfen.h
@@ -8,7 +8,7 @@
 namespace Learner {
 
     // Automatic generation of teacher position
-    void gen_sfen(Position& pos, std::istringstream& is);
+    void gensfen(std::istringstream& is);
 }
 
 #endif

--- a/src/misc.h
+++ b/src/misc.h
@@ -84,6 +84,11 @@ struct SynchronizedRegionLogger
   {
     friend struct SynchronizedRegionLogger;
 
+    Region() :
+      logger(nullptr), region_id(0), is_held(false)
+    {
+    }
+
     Region(const Region&) = delete;
     Region& operator=(const Region&) = delete;
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -338,7 +338,7 @@ void UCI::loop(int argc, char* argv[]) {
       else if (token == "eval")     trace_eval(pos);
       else if (token == "compiler") sync_cout << compiler_info() << sync_endl;
 
-      else if (token == "gensfen") Learner::gen_sfen(pos, is);
+      else if (token == "gensfen") Learner::gensfen(is);
       else if (token == "learn") Learner::learn(pos, is);
       else if (token == "convert") Learner::convert(is);
       else if (token == "convert_bin") Learner::convert_bin(is);

--- a/tests/instrumented_learn.sh
+++ b/tests/instrumented_learn.sh
@@ -79,11 +79,11 @@ cat << EOF > gensfen01.exp
  send "setoption name Use NNUE value false\n"
  send "isready\n"
  send "gensfen depth 3 loop 100 use_draw_in_training_data_generation 1 eval_limit 32000 output_file_name training_data/training_data.bin sfen_format bin\n"
- expect "gensfen finished."
+ expect "INFO: Gensfen finished."
  send "convert_plain targetfile training_data/training_data.bin output_file_name training_data.txt\n"
  expect "all done"
  send "gensfen depth 3 loop 100 use_draw_in_training_data_generation 1 eval_limit 32000 output_file_name training_data/training_data.binpack sfen_format binpack\n"
- expect "gensfen finished."
+ expect "INFO: Gensfen finished."
 
  send "quit\n"
  expect eof
@@ -105,9 +105,9 @@ cat << EOF > gensfen02.exp
  send "setoption name Use NNUE value true\n"
  send "isready\n"
  send "gensfen depth 4 loop 50 use_draw_in_training_data_generation 1 eval_limit 32000 output_file_name validation_data/validation_data.bin sfen_format bin\n"
- expect "gensfen finished."
+ expect "INFO: Gensfen finished."
  send "gensfen depth 4 loop 50 use_draw_in_training_data_generation 1 eval_limit 32000 output_file_name validation_data/validation_data.binpack sfen_format binpack\n"
- expect "gensfen finished."
+ expect "INFO: Gensfen finished."
 
  send "quit\n"
  expect eof
@@ -129,7 +129,7 @@ cat << EOF > learn01.exp
  send "isready\n"
  send "learn targetdir training_data epochs 1 sfen_read_size 100 thread_buffer_size 10 batchsize 100 use_draw_in_training 1 use_draw_in_validation 1 lr 1 eval_limit 32000 nn_batch_size 30 newbob_decay 0.5 eval_save_interval 30 loss_output_interval 10 validation_set_file_name validation_data/validation_data.bin\n"
 
- expect "INFO (save_eval): Saving current evaluation file in"
+ expect "INFO (save_eval): Finished saving evaluation file in"
 
  send "quit\n"
  expect eof


### PR DESCRIPTION
This PR makes the gensfen work on the stockfish's thread pool instead of using multithink. It also performs other minor changes:

- a collective parameter struct with clear defaults
- progress output is moved from sfen writer to gensfen and is more responsive
- sfen writer now correctly flushes the output when it's destroyed.
- clarity of the info messages is improved
- gensfen state is encapsulated better
- output is sychronized such that "created file" from sfen writer won't break the progress output from gensfen
- the race conditions that resulted in the number of emitted positions sometimes deviating from `loop_max` are now gone
- all parameters are printed