### PR TITLE
Replace non-blas parts of trainers with our own blas-like routines.

### DIFF
--- a/tests/instrumented_learn.sh
+++ b/tests/instrumented_learn.sh
@@ -129,7 +129,7 @@ cat << EOF > learn01.exp
  send "isready\n"
  send "learn targetdir training_data epochs 1 sfen_read_size 100 thread_buffer_size 10 batchsize 100 use_draw_in_training 1 use_draw_in_validation 1 lr 1 eval_limit 32000 nn_batch_size 30 newbob_decay 0.5 eval_save_interval 30 loss_output_interval 10 validation_set_file_name validation_data/validation_data.bin\n"
 
- expect "INFO (save_eval): Finished saving evaluation file in"
+ expect "INFO (save_eval): Finished saving evaluation file in evalsave/final"
 
  send "quit\n"
  expect eof


### PR DESCRIPTION
This PR replaces the manual non-blas loops inside the trainers with our new implementation of blas-like routines. The interface is almost the same but for now I would like to keep clear separation between our and external blas. In the future we may consider coalescing the calls somehow.

This makes the compiles with `blas=no` about as fast on my setup as compiles with `blas=yes`. YMMV for >=AVX as it's not optimized for yet.