### PR TITLE
Add skipping of bad learning examples.

### DIFF
--- a/docs/gensfen.md
+++ b/docs/gensfen.md
@@ -62,4 +62,6 @@ Currently the following options are available:
 
 `sfen_format` - format of the training data to use. Either `bin` or `binpack`. Default: `binpack`.
 
+`ensure_quiet` - this is a flag option. When specified the positions will be from the qsearch leaf.
+
 `seed` - seed for the PRNG. Can be either a number or a string. If it's a string then its hash will be used. If not specified then the current time will be used.

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -64,6 +64,10 @@ Currently the following options are available:
 
 `newbob_decay` - learning rate will be multiplied by this factor every time a net is rejected (so in other words it controls LR drops). Default: 0.5 (no LR drops)
 
+`assume_quiet` - this is a flag option. When specified learn will not perform qsearch to reach a quiet position.
+
+`smart_fen_skipping` - this is a flag option. When specified some position that are not good candidates for teaching are skipped. This includes positions where the best move is a capture or promotion, and position where a king is in check.
+
 `newbob_num_trials` - determines after how many subsequent rejected nets the training process will be terminated. Default: 4.
 
 `auto_lr_drop` - every time this many positions are processed the learning rate is multiplied by `newbob_decay`. In other words this value specifies for how many positions a single learning rate stage lasts. If 0 then doesn't have any effect. Default: 0.

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -400,6 +400,7 @@ namespace Learner
             bool skip_duplicated_positions_in_training = true;
 
             bool assume_quiet = false;
+            bool smart_fen_skipping = false;
 
             double learning_rate = 1.0;
 
@@ -680,7 +681,8 @@ namespace Learner
                 goto RETRY_READ;
             }
 
-            if (!params.assume_quiet)
+            // We don't need to qsearch when doing smart skipping
+            if (!params.assume_quiet && !params.smart_fen_skipping)
             {
                 int ply = 0;
                 pos.do_move((Move)ps.move, state[ply++]);
@@ -694,6 +696,13 @@ namespace Learner
                 }
             }
 
+            if (params.smart_fen_skipping
+                && (pos.capture_or_promotion((Move)ps.move)
+                    || pos.checkers()))
+            {
+                goto RETRY_READ;
+            }
+            
             // We want to position being trained on not to be terminal
             if (MoveList<LEGAL>(pos).size() == 0)
                 goto RETRY_READ;
@@ -1115,6 +1124,7 @@ namespace Learner
             }
             else if (option == "verbose") params.verbose = true;
             else if (option == "assume_quiet") params.assume_quiet = true;
+            else if (option == "smart_fen_skipping") params.smart_fen_skipping = true;
             else
             {
                 out << "INFO: Unknown option: " << option << ". Ignoring.\n";


### PR DESCRIPTION
This PR adds an option `smart_fen_skipping`. The name is not very telling because we want it to be easly extensible in the future without losing meaning.

Currently it allows skipping positions that have capture or promotion as best move, and position where a king is in check.

Trained without: https://tests.stockfishchess.org/tests/view/5fb9383a67cbf42301d6afbf
Trained with: https://tests.stockfishchess.org/tests/view/5fba952867cbf42301d6b0aa

> noobpwnftw: so for bestmove being capturing moves or so, it is obvious that naturally the gensfen will play this move and capture the piece, and in practice, SF likely try out captures without eval, or use SEE to check it, and the position eval does not contribute much to search decision, therefore, we skip them in training and the actual landing position will be trained on later examples
> [6:07 PM] noobpwnftw: as for incheck, it is simply that we never call eval there, so we don't care how that is evaluated, therefore don't train
> [6:08 PM] noobpwnftw: there may be something else in the future that we find needs such filtering, therefore we name it "smart" so that average users don't need to know the specific details about the reasoning behind those individual cases we skip