### PR TITLE
Automatic differentiation for the loss function.

### DIFF
--- a/src/learn/autograd.h
+++ b/src/learn/autograd.h
@@ -209,7 +209,7 @@ namespace Learner::Autograd::UnivariateStatic
     struct VariableParameter : Evaluable<T, VariableParameter<T, I>>
     {
         using ValueType = T;
-        
+
         static constexpr bool is_constant = false;
 
         constexpr VariableParameter()
@@ -279,6 +279,36 @@ namespace Learner::Autograd::UnivariateStatic
 
     private:
         T m_x;
+    };
+
+    // The "constant" may change between executions, but is assumed to be
+    // constant during a single evaluation.
+    template <typename T>
+    struct ConstantRef : Evaluable<T, ConstantRef<T>>
+    {
+        using ValueType = T;
+
+        static constexpr bool is_constant = true;
+
+        constexpr ConstantRef(const T& x) :
+            m_x(x)
+        {
+        }
+
+        template <typename... ArgsTs>
+        [[nodiscard]] T calculate_value(const std::tuple<ArgsTs...>&) const
+        {
+            return m_x;
+        }
+
+        template <typename... ArgsTs>
+        [[nodiscard]] T calculate_grad(const std::tuple<ArgsTs...>&) const
+        {
+            return T(0.0);
+        }
+
+    private:
+        const T& m_x;
     };
 
     template <typename LhsT, typename RhsT, typename T = typename std::remove_reference_t<LhsT>::ValueType>

--- a/src/learn/autograd.h
+++ b/src/learn/autograd.h
@@ -69,6 +69,13 @@ namespace Learner::Autograd::UnivariateStatic
     template <typename T>
     using Id = typename Identity<T>::type;
 
+    template <typename T>
+    using StoreValueOrRef = std::conditional_t<
+            std::is_rvalue_reference_v<T>,
+            std::remove_reference_t<T>,
+            const std::remove_reference_t<T>&
+        >;
+
     template <typename T, typename ChildT>
     struct Evaluable
     {
@@ -179,14 +186,14 @@ namespace Learner::Autograd::UnivariateStatic
         T m_x;
     };
 
-    template <typename LhsT, typename RhsT, typename T = typename LhsT::ValueType>
+    template <typename LhsT, typename RhsT, typename T = typename std::remove_reference_t<LhsT>::ValueType>
     struct Sum : Evaluable<T, Sum<LhsT, RhsT, T>>
     {
         using ValueType = T;
 
-        Sum(LhsT lhs, RhsT rhs) :
-            m_lhs(std::move(lhs)),
-            m_rhs(std::move(rhs))
+        Sum(LhsT&& lhs, RhsT&& rhs) :
+            m_lhs(std::forward<LhsT>(lhs)),
+            m_rhs(std::forward<RhsT>(rhs))
         {
         }
 
@@ -203,36 +210,36 @@ namespace Learner::Autograd::UnivariateStatic
         }
 
     private:
-        LhsT m_lhs;
-        RhsT m_rhs;
+        StoreValueOrRef<LhsT> m_lhs;
+        StoreValueOrRef<RhsT> m_rhs;
     };
 
-    template <typename LhsT, typename RhsT, typename T = typename LhsT::ValueType>
-    auto operator+(LhsT lhs, RhsT rhs)
+    template <typename LhsT, typename RhsT, typename T = typename std::remove_reference_t<LhsT>::ValueType>
+    auto operator+(LhsT&& lhs, RhsT&& rhs)
     {
-        return Sum(std::move(lhs), std::move(rhs));
+        return Sum<LhsT&&, RhsT&&>(std::forward<LhsT>(lhs), std::forward<RhsT>(rhs));
     }
 
-    template <typename LhsT, typename T = typename LhsT::ValueType>
-    auto operator+(LhsT lhs, Id<T> rhs)
+    template <typename LhsT, typename T = typename std::remove_reference_t<LhsT>::ValueType>
+    auto operator+(LhsT&& lhs, Id<T> rhs)
     {
-        return Sum(std::move(lhs), Constant(rhs));
+        return Sum<LhsT&&, Constant<T>&&>(std::forward<LhsT>(lhs), Constant(rhs));
     }
 
-    template <typename RhsT, typename T = typename RhsT::ValueType>
-    auto operator+(Id<T> lhs, RhsT rhs)
+    template <typename RhsT, typename T = typename std::remove_reference_t<RhsT>::ValueType>
+    auto operator+(Id<T> lhs, RhsT&& rhs)
     {
-        return Sum(Constant(lhs), std::move(rhs));
+        return Sum<Constant<T>&&, RhsT&&>(Constant(lhs), std::forward<RhsT>(rhs));
     }
 
-    template <typename LhsT, typename RhsT, typename T = typename LhsT::ValueType>
+    template <typename LhsT, typename RhsT, typename T = typename std::remove_reference_t<LhsT>::ValueType>
     struct Difference : Evaluable<T, Difference<LhsT, RhsT, T>>
     {
         using ValueType = T;
 
-        Difference(LhsT lhs, RhsT rhs) :
-            m_lhs(std::move(lhs)),
-            m_rhs(std::move(rhs))
+        Difference(LhsT&& lhs, RhsT&& rhs) :
+            m_lhs(std::forward<LhsT>(lhs)),
+            m_rhs(std::forward<RhsT>(rhs))
         {
         }
 
@@ -249,36 +256,36 @@ namespace Learner::Autograd::UnivariateStatic
         }
 
     private:
-        LhsT m_lhs;
-        RhsT m_rhs;
+        StoreValueOrRef<LhsT> m_lhs;
+        StoreValueOrRef<RhsT> m_rhs;
     };
 
-    template <typename LhsT, typename RhsT, typename T = typename LhsT::ValueType>
-    auto operator-(LhsT lhs, RhsT rhs)
+    template <typename LhsT, typename RhsT, typename T = typename std::remove_reference_t<LhsT>::ValueType>
+    auto operator-(LhsT&& lhs, RhsT&& rhs)
     {
-        return Difference(std::move(lhs), std::move(rhs));
+        return Difference<LhsT&&, RhsT&&>(std::forward<LhsT>(lhs), std::forward<RhsT>(rhs));
     }
 
-    template <typename LhsT, typename T = typename LhsT::ValueType>
-    auto operator-(LhsT lhs, Id<T> rhs)
+    template <typename LhsT, typename T = typename std::remove_reference_t<LhsT>::ValueType>
+    auto operator-(LhsT&& lhs, Id<T> rhs)
     {
-        return Difference(std::move(lhs), Constant(rhs));
+        return Difference<LhsT&&, Constant<T>&&>(std::forward<LhsT>(lhs), Constant(rhs));
     }
 
-    template <typename RhsT, typename T = typename RhsT::ValueType>
-    auto operator-(Id<T> lhs, RhsT rhs)
+    template <typename RhsT, typename T = typename std::remove_reference_t<RhsT>::ValueType>
+    auto operator-(Id<T> lhs, RhsT&& rhs)
     {
-        return Difference(Constant(lhs), std::move(rhs));
+        return Difference<Constant<T>&&, RhsT&&>(Constant(lhs), std::forward<RhsT>(rhs));
     }
 
-    template <typename LhsT, typename RhsT, typename T = typename LhsT::ValueType>
+    template <typename LhsT, typename RhsT, typename T = typename std::remove_reference_t<LhsT>::ValueType>
     struct Product : Evaluable<T, Product<LhsT, RhsT, T>>
     {
         using ValueType = T;
 
-        Product(LhsT lhs, RhsT rhs) :
-            m_lhs(std::move(lhs)),
-            m_rhs(std::move(rhs))
+        Product(LhsT&& lhs, RhsT&& rhs) :
+            m_lhs(std::forward<LhsT>(lhs)),
+            m_rhs(std::forward<RhsT>(rhs))
         {
         }
 
@@ -295,35 +302,35 @@ namespace Learner::Autograd::UnivariateStatic
         }
 
     private:
