### PR TITLE
Support for only quiet generation and learning.

### DIFF
--- a/src/learn/gensfen.cpp
+++ b/src/learn/gensfen.cpp
@@ -94,6 +94,8 @@ namespace Learner
             bool detect_draw_by_consecutive_low_score = true;
             bool detect_draw_by_insufficient_mating_material = true;
 
+            bool ensure_quiet = false;
+
             uint64_t num_threads;
 
             void enforce_constraints()
@@ -316,19 +318,86 @@ namespace Learner
                 // Discard stuff before write_minply is reached
                 // because it can harm training due to overfitting.
                 // Initial positions would be too common.
-                if (ply >= params.write_minply && !was_seen_before(pos))
+                if (ply >= params.write_minply)
                 {
                     packed_sfens.emplace_back(PackedSfenValue());
 
                     auto& psv = packed_sfens.back();
 
-                    // Here we only write the position data.
-                    // Result is added after the whole game is done.
-                    pos.sfen_pack(psv.sfen);
+                    if (params.ensure_quiet)
+                    {
+                        auto [qsearch_value, qsearch_pv] = Search::qsearch(pos);
+                        if (qsearch_pv.empty())
+                        {
+                            // Here we only write the position data.
+                            // Result is added after the whole game is done.
+                            pos.sfen_pack(psv.sfen);
 
-                    psv.score = search_value;
-                    psv.gamePly = ply;
-                    psv.move = search_pv[0];
+                            // Already a quiet position
+                            psv.score = search_value;
+                            psv.move = search_pv[0];
+                            psv.gamePly = ply;
+                        }
+                        else
+                        {
+                            // Navigate to a quiet
+                            int old_ply = ply;
+                            for (auto m : qsearch_pv)
+                            {
+                                pos.do_move(m, states[ply++]);
+                            }
+
+                            if (was_seen_before(pos))
+                            {
+                                // Just skip the move.
+                                packed_sfens.pop_back();
+                            }
+                            else
+                            {
+                                // Reevaluate
+                                auto [quiet_search_value, quiet_search_pv] = Search::search(pos, depth, 1, params.nodes);
+                                if (quiet_search_pv.empty())
+                                {
+                                    // Just skip the move.
+                                    packed_sfens.pop_back();
+                                }
+                                else
+                                {
+                                    // Here we only write the position data.
+                                    // Result is added after the whole game is done.
+                                    pos.sfen_pack(psv.sfen);
+
+                                    psv.score = quiet_search_value;
+                                    psv.move = quiet_search_pv[0];
+                                    psv.gamePly = ply;
+                                }
+                            }
+
+                            // Get back to the game
+                            for (auto it = qsearch_pv.rbegin(); it != qsearch_pv.rend(); ++it)
+                            {
+                                pos.undo_move(*it);
+                            }
+                            ply = old_ply;
+                        }
+                    }
+                    else
+                    {
+                        if (was_seen_before(pos))
+                        {
+                            packed_sfens.pop_back();
+                        }
+                        else
+                        {
+                            // Here we only write the position data.
+                            // Result is added after the whole game is done.
+                            pos.sfen_pack(psv.sfen);
+
+                            psv.score = search_value;
+                            psv.move = search_pv[0];
+                            psv.gamePly = ply;
+                        }
+                    }
                 }
 
                 // Update the next move according to best search result or random move.
@@ -777,6 +846,10 @@ namespace Learner
                 UCI::setoption("PruneAtShallowDepth", "false");
                 UCI::setoption("EnableTranspositionTable", "true");
             }
+            else if (token == "ensure_quiet")
+            {
+                params.ensure_quiet = true;
+            }
             else
                 cout << "ERROR: Ignoring unknown option " << token << endl;
         }
@@ -789,6 +862,12 @@ namespace Learner
                 params.sfen_format = SfenOutputType::Binpack;
             else
                 cout << "WARNING: Unknown sfen format `" << sfen_format << "`. Using bin\n";
