### PR TITLE
Move the terminal position check to after qsearch

### DIFF
--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -685,10 +685,6 @@ namespace Learner
                 int ply = 0;
                 pos.do_move((Move)ps.move, state[ply++]);
 
-                // We want to position being trained on not to be terminal
-                if (MoveList<LEGAL>(pos).size() == 0)
-                    goto RETRY_READ;
-
                 // Evaluation value of shallow search (qsearch)
                 const auto [_, pv] = Search::qsearch(pos);
 
@@ -697,6 +693,10 @@ namespace Learner
                     pos.do_move(m, state[ply++]);
                 }
             }
+
+            // We want to position being trained on not to be terminal
+            if (MoveList<LEGAL>(pos).size() == 0)
+                goto RETRY_READ;
 
             // Since we have reached the end phase of PV, add the slope here.
             pos_add_grad();


### PR DESCRIPTION
Otherwise qsearch may end up in a terminal position. This was found by noob.