-        LhsT m_lhs;
-        RhsT m_rhs;
+        StoreValueOrRef<LhsT> m_lhs;
+        StoreValueOrRef<RhsT> m_rhs;
     };
 
-    template <typename LhsT, typename RhsT, typename T = typename LhsT::ValueType>
-    auto operator*(LhsT lhs, RhsT rhs)
+    template <typename LhsT, typename RhsT, typename T = typename std::remove_reference_t<LhsT>::ValueType>
+    auto operator*(LhsT&& lhs, RhsT&& rhs)
     {
-        return Product(std::move(lhs), std::move(rhs));
+        return Product<LhsT&&, RhsT&&>(std::forward<LhsT>(lhs), std::forward<RhsT>(rhs));
     }
 
-    template <typename LhsT, typename T = typename LhsT::ValueType>
-    auto operator*(LhsT lhs, Id<T> rhs)
+    template <typename LhsT, typename T = typename std::remove_reference_t<LhsT>::ValueType>
+    auto operator*(LhsT&& lhs, Id<T> rhs)
     {
-        return Product(std::move(lhs), Constant(rhs));
+        return Product<LhsT&&, Constant<T>&&>(std::forward<LhsT>(lhs), Constant(rhs));
     }
 
-    template <typename RhsT, typename T = typename RhsT::ValueType>
-    auto operator*(Id<T> lhs, RhsT rhs)
+    template <typename RhsT, typename T = typename std::remove_reference_t<RhsT>::ValueType>
+    auto operator*(Id<T> lhs, RhsT&& rhs)
     {
-        return Product(Constant(lhs), std::move(rhs));
+        return Product<Constant<T>&&, RhsT&&>(Constant(lhs), std::forward<RhsT>(rhs));
     }
 
-    template <typename ArgT, typename T = typename ArgT::ValueType>
+    template <typename ArgT, typename T = typename std::remove_reference_t<ArgT>::ValueType>
     struct Negation : Evaluable<T, Negation<ArgT, T>>
     {
         using ValueType = T;
 
-        explicit Negation(ArgT x) :
-            m_x(std::move(x))
+        explicit Negation(ArgT&& x) :
+            m_x(std::forward<ArgT>(x))
         {
         }
 
@@ -340,22 +347,22 @@ namespace Learner::Autograd::UnivariateStatic
         }
 
     private:
-        ArgT m_x;
+        StoreValueOrRef<ArgT> m_x;
     };
 
-    template <typename ArgT, typename T = typename ArgT::ValueType>
-    auto operator-(ArgT x)
+    template <typename ArgT, typename T = typename std::remove_reference_t<ArgT>::ValueType>
+    auto operator-(ArgT&& x)
     {
-        return Negation(std::move(x));
+        return Negation<ArgT&&>(std::forward<ArgT>(x));
     }
 
-    template <typename ArgT, typename T = typename ArgT::ValueType>
+    template <typename ArgT, typename T = typename std::remove_reference_t<ArgT>::ValueType>
     struct Sigmoid : Evaluable<T, Sigmoid<ArgT, T>>
     {
         using ValueType = T;
 
-        explicit Sigmoid(ArgT x) :
-            m_x(std::move(x))
+        explicit Sigmoid(ArgT&& x) :
+            m_x(std::forward<ArgT>(x))
         {
         }
 
@@ -372,7 +379,7 @@ namespace Learner::Autograd::UnivariateStatic
         }
 
     private:
-        ArgT m_x;
+        StoreValueOrRef<ArgT> m_x;
 
         T value_(T x) const
         {
@@ -385,19 +392,19 @@ namespace Learner::Autograd::UnivariateStatic
         }
     };
 
-    template <typename ArgT, typename T = typename ArgT::ValueType>
-    auto sigmoid(ArgT x)
+    template <typename ArgT, typename T = typename std::remove_reference_t<ArgT>::ValueType>
+    auto sigmoid(ArgT&& x)
     {
-        return Sigmoid(std::move(x));
+        return Sigmoid<ArgT&&>(std::forward<ArgT>(x));
     }
 
-    template <typename ArgT, typename T = typename ArgT::ValueType>
+    template <typename ArgT, typename T = typename std::remove_reference_t<ArgT>::ValueType>
     struct Pow : Evaluable<T, Pow<ArgT, T>>
     {
         using ValueType = T;
 
-        explicit Pow(ArgT x, Id<T> exponent) :
-            m_x(std::move(x)),
+        explicit Pow(ArgT&& x, Id<T> exponent) :
+            m_x(std::forward<ArgT>(x)),
             m_exponent(std::move(exponent))
         {
         }
@@ -415,23 +422,23 @@ namespace Learner::Autograd::UnivariateStatic
         }
 
     private:
-        ArgT m_x;
+        StoreValueOrRef<ArgT> m_x;
         T m_exponent;
     };
 
-    template <typename ArgT, typename T = typename ArgT::ValueType>
-    auto pow(ArgT x, Id<T> exp)
+    template <typename ArgT, typename T = typename std::remove_reference_t<ArgT>::ValueType>
+    auto pow(ArgT&& x, Id<T> exp)
     {
-        return Pow(std::move(x), std::move(exp));
+        return Pow<ArgT&&>(std::forward<ArgT>(x), std::move(exp));
     }
 
-    template <typename ArgT, typename T = typename ArgT::ValueType>
+    template <typename ArgT, typename T = typename std::remove_reference_t<ArgT>::ValueType>
     struct Log : Evaluable<T, Log<ArgT, T>>
     {
         using ValueType = T;
 
-        explicit Log(ArgT x) :
-            m_x(std::move(x))
+        explicit Log(ArgT&& x) :
+            m_x(std::forward<ArgT>(x))
         {
         }
 
@@ -448,7 +455,7 @@ namespace Learner::Autograd::UnivariateStatic
         }
 
     private:
-        ArgT m_x;
+        StoreValueOrRef<ArgT> m_x;
 
         T value_(T x) const
         {
@@ -461,10 +468,10 @@ namespace Learner::Autograd::UnivariateStatic
         }
     };
 
-    template <typename ArgT, typename T = typename ArgT::ValueType>
-    auto log(ArgT x)
+    template <typename ArgT, typename T = typename std::remove_reference_t<ArgT>::ValueType>
+    auto log(ArgT&& x)
     {
-        return Log(std::move(x));
+        return Log<ArgT&&>(std::forward<ArgT>(x));
     }
 
 }