+        }
+
+        if (params.ensure_quiet)
+        {
+            // Otherwise we can't ensure quiet positions...
+            UCI::setoption("EnableTranspositionTable", "false");
         }
 
         if (random_file_name)

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -397,6 +397,8 @@ namespace Learner
             bool use_draw_games_in_validation = true;
             bool skip_duplicated_positions_in_training = true;
 
+            bool assume_quiet = false;
+
             double learning_rate = 1.0;
 
             string validation_set_file_name;
@@ -676,19 +678,22 @@ namespace Learner
                 goto RETRY_READ;
             }
 
-            int ply = 0;
-            pos.do_move((Move)ps.move, state[ply++]);
-
-            // We want to position being trained on not to be terminal
-            if (MoveList<LEGAL>(pos).size() == 0)
-                goto RETRY_READ;
-
-            // Evaluation value of shallow search (qsearch)
-            const auto [_, pv] = Search::qsearch(pos);
-
-            for (auto m : pv)
+            if (!params.assume_quiet)
             {
-                pos.do_move(m, state[ply++]);
+                int ply = 0;
+                pos.do_move((Move)ps.move, state[ply++]);
+
+                // We want to position being trained on not to be terminal
+                if (MoveList<LEGAL>(pos).size() == 0)
+                    goto RETRY_READ;
+
+                // Evaluation value of shallow search (qsearch)
+                const auto [_, pv] = Search::qsearch(pos);
+
+                for (auto m : pv)
+                {
+                    pos.do_move(m, state[ply++]);
+                }
             }
 
             // Since we have reached the end phase of PV, add the slope here.
@@ -1106,6 +1111,7 @@ namespace Learner
                 UCI::setoption("EnableTranspositionTable", "false");
             }
             else if (option == "verbose") params.verbose = true;
+            else if (option == "assume_quiet") params.assume_quiet = true;
             else
             {
                 out << "INFO: Unknown option: " << option << ". Ignoring.\n";

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1976,7 +1976,7 @@ namespace Search
 
   // Initialization for learning.
   // Called from Learner::search(),Learner::qsearch().
-  static void init_for_search(Position& pos, Stack* ss)
+  static bool init_for_search(Position& pos, Stack* ss)
   {
 
     // RootNode requires ss->ply == 0.
@@ -2026,7 +2026,10 @@ namespace Search
       for (auto m: MoveList<LEGAL>(pos))
         rootMoves.push_back(Search::RootMove(m));
 
-      assert(!rootMoves.empty());
+      // Check if we're at a terminal node. Otherwise we end up returning
+      // malformed PV later on.
+      if (rootMoves.empty())
+        return false;
 
       th->UseRule50 = bool(Options["Syzygy50MoveRule"]);
       th->ProbeDepth = int(Options["SyzygyProbeDepth"]);
@@ -2042,6 +2045,8 @@ namespace Search
 
       Tablebases::rank_root_moves(pos, rootMoves);
     }
+
+    return true;
   }
 
   // Stationary search.
@@ -2061,7 +2066,9 @@ namespace Search
     Stack stack[MAX_PLY+10], *ss = stack+7;
     Move  pv[MAX_PLY+1];
 
-    init_for_search(pos, ss);
+    if (!init_for_search(pos, ss))
+      return {};
+
     ss->pv = pv; // For the time being, it must be a dummy and somewhere with a buffer.
 
     if (pos.is_draw(0)) {
@@ -2116,7 +2123,8 @@ namespace Search
     Stack stack[MAX_PLY + 10], * ss = stack + 7;
     Move pv[MAX_PLY + 1];
 
-    init_for_search(pos, ss);
+    if (!init_for_search(pos, ss))
+      return {};
 
 	ss->pv = pv; // For the time being, it must be a dummy and somewhere with a buffer.
 


### PR DESCRIPTION
This PR adds an optional flag to gensfen `ensure_quiet` which when specified makes the generated positions be from the and of a qsearch. This is required for trainers that don't have qsearch, like the pytorch trainer.

It also adds an optional flag to learn `assume_quiet` which when specified makes `learn` not perform qsearch, making the training progress faster if the data is already only quiet positions.