### PR TITLE
Fix incorrect enpassant flag for moves read from uci format in the binpack lib

### DIFF
--- a/src/extra/nnue_data_binpack_format.h
+++ b/src/extra/nnue_data_binpack_format.h
@@ -6238,7 +6238,7 @@ namespace chess
 
                     return Move::castle(castleType, pos.sideToMove());
                 }
-                else if (pos.epSquare() == to)
+                else if (pos.pieceAt(from).type() == PieceType::Pawn && pos.epSquare() == to)
                 {
                     return Move::enPassant(from, to);
                 }


### PR DESCRIPTION
from discord.
```
[11:25 PM] vondele: @Sopel I have the following .plain entry:
fen 5k2/2R5/6P1/8/6pP/2p2r2/6K1/8 b - h3 0 45
move f3h3
score 0
ply 89
result 0
e

../../src/stockfish convert test.plain test.binpack validate
yields:
Illegal move f3h3 for position 5k2/2R5/6P1/8/6pP/2p2r2/6K1/8 b - h3 0 45
```

This fixes it.