--- a/src/learn/autograd.h
+++ b/src/learn/autograd.h
@@ -79,6 +79,8 @@ namespace Learner::Autograd::UnivariateStatic
     template <typename T, typename ChildT>
     struct Evaluable
     {
+        constexpr Evaluable() = default;
+
         template <typename... ArgsTs>
         auto eval(const std::tuple<ArgsTs...>& args) const
         {
@@ -121,7 +123,7 @@ namespace Learner::Autograd::UnivariateStatic
     {
         using ValueType = T;
 
-        VariableParameter()
+        constexpr VariableParameter()
         {
         }
 
@@ -143,7 +145,7 @@ namespace Learner::Autograd::UnivariateStatic
     {
         using ValueType = T;
 
-        ConstantParameter()
+        constexpr ConstantParameter()
         {
         }
 
@@ -165,7 +167,7 @@ namespace Learner::Autograd::UnivariateStatic
     {
         using ValueType = T;
 
-        Constant(T x) :
+        constexpr Constant(T x) :
             m_x(std::move(x))
         {
         }
@@ -191,7 +193,7 @@ namespace Learner::Autograd::UnivariateStatic
     {
         using ValueType = T;
 
-        Sum(LhsT&& lhs, RhsT&& rhs) :
+        constexpr Sum(LhsT&& lhs, RhsT&& rhs) :
             m_lhs(std::forward<LhsT>(lhs)),
             m_rhs(std::forward<RhsT>(rhs))
         {
@@ -215,19 +217,19 @@ namespace Learner::Autograd::UnivariateStatic
     };
 
     template <typename LhsT, typename RhsT, typename T = typename std::remove_reference_t<LhsT>::ValueType>
-    auto operator+(LhsT&& lhs, RhsT&& rhs)
+    constexpr auto operator+(LhsT&& lhs, RhsT&& rhs)
     {
         return Sum<LhsT&&, RhsT&&>(std::forward<LhsT>(lhs), std::forward<RhsT>(rhs));
     }
 
     template <typename LhsT, typename T = typename std::remove_reference_t<LhsT>::ValueType>
-    auto operator+(LhsT&& lhs, Id<T> rhs)
+    constexpr auto operator+(LhsT&& lhs, Id<T> rhs)
     {
         return Sum<LhsT&&, Constant<T>&&>(std::forward<LhsT>(lhs), Constant(rhs));
     }
 
     template <typename RhsT, typename T = typename std::remove_reference_t<RhsT>::ValueType>
-    auto operator+(Id<T> lhs, RhsT&& rhs)
+    constexpr auto operator+(Id<T> lhs, RhsT&& rhs)
     {
         return Sum<Constant<T>&&, RhsT&&>(Constant(lhs), std::forward<RhsT>(rhs));
     }
@@ -237,7 +239,7 @@ namespace Learner::Autograd::UnivariateStatic
     {
         using ValueType = T;
 
-        Difference(LhsT&& lhs, RhsT&& rhs) :
+        constexpr Difference(LhsT&& lhs, RhsT&& rhs) :
             m_lhs(std::forward<LhsT>(lhs)),
             m_rhs(std::forward<RhsT>(rhs))
         {
@@ -261,19 +263,19 @@ namespace Learner::Autograd::UnivariateStatic
     };
 
     template <typename LhsT, typename RhsT, typename T = typename std::remove_reference_t<LhsT>::ValueType>
-    auto operator-(LhsT&& lhs, RhsT&& rhs)
+    constexpr auto operator-(LhsT&& lhs, RhsT&& rhs)
     {
         return Difference<LhsT&&, RhsT&&>(std::forward<LhsT>(lhs), std::forward<RhsT>(rhs));
     }
 
     template <typename LhsT, typename T = typename std::remove_reference_t<LhsT>::ValueType>
-    auto operator-(LhsT&& lhs, Id<T> rhs)
+    constexpr auto operator-(LhsT&& lhs, Id<T> rhs)
     {
         return Difference<LhsT&&, Constant<T>&&>(std::forward<LhsT>(lhs), Constant(rhs));
     }
 
     template <typename RhsT, typename T = typename std::remove_reference_t<RhsT>::ValueType>
-    auto operator-(Id<T> lhs, RhsT&& rhs)
+    constexpr auto operator-(Id<T> lhs, RhsT&& rhs)
     {
         return Difference<Constant<T>&&, RhsT&&>(Constant(lhs), std::forward<RhsT>(rhs));
     }
@@ -283,7 +285,7 @@ namespace Learner::Autograd::UnivariateStatic
     {
         using ValueType = T;
 
-        Product(LhsT&& lhs, RhsT&& rhs) :
+        constexpr Product(LhsT&& lhs, RhsT&& rhs) :
             m_lhs(std::forward<LhsT>(lhs)),
             m_rhs(std::forward<RhsT>(rhs))
         {
@@ -307,19 +309,19 @@ namespace Learner::Autograd::UnivariateStatic
     };
 
     template <typename LhsT, typename RhsT, typename T = typename std::remove_reference_t<LhsT>::ValueType>
-    auto operator*(LhsT&& lhs, RhsT&& rhs)
+    constexpr auto operator*(LhsT&& lhs, RhsT&& rhs)
     {
         return Product<LhsT&&, RhsT&&>(std::forward<LhsT>(lhs), std::forward<RhsT>(rhs));
     }
 
     template <typename LhsT, typename T = typename std::remove_reference_t<LhsT>::ValueType>
-    auto operator*(LhsT&& lhs, Id<T> rhs)
+    constexpr auto operator*(LhsT&& lhs, Id<T> rhs)
     {
         return Product<LhsT&&, Constant<T>&&>(std::forward<LhsT>(lhs), Constant(rhs));
     }
 
     template <typename RhsT, typename T = typename std::remove_reference_t<RhsT>::ValueType>
-    auto operator*(Id<T> lhs, RhsT&& rhs)
+    constexpr auto operator*(Id<T> lhs, RhsT&& rhs)
     {
         return Product<Constant<T>&&, RhsT&&>(Constant(lhs), std::forward<RhsT>(rhs));
     }
@@ -329,7 +331,7 @@ namespace Learner::Autograd::UnivariateStatic
     {
         using ValueType = T;
 
-        explicit Negation(ArgT&& x) :
+        constexpr explicit Negation(ArgT&& x) :
             m_x(std::forward<ArgT>(x))
         {
         }
@@ -351,7 +353,7 @@ namespace Learner::Autograd::UnivariateStatic
     };
 
     template <typename ArgT, typename T = typename std::remove_reference_t<ArgT>::ValueType>
-    auto operator-(ArgT&& x)
+    constexpr auto operator-(ArgT&& x)
     {
         return Negation<ArgT&&>(std::forward<ArgT>(x));
     }
@@ -361,7 +363,7 @@ namespace Learner::Autograd::UnivariateStatic
     {
         using ValueType = T;
 
-        explicit Sigmoid(ArgT&& x) :
+        constexpr explicit Sigmoid(ArgT&& x) :
             m_x(std::forward<ArgT>(x))
         {
         }
@@ -393,7 +395,7 @@ namespace Learner::Autograd::UnivariateStatic
     };
 
     template <typename ArgT, typename T = typename std::remove_reference_t<ArgT>::ValueType>
-    auto sigmoid(ArgT&& x)
+    constexpr auto sigmoid(ArgT&& x)
     {
         return Sigmoid<ArgT&&>(std::forward<ArgT>(x));
     }
@@ -403,7 +405,7 @@ namespace Learner::Autograd::UnivariateStatic
     {
         using ValueType = T;
 
-        explicit Pow(ArgT&& x, Id<T> exponent) :
+        constexpr explicit Pow(ArgT&& x, Id<T> exponent) :
             m_x(std::forward<ArgT>(x)),
             m_exponent(std::move(exponent))
         {
@@ -427,7 +429,7 @@ namespace Learner::Autograd::UnivariateStatic
     };
 
     template <typename ArgT, typename T = typename std::remove_reference_t<ArgT>::ValueType>
-    auto pow(ArgT&& x, Id<T> exp)
+    constexpr auto pow(ArgT&& x, Id<T> exp)
     {
         return Pow<ArgT&&>(std::forward<ArgT>(x), std::move(exp));
     }
@@ -437,7 +439,7 @@ namespace Learner::Autograd::UnivariateStatic
     {
         using ValueType = T;
 
-        explicit Log(ArgT&& x) :
+        constexpr explicit Log(ArgT&& x) :
             m_x(std::forward<ArgT>(x))
         {
         }
@@ -469,7 +471,7 @@ namespace Learner::Autograd::UnivariateStatic
     };
 
     template <typename ArgT, typename T = typename std::remove_reference_t<ArgT>::ValueType>
-    auto log(ArgT&& x)
+    constexpr auto log(ArgT&& x)
     {
         return Log<ArgT&&>(std::forward<ArgT>(x));
     }

--- a/src/learn/autograd.h
+++ b/src/learn/autograd.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <tuple>
 #include <optional>
+#include <algorithm>
 
 namespace Learner
 {
@@ -47,6 +48,11 @@ namespace Learner
         ValueWithGrad abs() const
         {
             return { std::abs(value), std::abs(grad) };
+        }
+
+        ValueWithGrad clamp_grad(T max) const
+        {
+            return { value, std::clamp(grad, -max, max) };
         }
     };
 }

--- a/src/learn/autograd.h
+++ b/src/learn/autograd.h
@@ -283,6 +283,38 @@ namespace Learner::Autograd::UnivariateStatic
     }
 
     template <typename ArgT, typename T = typename ArgT::ValueType>
+    struct Negation : Evaluable<Negation<ArgT, T>>
+    {
+        using ValueType = T;
+
+        explicit Negation(ArgT x) :
+            m_x(std::move(x))
+        {
+        }
+
+        template <typename... ArgsTs>
+        T value(const std::tuple<ArgsTs...>& args) const
+        {
+            return -m_x.value(args);
+        }
+
+        template <typename... ArgsTs>
+        T grad(const std::tuple<ArgsTs...>& args) const
+        {
+            return -m_x.grad(args);
+        }
+
+    private:
+        ArgT m_x;
+    };
+
+    template <typename ArgT, typename T = typename ArgT::ValueType>
+    auto operator-(ArgT x)
+    {
+        return Negation(std::move(x));
+    }
+
+    template <typename ArgT, typename T = typename ArgT::ValueType>
     struct Sigmoid : Evaluable<Sigmoid<ArgT, T>>
     {
         using ValueType = T;
@@ -318,7 +350,7 @@ namespace Learner::Autograd::UnivariateStatic
         }
     };
 
-    template <typename ArgT>
+    template <typename ArgT, typename T = typename ArgT::ValueType>
     auto sigmoid(ArgT x)
     {
         return Sigmoid(std::move(x));
@@ -394,7 +426,7 @@ namespace Learner::Autograd::UnivariateStatic
         }
     };
 
-    template <typename ArgT>
+    template <typename ArgT, typename T = typename ArgT::ValueType>
     auto log(ArgT x)
     {
         return Log(std::move(x));

--- a/src/learn/autograd.h
+++ b/src/learn/autograd.h
@@ -45,12 +45,12 @@ namespace Learner
             return *this;
         }
 
-        ValueWithGrad abs() const
+        [[nodiscard]] ValueWithGrad abs() const
         {
             return { std::abs(value), std::abs(grad) };
         }
 
-        ValueWithGrad clamp_grad(T max) const
+        [[nodiscard]] ValueWithGrad clamp_grad(T max) const
         {
             return { value, std::clamp(grad, -max, max) };
         }
@@ -82,13 +82,13 @@ namespace Learner::Autograd::UnivariateStatic
         constexpr Evaluable() = default;
 
         template <typename... ArgsTs>
-        auto eval(const std::tuple<ArgsTs...>& args) const
+        [[nodiscard]] auto eval(const std::tuple<ArgsTs...>& args) const
         {
             return ValueWithGrad<T>{ value(args), grad(args) };
         }
 
         template <typename... ArgsTs>
-        auto value(const std::tuple<ArgsTs...>& args) const
+        [[nodiscard]] auto value(const std::tuple<ArgsTs...>& args) const
         {
             const ChildT* this_ = static_cast<const ChildT*>(this);
 
@@ -101,7 +101,7 @@ namespace Learner::Autograd::UnivariateStatic
         }
 
         template <typename... ArgsTs>
-        auto grad(const std::tuple<ArgsTs...>& args) const
+        [[nodiscard]] auto grad(const std::tuple<ArgsTs...>& args) const
         {
             const ChildT* this_ = static_cast<const ChildT*>(this);
 
@@ -128,13 +128,13 @@ namespace Learner::Autograd::UnivariateStatic
         }
 
         template <typename... ArgsTs>
-        T calculate_value(const std::tuple<ArgsTs...>& args) const
+        [[nodiscard]] T calculate_value(const std::tuple<ArgsTs...>& args) const
         {
             return std::get<I>(args);
         }
 
         template <typename... ArgsTs>
-        T calculate_grad(const std::tuple<ArgsTs...>&) const
+        [[nodiscard]] T calculate_grad(const std::tuple<ArgsTs...>&) const
         {
             return T(1.0);
         }
@@ -150,13 +150,13 @@ namespace Learner::Autograd::UnivariateStatic
         }
 
         template <typename... ArgsTs>
-        T calculate_value(const std::tuple<ArgsTs...>& args) const
+        [[nodiscard]] T calculate_value(const std::tuple<ArgsTs...>& args) const
         {
             return std::get<I>(args);
         }
 
         template <typename... ArgsTs>
-        T calculate_grad(const std::tuple<ArgsTs...>&) const
+        [[nodiscard]] T calculate_grad(const std::tuple<ArgsTs...>&) const
         {
             return T(0.0);
         }
@@ -173,13 +173,13 @@ namespace Learner::Autograd::UnivariateStatic
         }
 
         template <typename... ArgsTs>
-        T calculate_value(const std::tuple<ArgsTs...>&) const
+        [[nodiscard]] T calculate_value(const std::tuple<ArgsTs...>&) const
         {
             return m_x;
         }
 
         template <typename... ArgsTs>
-        T calculate_grad(const std::tuple<ArgsTs...>&) const
+        [[nodiscard]] T calculate_grad(const std::tuple<ArgsTs...>&) const
         {
             return T(0.0);
         }
@@ -200,13 +200,13 @@ namespace Learner::Autograd::UnivariateStatic
         }
 
         template <typename... ArgsTs>
-        T calculate_value(const std::tuple<ArgsTs...>& args) const
+        [[nodiscard]] T calculate_value(const std::tuple<ArgsTs...>& args) const
         {
             return m_lhs.value(args) + m_rhs.value(args);
         }
 
         template <typename... ArgsTs>
-        T calculate_grad(const std::tuple<ArgsTs...>& args) const
+        [[nodiscard]] T calculate_grad(const std::tuple<ArgsTs...>& args) const
         {
             return m_lhs.grad(args) + m_rhs.grad(args);
         }
@@ -217,19 +217,19 @@ namespace Learner::Autograd::UnivariateStatic
     };
 
     template <typename LhsT, typename RhsT, typename T = typename std::remove_reference_t<LhsT>::ValueType>
-    constexpr auto operator+(LhsT&& lhs, RhsT&& rhs)
+    [[nodiscard]] constexpr auto operator+(LhsT&& lhs, RhsT&& rhs)
     {
         return Sum<LhsT&&, RhsT&&>(std::forward<LhsT>(lhs), std::forward<RhsT>(rhs));
     }
 
     template <typename LhsT, typename T = typename std::remove_reference_t<LhsT>::ValueType>
-    constexpr auto operator+(LhsT&& lhs, Id<T> rhs)
+    [[nodiscard]] constexpr auto operator+(LhsT&& lhs, Id<T> rhs)
     {
         return Sum<LhsT&&, Constant<T>&&>(std::forward<LhsT>(lhs), Constant(rhs));
     }
 
     template <typename RhsT, typename T = typename std::remove_reference_t<RhsT>::ValueType>
-    constexpr auto operator+(Id<T> lhs, RhsT&& rhs)
+    [[nodiscard]] constexpr auto operator+(Id<T> lhs, RhsT&& rhs)
     {
         return Sum<Constant<T>&&, RhsT&&>(Constant(lhs), std::forward<RhsT>(rhs));
     }
@@ -246,13 +246,13 @@ namespace Learner::Autograd::UnivariateStatic
         }
 
         template <typename... ArgsTs>
