### PR TITLE
[WIP] More coarse grained multithreading for forward/backward when learning.

### DIFF
--- a/src/extra/stockfish_blas.cpp
+++ b/src/extra/stockfish_blas.cpp
@@ -177,10 +177,19 @@ namespace Blas {
         float * SF_BLAS_RESTRICT Y
     )
     {
-
-        for(int i = 0; i < N; ++i)
+        if (alpha == 1.0f)
         {
-            Y[i] += X[i] * alpha;
+            for (int i = 0; i < N; ++i)
+            {
+                Y[i] += X[i];
+            }
+        }
+        else
+        {
+            for (int i = 0; i < N; ++i)
+            {
+                Y[i] += X[i] * alpha;
+            }
         }
 
     }

--- a/src/extra/stockfish_blas.cpp
+++ b/src/extra/stockfish_blas.cpp
@@ -178,52 +178,10 @@ namespace Blas {
     )
     {
 
-#if defined (USE_SSE2)
-
-        const __m128 alpha4 = _mm_set1_ps(alpha);
-
-        int i = 0;
-        for(; i < N - 15; i += 16)
-        {
-            __m128 x0 = _mm_loadu_ps(X + i +  0);
-            __m128 x1 = _mm_loadu_ps(X + i +  4);
-            __m128 x2 = _mm_loadu_ps(X + i +  8);
-            __m128 x3 = _mm_loadu_ps(X + i + 12);
-
-            __m128 y0 = _mm_loadu_ps(Y + i +  0);
-            __m128 y1 = _mm_loadu_ps(Y + i +  4);
-            __m128 y2 = _mm_loadu_ps(Y + i +  8);
-            __m128 y3 = _mm_loadu_ps(Y + i + 12);
-
-            x0 = _mm_mul_ps(x0, alpha4);
-            x1 = _mm_mul_ps(x1, alpha4);
-            x2 = _mm_mul_ps(x2, alpha4);
-            x3 = _mm_mul_ps(x3, alpha4);
-
-            x0 = _mm_add_ps(x0, y0);
-            x1 = _mm_add_ps(x1, y1);
-            x2 = _mm_add_ps(x2, y2);
-            x3 = _mm_add_ps(x3, y3);
-
-            _mm_storeu_ps(Y + i +  0, x0);
-            _mm_storeu_ps(Y + i +  4, x1);
-            _mm_storeu_ps(Y + i +  8, x2);
-            _mm_storeu_ps(Y + i + 12, x3);
-        }
-
-        for(; i < N; ++i)
-        {
-            Y[i] += X[i] * alpha;
-        }
-
-#else
-
         for(int i = 0; i < N; ++i)
         {
             Y[i] += X[i] * alpha;
         }
-
-#endif
 
     }
 
