### PR TITLE
Rescoring tool.

### DIFF
--- a/docs/transform.md
+++ b/docs/transform.md
@@ -4,7 +4,7 @@
 
 ## `nudged_static`
 
-`transform nudged_static` takes named parameters in the form of `gensfen param_1_name param_1_value param_2_name param_2_value ...` and flag parameters which don't require values.
+`transform nudged_static` takes named parameters in the form of `transform nudged_static param_1_name param_1_value param_2_name param_2_value ...` and flag parameters which don't require values.
 
 This command goes through positions in the input files and replaces the scores with new ones - generated from static eval - but slightly adjusted based on the scores in the original input file.
 
@@ -19,3 +19,18 @@ Currently the following options are available:
 `relative` - states that the adjustment should be bounded by a value relative in magnitude to the static eval value. After this token follows the maximum relative change - a floating point value greater than 0. For example a value of 0.1 only allows changing the static eval by at most 10% towards the score from the input file.
 
 `interpolate` states that the output score should be a value interpolated between static eval and the score from the input file. After this token follows the interpolation constant `t`. `t` of 0 means that only static eval is used. `t` of 1 means that only score from the input file is used. `t` of 0.5 means that the static eval and input score are averaged. It accepts values outside of range `<0, 1>`, but the usefulness is questionable.
+
+## `rescore_fen`
+
+`transform rescore_fen` takes named parameters in the form of `transform rescore_fen param_1_name param_1_value param_2_name param_2_value ...` and flag parameters which don't require values.
+
+This command takes a path to the input file which contains one FEN per line and outputs a .bin or .binpack file with these positions rescored with specified depth search.
+
+Currently the following options are available:
+
+`input_file` - path to the input .epd file. Default: in.binpack.
+
+`output_file` - path to the output .bin or .binpack file. The file is opened in append mode. Default: out.binpack.
+
+`depth` - the search depth to use for rescoring. Default: 3.
+

--- a/docs/transform.md
+++ b/docs/transform.md
@@ -20,17 +20,21 @@ Currently the following options are available:
 
 `interpolate` states that the output score should be a value interpolated between static eval and the score from the input file. After this token follows the interpolation constant `t`. `t` of 0 means that only static eval is used. `t` of 1 means that only score from the input file is used. `t` of 0.5 means that the static eval and input score are averaged. It accepts values outside of range `<0, 1>`, but the usefulness is questionable.
 
-## `rescore_fen`
+## `rescore`
 
-`transform rescore_fen` takes named parameters in the form of `transform rescore_fen param_1_name param_1_value param_2_name param_2_value ...` and flag parameters which don't require values.
+`transform rescore` takes named parameters in the form of `transform rescore param_1_name param_1_value param_2_name param_2_value ...` and flag parameters which don't require values.
 
-This command takes a path to the input file which contains one FEN per line and outputs a .bin or .binpack file with these positions rescored with specified depth search.
+This tool respects the UCI option `Threads` and uses all available threads.
+
+This command takes a path to the input file that is either a .epd file which contains one FEN per line or a .bin or .binpack file and outputs a .bin or .binpack file with these positions rescored with specified depth search.
 
 Currently the following options are available:
 
-`input_file` - path to the input .epd file. Default: in.binpack.
+`input_file` - path to the input file. Default: in.binpack.
 
 `output_file` - path to the output .bin or .binpack file. The file is opened in append mode. Default: out.binpack.
 
 `depth` - the search depth to use for rescoring. Default: 3.
+
+`keep_moves` - whether to keep moves from the input file if available. Allows to keep compression in .binpack. Default: 1.
 


### PR DESCRIPTION
This PR adds a basic rescoring tool. It can either take an .epd file with FENs as input or a .bin or .binpack file. The general description and options can be found in docs. The tool utilizes all threads as set by the UCI option. There is an additional option `keep_moves` which default to true and means that the moves from the input .bin/.binpack file are kept, this allows to keep the good compression if the positions were linked in the input file.

Usage example:
```
./stockfish.exe
uci
setoption name Threads value 4
setoption name PruneAtShallowDepth value false
isready
transform rescore in.binpack out.binpack depth 6 keep_moves 1
transform rescore in.epd out.binpack depth 6
quit
```

The tool might not scale well to many threads on very low depth rescorings as the sfen reader is primitive and has a large critical section. Waiting for #271  to be fixed.