-        T calculate_value(const std::tuple<ArgsTs...>& args) const
+        [[nodiscard]] T calculate_value(const std::tuple<ArgsTs...>& args) const
         {
             return m_lhs.value(args) - m_rhs.value(args);
         }
 
         template <typename... ArgsTs>
-        T calculate_grad(const std::tuple<ArgsTs...>& args) const
+        [[nodiscard]] T calculate_grad(const std::tuple<ArgsTs...>& args) const
         {
             return m_lhs.grad(args) - m_rhs.grad(args);
         }
@@ -263,19 +263,19 @@ namespace Learner::Autograd::UnivariateStatic
     };
 
     template <typename LhsT, typename RhsT, typename T = typename std::remove_reference_t<LhsT>::ValueType>
-    constexpr auto operator-(LhsT&& lhs, RhsT&& rhs)
+    [[nodiscard]] constexpr auto operator-(LhsT&& lhs, RhsT&& rhs)
     {
         return Difference<LhsT&&, RhsT&&>(std::forward<LhsT>(lhs), std::forward<RhsT>(rhs));
     }
 
     template <typename LhsT, typename T = typename std::remove_reference_t<LhsT>::ValueType>
-    constexpr auto operator-(LhsT&& lhs, Id<T> rhs)
+    [[nodiscard]] constexpr auto operator-(LhsT&& lhs, Id<T> rhs)
     {
         return Difference<LhsT&&, Constant<T>&&>(std::forward<LhsT>(lhs), Constant(rhs));
     }
 
     template <typename RhsT, typename T = typename std::remove_reference_t<RhsT>::ValueType>