@@ -564,7 +522,8 @@ namespace Blas {
         const __m128 alpha4 = _mm_set1_ps(alpha);
         const __m128 beta4 = _mm_set1_ps(beta);
 
-        for (int m = 0; m < M - 1; m += 2)
+        int m = 0;
+        for (; m < M - 1; m += 2)
         {
             int n = 0;
             for (; n < N - 3; n += 4)

--- a/src/extra/stockfish_blas.h
+++ b/src/extra/stockfish_blas.h
@@ -118,6 +118,16 @@ namespace Blas {
         float * SF_BLAS_RESTRICT C, const int ldc
     );
 
+    void sgemm(
+        MatrixLayout layout, MatrixTranspose TransA, MatrixTranspose TransB,
+        const int M, const int N, const int K,
+        const float alpha,
+        const float * SF_BLAS_RESTRICT A, const int lda,
+        const float * SF_BLAS_RESTRICT B, const int ldb,
+        const float beta,
+        float * SF_BLAS_RESTRICT C, const int ldc
+    );
+
     void test(
         ThreadPool& thread_pool
     );

--- a/src/nnue/evaluate_nnue_learner.cpp
+++ b/src/nnue/evaluate_nnue_learner.cpp
@@ -214,7 +214,7 @@ namespace Eval::NNUE {
         std::vector<double> gradient_norm_local(thread_pool.size(), 0.0);
 
         auto prev_batch_begin = examples.end();
-        while (prev_batch_begin - examples.begin() >= batch_size) {
+        while ((long)(prev_batch_begin - examples.begin()) >= (long)batch_size) {
             auto batch_begin = prev_batch_begin - batch_size;
             auto batch_end = prev_batch_begin;
             auto size = batch_end - batch_begin;

--- a/src/nnue/evaluate_nnue_learner.cpp
+++ b/src/nnue/evaluate_nnue_learner.cpp
@@ -157,8 +157,12 @@ namespace Eval::NNUE {
             active_indices[0].swap(active_indices[1]);
         }
 
+        static thread_local std::vector<TrainingFeature> s_training_features;
+        auto& training_features = s_training_features;
+
         for (const auto color : Colors) {
-            std::vector<TrainingFeature> training_features;
+            training_features.clear();
+
             for (const auto base_index : active_indices[color]) {
                 static_assert(Features::Factorizer<RawFeatures>::get_dimensions() <
                               (1 << TrainingFeature::kIndexBits), "");
@@ -169,6 +173,7 @@ namespace Eval::NNUE {
             std::sort(training_features.begin(), training_features.end());
 
             auto& unique_features = example.training_features[color];
+            unique_features.reserve(training_features.size());
             for (const auto& feature : training_features) {
                 if (!unique_features.empty() &&
                     feature.get_index() == unique_features.back().get_index()) {

--- a/src/nnue/evaluate_nnue_learner.cpp
+++ b/src/nnue/evaluate_nnue_learner.cpp
@@ -202,7 +202,6 @@ namespace Eval::NNUE {
         learning_rate /= batch_size;
 
         std::lock_guard<std::mutex> lock(examples_mutex);
-        std::shuffle(examples.begin(), examples.end(), rng);
 
         double abs_eval_diff_sum = 0.0;
         double abs_discrete_eval_sum = 0.0;

--- a/src/nnue/trainer/trainer_affine_transform.h
+++ b/src/nnue/trainer/trainer_affine_transform.h
@@ -95,7 +95,7 @@ namespace Eval::NNUE {
         {
             const auto size = batch_end - batch_begin;
 
-            if (output_.size() < kOutputDimensions * size) {
+            if ((long)output_.size() < (long)kOutputDimensions * size) {
                 output_.resize(kOutputDimensions * size);
                 gradients_.resize(kInputDimensions * size);
             }

--- a/src/nnue/trainer/trainer_affine_transform.h
+++ b/src/nnue/trainer/trainer_affine_transform.h
@@ -91,11 +91,13 @@ namespace Eval::NNUE {
             quantize_parameters();
         }
 
-        const LearnFloatType* step_start(ThreadPool& thread_pool, const std::vector<Example>& combined_batch)
+        const LearnFloatType* step_start(ThreadPool& thread_pool, std::vector<Example>::const_iterator batch_begin, std::vector<Example>::const_iterator batch_end)
         {
-            if (output_.size() < kOutputDimensions * combined_batch.size()) {
-                output_.resize(kOutputDimensions * combined_batch.size());
-                gradients_.resize(kInputDimensions * combined_batch.size());
+            const auto size = batch_end - batch_begin;
+
+            if (output_.size() < kOutputDimensions * size) {
+                output_.resize(kOutputDimensions * size);
+                gradients_.resize(kInputDimensions * size);
             }
 
             if (thread_states_.size() < thread_pool.size())
@@ -103,8 +105,8 @@ namespace Eval::NNUE {
                 thread_states_.resize(thread_pool.size());
             }
 
-            combined_batch_size_ = static_cast<IndexType>(combined_batch.size());
-            combined_batch_input_ = previous_layer_trainer_->step_start(thread_pool, combined_batch);
+            combined_batch_size_ = size;
+            combined_batch_input_ = previous_layer_trainer_->step_start(thread_pool, batch_begin, batch_end);
 
             auto& main_thread_state = thread_states_[0];
 

--- a/src/nnue/trainer/trainer_clipped_relu.h
+++ b/src/nnue/trainer/trainer_clipped_relu.h
@@ -46,7 +46,7 @@ namespace Eval::NNUE {
         {
             const auto size = batch_end - batch_begin;
 
-            if (output_.size() < kOutputDimensions * size) {
+            if ((long)output_.size() < (long)kOutputDimensions * size) {
               output_.resize(kOutputDimensions * size);
               gradients_.resize(kInputDimensions * size);
             }

--- a/src/nnue/trainer/trainer_clipped_relu.h
+++ b/src/nnue/trainer/trainer_clipped_relu.h
@@ -42,11 +42,13 @@ namespace Eval::NNUE {
             previous_layer_trainer_->initialize(rng);
         }
 
-        const LearnFloatType* step_start(ThreadPool& thread_pool, const std::vector<Example>& combined_batch)
+        const LearnFloatType* step_start(ThreadPool& thread_pool, std::vector<Example>::const_iterator batch_begin, std::vector<Example>::const_iterator batch_end)
         {
-            if (output_.size() < kOutputDimensions * combined_batch.size()) {
-              output_.resize(kOutputDimensions * combined_batch.size());
-              gradients_.resize(kInputDimensions * combined_batch.size());
+            const auto size = batch_end - batch_begin;
+
+            if (output_.size() < kOutputDimensions * size) {
+              output_.resize(kOutputDimensions * size);
+              gradients_.resize(kInputDimensions * size);
             }
 
             if (thread_states_.size() < thread_pool.size())
@@ -54,9 +56,9 @@ namespace Eval::NNUE {
                 thread_states_.resize(thread_pool.size());
             }
 
-            input_ = previous_layer_trainer_->step_start(thread_pool, combined_batch);
+            input_ = previous_layer_trainer_->step_start(thread_pool, batch_begin, batch_end);
 
-            batch_size_ = static_cast<IndexType>(combined_batch.size());
+            batch_size_ = size;
 
             return output_.data();
         }

--- a/src/nnue/trainer/trainer_feature_transformer.h
+++ b/src/nnue/trainer/trainer_feature_transformer.h
@@ -164,7 +164,7 @@ namespace Eval::NNUE {
                         const IndexType weights_offset = kHalfDimensions * feature.get_index();
                         Blas::saxpy(
                             kHalfDimensions, (float)feature.get_count(),
-                            &weights_[weights_offset], 1, &output_[output_offset], 1
+                            &weights_[weights_offset], &output_[output_offset]
                         );
                     }
 
@@ -497,8 +497,8 @@ namespace Eval::NNUE {
 
                                 Blas::saxpy(
                                     kHalfDimensions, -scale,
-                                    &gradients_[output_offset], 1,
-                                    &weights_[weights_offset], 1
+                                    &gradients_[output_offset],
+                                    &weights_[weights_offset]
                                 );
 
 #endif

--- a/src/nnue/trainer/trainer_feature_transformer.h
+++ b/src/nnue/trainer/trainer_feature_transformer.h
@@ -93,7 +93,7 @@ namespace Eval::NNUE {
         {
             const auto size = batch_end - batch_begin;
 
-            if (output_.size() < kOutputDimensions * size) {
+            if ((long)output_.size() < (long)kOutputDimensions * size) {
                 output_.resize(kOutputDimensions * size);
                 gradients_.resize(kOutputDimensions * size);
             }

--- a/src/nnue/trainer/trainer_feature_transformer.h
+++ b/src/nnue/trainer/trainer_feature_transformer.h
@@ -151,7 +151,7 @@ namespace Eval::NNUE {
                         kHalfDimensions, biases_, 1, &output_[output_offset], 1
                     );
 
-                    for (const auto& feature : (*batch_)[b].training_features[c]) {
+                    for (const auto& feature : batch_[b].training_features[c]) {
                         const IndexType weights_offset = kHalfDimensions * feature.get_index();
                         cblas_saxpy(
                             kHalfDimensions, (float)feature.get_count(),

--- a/src/nnue/trainer/trainer_input_slice.h
+++ b/src/nnue/trainer/trainer_input_slice.h
@@ -66,8 +66,8 @@ namespace Eval::NNUE {
         const LearnFloatType* step_start(ThreadPool& thread_pool, std::vector<Example>::const_iterator batch_begin, std::vector<Example>::const_iterator batch_end)
         {
             const auto size = batch_end - batch_begin;
-            
-            if (gradients_.size() < kInputDimensions * size) {
+
+            if ((long)gradients_.size() < (long)kInputDimensions * size) {
                 gradients_.resize(kInputDimensions * size);
             }
 
@@ -244,7 +244,7 @@ namespace Eval::NNUE {
         {
             const auto size = batch_end - batch_begin;
 
-            if (output_.size() < kOutputDimensions * size) {
+            if ((long)output_.size() < (long)kOutputDimensions * size) {
               output_.resize(kOutputDimensions * size);
               gradients_.resize(kInputDimensions * size);
             }


### PR DESCRIPTION
In the current master the worker threads are launched many times during propagate/backpropagate passes. Most operations are too small to benefit from parallelization, and some are not parallelizable at all. This PR introduces a different approach. It splits the batch into num_threads parts and processes each batch part in one thread, all the way through `propagate` -> `calc_loss` -> `backward`. `step_start` and `step_end` are introduced as places to initialize for a batch and perform weight updates.

It seems faster on my 4 core machine, but I have no means of benchmarking this on higher core counts - and that's what I'm mainly trying to improve here. I believe this approach should scale much better to very high core counts. Before proceeding further with this I'd like to see some benchmarks done against current master with different thread counts. Hopefully someone can provide such benchmarks.