### PR TITLE
Move collection of observed features to a parallelized loop.

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -400,7 +400,7 @@ inline uint64_t mul_hi64(uint64_t a, uint64_t b) {
 // This bitset can be accessed concurrently, provided
 // the concurrent accesses are performed on distinct
 // instances of underlying type. That means the cuncurrent
-// accesses need to be spaced by at least 
+// accesses need to be spaced by at least
 // bits_per_bucket bits.
 // But at least best_concurrent_access_stride bits
 // is recommended to prevent false sharing.
@@ -417,6 +417,11 @@ public:
     constexpr static uint64_t bits_per_bucket = 8 * sizeof(uint64_t);
     constexpr static uint64_t num_buckets = (num_bits + bits_per_bucket - 1) / bits_per_bucket;
     constexpr static uint64_t best_concurrent_access_stride = 8 * cache_line_size;
+
+    LargeBitset()
+    {
+        std::fill(std::begin(bits), std::end(bits), 0);
+    }
 
     void set(uint64_t idx)
     {


### PR DESCRIPTION
This PR introduces a bitset that provides important guarantees about concurrent access. It allows each thread to independently work on different parts of the bitset. This new bitset is utilized in the trainer feature transformer to move the observed features counting loop to the parallelized one that already goes through the features. Also, previously the stride for threads was 1, not it is 512 so that the concurrent bitset access is possible and fast. This is in an effort to parallelize the sequential bits of the trainer.