-    constexpr auto operator-(Id<T> lhs, RhsT&& rhs)
+    [[nodiscard]] constexpr auto operator-(Id<T> lhs, RhsT&& rhs)
     {
         return Difference<Constant<T>&&, RhsT&&>(Constant(lhs), std::forward<RhsT>(rhs));
     }
@@ -292,13 +292,13 @@ namespace Learner::Autograd::UnivariateStatic
         }
 
         template <typename... ArgsTs>
-        T calculate_value(const std::tuple<ArgsTs...>& args) const
+        [[nodiscard]] T calculate_value(const std::tuple<ArgsTs...>& args) const
         {
             return m_lhs.value(args) * m_rhs.value(args);
         }
 
         template <typename... ArgsTs>
-        T calculate_grad(const std::tuple<ArgsTs...>& args) const
+        [[nodiscard]] T calculate_grad(const std::tuple<ArgsTs...>& args) const
         {
             return m_lhs.grad(args) * m_rhs.value(args) + m_lhs.value(args) * m_rhs.grad(args);
         }
@@ -309,19 +309,19 @@ namespace Learner::Autograd::UnivariateStatic
     };
 
     template <typename LhsT, typename RhsT, typename T = typename std::remove_reference_t<LhsT>::ValueType>
-    constexpr auto operator*(LhsT&& lhs, RhsT&& rhs)
+    [[nodiscard]] constexpr auto operator*(LhsT&& lhs, RhsT&& rhs)
     {
         return Product<LhsT&&, RhsT&&>(std::forward<LhsT>(lhs), std::forward<RhsT>(rhs));
     }
 
     template <typename LhsT, typename T = typename std::remove_reference_t<LhsT>::ValueType>
-    constexpr auto operator*(LhsT&& lhs, Id<T> rhs)
+    [[nodiscard]] constexpr auto operator*(LhsT&& lhs, Id<T> rhs)
     {
         return Product<LhsT&&, Constant<T>&&>(std::forward<LhsT>(lhs), Constant(rhs));
     }
 
     template <typename RhsT, typename T = typename std::remove_reference_t<RhsT>::ValueType>
-    constexpr auto operator*(Id<T> lhs, RhsT&& rhs)
+    [[nodiscard]] constexpr auto operator*(Id<T> lhs, RhsT&& rhs)
     {
         return Product<Constant<T>&&, RhsT&&>(Constant(lhs), std::forward<RhsT>(rhs));
     }
@@ -337,13 +337,13 @@ namespace Learner::Autograd::UnivariateStatic
         }
 
         template <typename... ArgsTs>
-        T calculate_value(const std::tuple<ArgsTs...>& args) const
+        [[nodiscard]] T calculate_value(const std::tuple<ArgsTs...>& args) const
         {
             return -m_x.value(args);
         }
 
         template <typename... ArgsTs>
-        T calculate_grad(const std::tuple<ArgsTs...>& args) const
+        [[nodiscard]] T calculate_grad(const std::tuple<ArgsTs...>& args) const
         {
             return -m_x.grad(args);
         }
@@ -353,7 +353,7 @@ namespace Learner::Autograd::UnivariateStatic
     };
 
     template <typename ArgT, typename T = typename std::remove_reference_t<ArgT>::ValueType>
-    constexpr auto operator-(ArgT&& x)
+    [[nodiscard]] constexpr auto operator-(ArgT&& x)
     {
         return Negation<ArgT&&>(std::forward<ArgT>(x));
     }
@@ -369,13 +369,13 @@ namespace Learner::Autograd::UnivariateStatic
         }
 
         template <typename... ArgsTs>
-        T calculate_value(const std::tuple<ArgsTs...>& args) const
+        [[nodiscard]] T calculate_value(const std::tuple<ArgsTs...>& args) const
         {
             return value_(m_x.value(args));
         }
 
         template <typename... ArgsTs>
-        T calculate_grad(const std::tuple<ArgsTs...>& args) const
+        [[nodiscard]] T calculate_grad(const std::tuple<ArgsTs...>& args) const
         {
             return m_x.grad(args) * grad_(m_x.value(args));
         }
@@ -383,19 +383,19 @@ namespace Learner::Autograd::UnivariateStatic
     private:
         StoreValueOrRef<ArgT> m_x;
 
-        T value_(T x) const
+        [[nodiscard]] T value_(T x) const
         {
             return 1.0 / (1.0 + std::exp(-x));
         }
 
-        T grad_(T x) const
+        [[nodiscard]] T grad_(T x) const
         {
             return value_(x) * (1.0 - value_(x));
         }
     };
 
     template <typename ArgT, typename T = typename std::remove_reference_t<ArgT>::ValueType>
-    constexpr auto sigmoid(ArgT&& x)
+    [[nodiscard]] constexpr auto sigmoid(ArgT&& x)
     {
         return Sigmoid<ArgT&&>(std::forward<ArgT>(x));
     }
@@ -412,13 +412,13 @@ namespace Learner::Autograd::UnivariateStatic
         }
 
         template <typename... ArgsTs>
-        T calculate_value(const std::tuple<ArgsTs...>& args) const
+        [[nodiscard]] T calculate_value(const std::tuple<ArgsTs...>& args) const
         {
             return std::pow(m_x.value(args), m_exponent);
         }
 
         template <typename... ArgsTs>
-        T calculate_grad(const std::tuple<ArgsTs...>& args) const
+        [[nodiscard]] T calculate_grad(const std::tuple<ArgsTs...>& args) const
         {
             return m_exponent * std::pow(m_x.value(args), m_exponent - T(1.0)) * m_x.grad(args);
         }
@@ -429,7 +429,7 @@ namespace Learner::Autograd::UnivariateStatic
     };
 
     template <typename ArgT, typename T = typename std::remove_reference_t<ArgT>::ValueType>
-    constexpr auto pow(ArgT&& x, Id<T> exp)
+    [[nodiscard]] constexpr auto pow(ArgT&& x, Id<T> exp)
     {
         return Pow<ArgT&&>(std::forward<ArgT>(x), std::move(exp));
     }
@@ -445,13 +445,13 @@ namespace Learner::Autograd::UnivariateStatic
         }
 
         template <typename... ArgsTs>
-        T calculate_value(const std::tuple<ArgsTs...>& args) const
+        [[nodiscard]] T calculate_value(const std::tuple<ArgsTs...>& args) const
         {
             return value_(m_x.value(args));
         }
 
         template <typename... ArgsTs>
-        T calculate_grad(const std::tuple<ArgsTs...>& args) const
+        [[nodiscard]] T calculate_grad(const std::tuple<ArgsTs...>& args) const
         {
             return m_x.grad(args) * grad_(m_x.value(args));
         }
@@ -471,7 +471,7 @@ namespace Learner::Autograd::UnivariateStatic
     };
 
     template <typename ArgT, typename T = typename std::remove_reference_t<ArgT>::ValueType>
-    constexpr auto log(ArgT&& x)
+    [[nodiscard]] constexpr auto log(ArgT&& x)
     {
         return Log<ArgT&&>(std::forward<ArgT>(x));
     }

--- a/src/learn/autograd.h
+++ b/src/learn/autograd.h
@@ -42,6 +42,11 @@ namespace Learner
             grad /= rhs;
             return *this;
         }
