### PR TITLE
Add -lstdc++fs to the link line of gcc

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -328,7 +328,7 @@ endif
 ifeq ($(COMP),gcc)
 	comp=gcc
 	CXX=g++
-	CXXFLAGS += -pedantic -Wextra -Wshadow
+	CXXFLAGS += -pedantic -Wextra -Wshadow -lstdc++fs
 
 	ifeq ($(arch),$(filter $(arch),armv7 armv8))
 		ifeq ($(OS),Android)

--- a/src/learn/convert.cpp
+++ b/src/learn/convert.cpp
@@ -25,7 +25,6 @@
 #include <chrono>
 #include <random>
 #include <regex>
-#include <filesystem>
 
 using namespace std;
 
@@ -610,7 +609,6 @@ namespace Learner
     {
         string kif_base_dir = Path::combine(base_dir, target_dir);
 
-        namespace sys = std::filesystem;
         sys::path p(kif_base_dir); // Origin of enumeration
         std::for_each(sys::directory_iterator(p), sys::directory_iterator(),
             [&](const sys::path& path) {

--- a/src/learn/gensfen.cpp
+++ b/src/learn/gensfen.cpp
@@ -22,7 +22,6 @@
 #include <climits>
 #include <cmath>
 #include <cstring>
-#include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <limits>

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -39,7 +39,6 @@
 #include <climits>
 #include <cmath>    // std::exp(),std::pow(),std::log()
 #include <cstring>  // memcpy()
-#include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <limits>
@@ -104,7 +103,6 @@ namespace Learner
     {
         string kif_base_dir = Path::combine(base_dir, target_dir);
 
-        namespace sys = std::filesystem;
         sys::path p(kif_base_dir); // Origin of enumeration
         std::for_each(sys::directory_iterator(p), sys::directory_iterator(),
             [&](const sys::path& path) {

--- a/src/learn/sfen_writer.h
+++ b/src/learn/sfen_writer.h
@@ -8,7 +8,6 @@
 #include "syzygy/tbprobe.h"
 
 #include <cstring>
-#include <filesystem>
 #include <fstream>
 #include <limits>
 #include <list>

--- a/src/nnue/evaluate_nnue_learner.cpp
+++ b/src/nnue/evaluate_nnue_learner.cpp
@@ -1,6 +1,5 @@
 ﻿#include <random>
 #include <fstream>
-#include <filesystem>
 
 #include "evaluate_nnue.h"
 #include "evaluate_nnue_learner.h"
@@ -326,7 +325,7 @@ namespace Eval::NNUE {
         // mkdir() will fail if this folder already exists, but
         // Apart from that. If not, I just want you to make it.
         // Also, assume that the folders up to EvalSaveDir have been dug.
-        std::filesystem::create_directories(eval_dir);
+        sys::create_directories(eval_dir);
 
         const std::string file_name = Path::combine(eval_dir, NNUE::savedfileName);
         std::ofstream stream(file_name, std::ios::binary);

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -25,6 +25,13 @@
 
 #include <cstring>
 #include <iostream>
+#if defined(__GNUC__ ) && (__GNUC__ < 8)
+#include <experimental/filesystem>
+namespace sys = std::experimental::filesystem;
+#else
+#include <filesystem>
+namespace sys = std::filesystem;
+#endif
 
 #if defined(USE_AVX2)
 #include <immintrin.h>


### PR DESCRIPTION
older versions of gcc (<8.1) need this, even if they accept -std=c++17

with this patch, the code can be run on fishtest again,
at least by the majority of workers (fishtest doesn't require c++17 to be available)

See e.g.
https://tests.stockfishchess.org/tests/view/5fcfbf801ac1691201888235

Bench: 3820648