+
+        ValueWithGrad abs() const
+        {
+            return { std::abs(value), std::abs(grad) };
+        }
     };
 }
 

--- a/src/learn/autograd.h
+++ b/src/learn/autograd.h
@@ -1,0 +1,350 @@
+#ifndef LEARNER_AUTOGRAD_H
+#define LEARNER_AUTOGRAD_H
+
+#include <cmath>
+#include <utility>
+#include <type_traits>
+#include <memory>
+#include <tuple>
+
+namespace Learner::Autograd::UnivariateStatic
+{
+
+    template <typename T>
+    struct Identity
+    {
+        using type = T;
+    };
+
+    template <typename T>
+    using Id = typename Identity<T>::type;
+
+    template <typename T, int I>
+    struct VariableParameter
+    {
+        using ValueType = T;
+
+        VariableParameter()
+        {
+        }
+
+        template <typename... ArgsTs>
+        T value(const std::tuple<ArgsTs...>& args) const
+        {
+            return std::get<I>(args);
+        }
+
+        template <typename... ArgsTs>
+        T grad(const std::tuple<ArgsTs...>&) const
+        {
+            return T(1.0);
+        }
+    };
+
+    template <typename T, int I>
+    struct ConstantParameter
+    {
+        using ValueType = T;
+
+        ConstantParameter()
+        {
+        }
+
+        template <typename... ArgsTs>
+        T value(const std::tuple<ArgsTs...>& args) const
+        {
+            return std::get<I>(args);
+        }
+
+        template <typename... ArgsTs>
+        T grad(const std::tuple<ArgsTs...>&) const
+        {
+            return T(0.0);
+        }
+    };
+
+    template <typename T>
+    struct Constant
+    {
+        using ValueType = T;
+
+        Constant(T x) :
+            m_x(std::move(x))
+        {
+        }
+
+        template <typename... ArgsTs>
+        T value(const std::tuple<ArgsTs...>&) const
+        {
+            return m_x;
+        }
+
+        template <typename... ArgsTs>
+        T grad(const std::tuple<ArgsTs...>&) const
+        {
+            return T(0.0);
+        }
+
+    private:
+        T m_x;
+    };
+
+    template <typename LhsT, typename RhsT, typename T = typename LhsT::ValueType>
+    struct Sum
+    {
+        using ValueType = T;
+
+        Sum(LhsT lhs, RhsT rhs) :
+            m_lhs(std::move(lhs)),
+            m_rhs(std::move(rhs))
+        {
+        }
+
+        template <typename... ArgsTs>
+        T value(const std::tuple<ArgsTs...>& args) const
+        {
+            return m_lhs.value(args) + m_rhs.value(args);
+        }
+
+        template <typename... ArgsTs>
+        T grad(const std::tuple<ArgsTs...>& args) const
+        {
+            return m_lhs.grad(args) + m_rhs.grad(args);
+        }
+
+    private:
+        LhsT m_lhs;
+        RhsT m_rhs;
+    };
+
+    template <typename LhsT, typename RhsT, typename T = typename LhsT::ValueType>
+    auto operator+(LhsT lhs, RhsT rhs)
+    {
+        return Sum(std::move(lhs), std::move(rhs));
+    }
+
+    template <typename LhsT, typename T = typename LhsT::ValueType>
+    auto operator+(LhsT lhs, Id<T> rhs)
+    {
+        return Sum(std::move(lhs), Constant(rhs));
+    }
+
+    template <typename RhsT, typename T = typename RhsT::ValueType>
+    auto operator+(Id<T> lhs, RhsT rhs)
+    {
+        return Sum(Constant(lhs), std::move(rhs));
+    }
+
+    template <typename LhsT, typename RhsT, typename T = typename LhsT::ValueType>
+    struct Difference
+    {
+        using ValueType = T;
+
+        Difference(LhsT lhs, RhsT rhs) :
+            m_lhs(std::move(lhs)),
+            m_rhs(std::move(rhs))
+        {
+        }
+
+        template <typename... ArgsTs>
+        T value(const std::tuple<ArgsTs...>& args) const
+        {
+            return m_lhs.value(args) - m_rhs.value(args);
+        }
+
+        template <typename... ArgsTs>
+        T grad(const std::tuple<ArgsTs...>& args) const
+        {
+            return m_lhs.grad(args) - m_rhs.grad(args);
+        }
+
+    private:
+        LhsT m_lhs;
+        RhsT m_rhs;
+    };
+
+    template <typename LhsT, typename RhsT, typename T = typename LhsT::ValueType>
+    auto operator-(LhsT lhs, RhsT rhs)
+    {
+        return Difference(std::move(lhs), std::move(rhs));
+    }
+
+    template <typename LhsT, typename T = typename LhsT::ValueType>
+    auto operator-(LhsT lhs, Id<T> rhs)
+    {
+        return Difference(std::move(lhs), Constant(rhs));
+    }
+
+    template <typename RhsT, typename T = typename RhsT::ValueType>
+    auto operator-(Id<T> lhs, RhsT rhs)
+    {
+        return Difference(Constant(lhs), std::move(rhs));
+    }
+
+    template <typename LhsT, typename RhsT, typename T = typename LhsT::ValueType>
+    struct Product
+    {
+        using ValueType = T;
+
+        Product(LhsT lhs, RhsT rhs) :
+            m_lhs(std::move(lhs)),
+            m_rhs(std::move(rhs))
+        {
+        }
+
+        template <typename... ArgsTs>
+        T value(const std::tuple<ArgsTs...>& args) const
+        {
+            return m_lhs.value(args) * m_rhs.value(args);
+        }
+
+        template <typename... ArgsTs>
+        T grad(const std::tuple<ArgsTs...>& args) const
+        {
+            return m_lhs.grad(args) * m_rhs.value(args) + m_lhs.value(args) * m_rhs.grad(args);
+        }
+
+    private:
+        LhsT m_lhs;
+        RhsT m_rhs;
+    };
+
+    template <typename LhsT, typename RhsT, typename T = typename LhsT::ValueType>
+    auto operator*(LhsT lhs, RhsT rhs)
+    {
+        return Product(std::move(lhs), std::move(rhs));
+    }
+
+    template <typename LhsT, typename T = typename LhsT::ValueType>
+    auto operator*(LhsT lhs, Id<T> rhs)
+    {
+        return Product(std::move(lhs), Constant(rhs));
+    }
+
+    template <typename RhsT, typename T = typename RhsT::ValueType>
+    auto operator*(Id<T> lhs, RhsT rhs)
+    {
+        return Product(Constant(lhs), std::move(rhs));
+    }
+
+    template <typename ArgT, typename T = typename ArgT::ValueType>
+    struct Sigmoid
+    {
+        using ValueType = T;
+
+        explicit Sigmoid(ArgT x) :
+            m_x(std::move(x))
+        {
+        }
+
+        template <typename... ArgsTs>
+        T value(const std::tuple<ArgsTs...>& args) const
+        {
+            return value_(m_x.value(args));
+        }
+
+        template <typename... ArgsTs>
+        T grad(const std::tuple<ArgsTs...>& args) const
+        {
+            return m_x.grad(args) * grad_(m_x.value(args));
+        }
+
+    private:
+        ArgT m_x;
+
+        T value_(T x) const
+        {
+            return 1.0 / (1.0 + std::exp(-x));
+        }
+
+        T grad_(T x) const
+        {
+            return value_(x) * (1.0 - value_(x));
+        }
+    };
+
+    template <typename ArgT>
+    auto sigmoid(ArgT x)
+    {
+        return Sigmoid(std::move(x));
+    }
+
+    template <typename ArgT, typename T = typename ArgT::ValueType>
+    struct Pow
+    {
+        using ValueType = T;
+
+        explicit Pow(ArgT x, Id<T> exponent) :
+            m_x(std::move(x)),
+            m_exponent(std::move(exponent))
+        {
+        }
+
+        template <typename... ArgsTs>
+        T value(const std::tuple<ArgsTs...>& args) const
+        {
+            return std::pow(m_x.value(args), m_exponent);
+        }
+
+        template <typename... ArgsTs>
+        T grad(const std::tuple<ArgsTs...>& args) const
+        {
+            return m_exponent * std::pow(m_x.value(args), m_exponent - T(1.0)) * m_x.grad(args);
+        }
+
+    private:
+        ArgT m_x;
+        T m_exponent;
+    };
+
+    template <typename ArgT, typename T = typename ArgT::ValueType>
+    auto pow(ArgT x, Id<T> exp)
+    {
+        return Pow(std::move(x), std::move(exp));
+    }
+
+    template <typename ArgT, typename T = typename ArgT::ValueType>
+    struct Log
+    {
+        using ValueType = T;
+
+        explicit Log(ArgT x) :
+            m_x(std::move(x))
+        {
+        }
+
+        template <typename... ArgsTs>
+        T value(const std::tuple<ArgsTs...>& args) const
+        {
+            return value_(m_x.value(args));
+        }
+
+        template <typename... ArgsTs>
+        T grad(const std::tuple<ArgsTs...>& args) const
+        {
+            return m_x.grad(args) * grad_(m_x.value(args));
+        }
+
+    private:
+        ArgT m_x;
+
+        T value_(T x) const
+        {
+            return std::log(x);
+        }
+
+        T grad_(T x) const
+        {
+            return 1.0 / x;
+        }
+    };
+
+    template <typename ArgT>
+    auto log(ArgT x)
+    {
+        return Log(std::move(x));
+    }
+
+}
+
+#endif

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -213,9 +213,9 @@ namespace Learner
         static thread_local auto outcome_loss_ = -(t_ * log(q_) + (1.0 - t_) * log(1.0 - q_));
         static thread_local auto result_ = lambda_ * teacher_loss_ + (1.0 - lambda_) * outcome_loss_;
         static thread_local auto entropy_ = lambda_ * teacher_entropy_ + (1.0 - lambda_) * outcome_entropy_;
-        static thread_local auto loss_ = result_ - entropy_;
+        static thread_local auto cross_entropy_ = result_ - entropy_;
 
-        return loss_;
+        return cross_entropy_;
     }
 
     template <typename ValueT>
@@ -247,23 +247,27 @@ namespace Learner
         return perf_;
     }
 
-    static ValueWithGrad<double> get_loss(Value shallow, Value teacher_signal, int result, int ply)
+    static ValueWithGrad<double> get_loss_noob(Value shallow, Value teacher_signal, int result, int /* ply */)
     {
         using namespace Learner::Autograd::UnivariateStatic;
 
-        /*
-        auto q_ = sigmoid(VariableParameter<double, 0>{} * winning_probability_coefficient);
-        auto p_ = sigmoid(ConstantParameter<double, 1>{} * winning_probability_coefficient);
-        auto t_ = (ConstantParameter<double, 2>{} + 1.0) * 0.5;
-        auto lambda_ = ConstantParameter<double, 3>{};
-        auto loss_ = pow(lambda_ * (q_ - p_) + (1.0 - lambda_) * (q_ - t_), 2.0);
-        */
+        static thread_local auto q_ = VariableParameter<double, 0>{};
+        static thread_local auto p_ = ConstantParameter<double, 1>{};
+        static thread_local auto loss_ = pow(q_ - p_, 2.0) * (1.0 / (2400.0 * 2.0 * 600.0));
 
-        /*
-        auto q_ = VariableParameter<double, 0>{};
-        auto p_ = ConstantParameter<double, 1>{};
-        auto loss_ = pow(q_ - p_, 2.0) * (1.0 / (2400.0 * 2.0 * 600.0));
-        */
+        auto args = std::tuple(
+            (double)shallow,
+            (double)teacher_signal,
+            (double)result,
+            calculate_lambda(teacher_signal)
+        );
+
+        return loss_.eval(args);
+    }
+
+    static ValueWithGrad<double> get_loss_cross_entropy(Value shallow, Value teacher_signal, int result, int /* ply */)
+    {
+        using namespace Learner::Autograd::UnivariateStatic;
 
         static thread_local auto q_ = expected_perf_(VariableParameter<double, 0>{});
         static thread_local auto p_ = expected_perf_(scale_score_(ConstantParameter<double, 1>{}));
@@ -279,6 +283,13 @@ namespace Learner
         );
 
         return loss_.eval(args);
+    }
+
+    static auto get_loss(Value shallow, Value teacher_signal, int result, int ply)
+    {
+        using namespace Learner::Autograd::UnivariateStatic;
+
+        return get_loss_cross_entropy(shallow, teacher_signal, result, ply);
     }
 
     static auto get_loss(

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -199,7 +199,7 @@ namespace Learner
     // differentiation of the loss function. While it works it has it's caveats.
     // To work fast enough it requires memoization and reference semantics.
     // Memoization is mostly opaque to the user and is only per eval basis.
-    // As for reference semantics, we cannot copy every node, 
+    // As for reference semantics, we cannot copy every node,
     // because we need a way to reuse computation.
     // But we can't really use shared_ptr because of the overhead. That means
     // that we have to ensure all parts of a loss expression are not destroyed
@@ -321,7 +321,7 @@ namespace Learner
 
         // The model captures only up to 240 plies, so limit input (and rescale)
         static thread_local auto m_ = std::forward<PlyT>(ply_) / 64.0;
-         
+
         static thread_local auto a_ = (((as[0] * m_ + as[1]) * m_ + as[2]) * m_) + as[3];
         static thread_local auto b_ = (((bs[0] * m_ + bs[1]) * m_ + bs[2]) * m_) + bs[3];
 
@@ -392,11 +392,11 @@ namespace Learner
     {
         using namespace Learner::Autograd::UnivariateStatic;
 
-        static thread_local auto q_ = expected_perf_(VariableParameter<double, 0>{});
-        static thread_local auto p_ = expected_perf_(scale_score_(ConstantParameter<double, 1>{}));
+        static thread_local auto& q_ = expected_perf_(VariableParameter<double, 0>{});
+        static thread_local auto& p_ = expected_perf_(scale_score_(ConstantParameter<double, 1>{}));
         static thread_local auto t_ = (ConstantParameter<double, 2>{} + 1.0) * 0.5;
         static thread_local auto lambda_ = ConstantParameter<double, 3>{};
-        static thread_local auto loss_ = cross_entropy_(q_, p_, t_, lambda_);
+        static thread_local auto& loss_ = cross_entropy_(q_, p_, t_, lambda_);
 
         auto args = std::tuple(
             (double)shallow,
@@ -415,14 +415,14 @@ namespace Learner
 
         static thread_local auto ply_ = ConstantParameter<double, 4>{};
         static thread_local auto shallow_ = VariableParameter<double, 0>{};
-        static thread_local auto q_ = expected_perf_use_wdl_(shallow_, ply_);
+        static thread_local auto& q_ = expected_perf_use_wdl_(shallow_, ply_);
         // We could do just this but MSVC crashes with an internal compiler error :(
-        // static thread_local auto scaled_teacher_ = scale_score_(ConstantParameter<double, 1>{});
-        // static thread_local auto p_ = expected_perf_use_wdl_(scaled_teacher_, ply_);
+        // static thread_local auto& scaled_teacher_ = scale_score_(ConstantParameter<double, 1>{});
+        // static thread_local auto& p_ = expected_perf_use_wdl_(scaled_teacher_, ply_);
         static thread_local auto p_ = ConstantParameter<double, 1>{};
         static thread_local auto t_ = (ConstantParameter<double, 2>{} + 1.0) * 0.5;
         static thread_local auto lambda_ = ConstantParameter<double, 3>{};
-        static thread_local auto loss_ = cross_entropy_(q_, p_, t_, lambda_);
+        static thread_local auto& loss_ = cross_entropy_(q_, p_, t_, lambda_);
 
         auto args = std::tuple(
             (double)shallow,

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -230,7 +230,7 @@ namespace Learner
         auto loss_ = result_ - entropy_;
 
         auto args = std::tuple((double)shallow, (double)teacher_signal, (double)result, calculate_lambda(teacher_signal));
-        return loss_.eval(args);
+        return loss_.eval(args).clamp_grad(max_grad);
     }
 
     static auto get_loss(

--- a/src/learn/learn.h
+++ b/src/learn/learn.h
@@ -33,6 +33,7 @@ using LearnFloatType = float;
 // Definition of struct used in Learner
 // ----------------------
 
+#include "autograd.h"
 #include "packed_sfen.h"
 
 #include "position.h"
@@ -68,6 +69,7 @@ namespace Learner
     void learn(std::istringstream& is);
 
     using CalcGradFunc = double(Value, Value, int, int);
+    using CalcLossFunc = ValueWithGrad<double>(Value, Value, int, int);
 }
 
 #endif // ifndef _LEARN_H_

--- a/src/learn/learn.h
+++ b/src/learn/learn.h
@@ -68,7 +68,6 @@ namespace Learner
     // Learning from the generated game record
     void learn(std::istringstream& is);
 
-    using CalcGradFunc = double(Value, Value, int, int);
     using CalcLossFunc = ValueWithGrad<double>(Value, Value, int, int);
 }
 

--- a/src/learn/learn.h
+++ b/src/learn/learn.h
@@ -126,10 +126,16 @@ namespace Learner
         }
 
         template <typename StreamT>
-        void print(const std::string& prefix, StreamT& s) const
+        void print_with_grad(const std::string& prefix, StreamT& s) const
         {
             s << "  - " << prefix << "_loss       = " << m_loss.value / (double)m_count << std::endl;
             s << "  - " << prefix << "_grad_norm  = " << m_loss.grad / (double)m_count << std::endl;
+        }
+
+        template <typename StreamT>
+        void print_only_loss(const std::string& prefix, StreamT& s) const
+        {
+            s << "  - " << prefix << "_loss       = " << m_loss.value / (double)m_count << std::endl;
         }
 
     private:

--- a/src/nnue/evaluate_nnue_learner.cpp
+++ b/src/nnue/evaluate_nnue_learner.cpp
@@ -195,6 +195,7 @@ namespace Eval::NNUE {
         uint64_t epoch,
         bool verbose,
         double learning_rate,
+        double max_grad,
         Learner::CalcLossFunc calc_loss)
     {
         using namespace Learner::Autograd::UnivariateStatic;
@@ -237,8 +238,9 @@ namespace Eval::NNUE {
                         const auto discrete = e.sign * e.discrete_nn_eval;
                         const auto& psv = e.psv;
                         const auto loss = calc_loss(shallow, (Value)psv.score, psv.game_result, psv.gamePly);
-                        const double gradient = loss.grad * e.sign * kPonanzaConstant;
-                        gradients[b] = static_cast<LearnFloatType>(gradient * e.weight);
+                        const double gradient = std::clamp(
+                            loss.grad * e.sign * kPonanzaConstant * e.weight, -max_grad, max_grad);
+                        gradients[b] = static_cast<LearnFloatType>(gradient);
 
 
                         // The discrete eval will only be valid before first backpropagation,

--- a/src/nnue/evaluate_nnue_learner.cpp
+++ b/src/nnue/evaluate_nnue_learner.cpp
@@ -195,8 +195,11 @@ namespace Eval::NNUE {
         uint64_t epoch,
         bool verbose,
         double learning_rate,
-        Learner::CalcGradFunc calc_grad)
+        Learner::CalcGradFunc calc_grad,
+        Learner::CalcLossFunc calc_loss)
     {
+        using namespace Learner::Autograd::UnivariateStatic;
+
         assert(batch_size > 0);
 
         learning_rate /= batch_size;

--- a/src/nnue/evaluate_nnue_learner.cpp
+++ b/src/nnue/evaluate_nnue_learner.cpp
@@ -195,7 +195,6 @@ namespace Eval::NNUE {
         uint64_t epoch,
         bool verbose,
         double learning_rate,
-        Learner::CalcGradFunc calc_grad,
         Learner::CalcLossFunc calc_loss)
     {
         using namespace Learner::Autograd::UnivariateStatic;
@@ -237,8 +236,8 @@ namespace Eval::NNUE {
                             e.sign * network_output[b] * kPonanzaConstant));
                         const auto discrete = e.sign * e.discrete_nn_eval;
                         const auto& psv = e.psv;
-                        const double gradient =
-                            e.sign * calc_grad(shallow, (Value)psv.score, psv.game_result, psv.gamePly);
+                        const auto loss = calc_loss(shallow, (Value)psv.score, psv.game_result, psv.gamePly);
+                        const double gradient = loss.grad * e.sign * kPonanzaConstant;
                         gradients[b] = static_cast<LearnFloatType>(gradient * e.weight);
 
 

--- a/src/nnue/evaluate_nnue_learner.h
+++ b/src/nnue/evaluate_nnue_learner.h
@@ -33,7 +33,7 @@ namespace Eval::NNUE {
         double weight);
 
     // update the evaluation function parameters
-    void update_parameters(
+    Learner::Loss update_parameters(
         ThreadPool& thread_pool,
         uint64_t epoch,
         bool verbose,

--- a/src/nnue/evaluate_nnue_learner.h
+++ b/src/nnue/evaluate_nnue_learner.h
@@ -38,7 +38,6 @@ namespace Eval::NNUE {
         uint64_t epoch,
         bool verbose,
         double learning_rate,
-        Learner::CalcGradFunc calc_grad,
         Learner::CalcLossFunc calc_loss);
 
     // Check if there are any problems with learning

--- a/src/nnue/evaluate_nnue_learner.h
+++ b/src/nnue/evaluate_nnue_learner.h
@@ -38,6 +38,7 @@ namespace Eval::NNUE {
         uint64_t epoch,
         bool verbose,
         double learning_rate,
+        double max_grad,
         Learner::CalcLossFunc calc_loss);
 
     // Check if there are any problems with learning

--- a/src/nnue/evaluate_nnue_learner.h
+++ b/src/nnue/evaluate_nnue_learner.h
@@ -38,7 +38,8 @@ namespace Eval::NNUE {
         uint64_t epoch,
         bool verbose,
         double learning_rate,
-        Learner::CalcGradFunc calc_grad);
+        Learner::CalcGradFunc calc_grad,
+        Learner::CalcLossFunc calc_loss);
 
     // Check if there are any problems with learning
     void check_health();


### PR DESCRIPTION
This is a WIP PR for replacing the machinery around the loss function with a more robust approach based on automatic differentiation. The advantages are twofold: 1. We don't have to compute the loss derivatives. 2. Loss always matches its derivative.

Currently I allowed myself to remove all the old loss code and replace it with cross entropy based loss. That means `use_wdl` and teacher score rescaling have no effect right now. I would like to bring back at least the `use_wdl` option, but I'd have to understand it deeper and create necessary automatic differentiation primitives to represent stockfish's wdl function with it.

As it stands, I trained one network with this trainer and it turned out, as expected, about equal to the network trained with an older version (Baseline was halfka flip with unoptimized master that's ~20% slower. The net trained with this PR turned out to be ~30 elo better, which accounting for all the things seems about right. Definitely proves correctness).

The design of this automatic differentiation framework relies on constructing expression templates of the computation tree. Each node contains two methods - one for computing the value, and one for computing the gradient. This is a very simple approach and only handles the univariate case with scalar inputs and outputs, but it's enough for any loss calculation we could imagine. Two optimizations are performed with this expression template scheme:
1. Memoization of the computed results, as it's common that reevaluation happens as we don't have precise control over common subexpression elimination.
2. Nodes passed as lvalue references to a node are assumed to outlive said node. Nodes passed as rvalue references are moved to storage inside the node. This has a big effect when combined with memoization as reference semantics allow reuse of common subexpression trees.