### PR TITLE
Use plain nnue eval for validation loss calculation instead of first performing qsearch

### DIFF
--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -608,8 +608,6 @@ namespace Learner
             atomic<int>& move_accord_count
         );
 
-        Value get_shallow_value(Position& pos);
-
         bool check_progress();
 
         // save merit function parameters to a file
@@ -958,7 +956,7 @@ namespace Learner
                 continue;
             }
 
-            const Value shallow_value = get_shallow_value(pos);
+            const Value shallow_value = Eval::evaluate(pos);
 
             // Evaluation value of deep search
             const auto deep_value = (Value)ps.score;
@@ -978,33 +976,6 @@ namespace Learner
         }
 
         test_loss_sum += local_loss_sum;
-    }
-
-    Value LearnerThink::get_shallow_value(Position& pos)
-    {
-        // Evaluation value for shallow search
-        // The value of evaluate() may be used, but when calculating loss, learn_cross_entropy and
-        // Use qsearch() because it is difficult to compare the values.
-        // EvalHash has been disabled in advance. (If not, the same value will be returned every time)
-        const auto [_, pv] = Search::qsearch(pos);
-
-        const auto rootColor = pos.side_to_move();
-
-        std::vector<StateInfo, AlignedAllocator<StateInfo>> states(pv.size());
-        for (size_t i = 0; i < pv.size(); ++i)
-        {
-            pos.do_move(pv[i], states[i]);
-        }
-
-        const Value shallow_value =
-            (rootColor == pos.side_to_move())
-            ? Eval::evaluate(pos)
-            : -Eval::evaluate(pos);
-
-        for (auto it = pv.rbegin(); it != pv.rend(); ++it)
-            pos.undo_move(*it);
-
-        return shallow_value;
     }
 
     bool LearnerThink::check_progress()

--- a/tests/instrumented_learn.sh
+++ b/tests/instrumented_learn.sh
@@ -124,7 +124,7 @@ cat << EOF > learn01.exp
 
  send "uci\n"
  send "setoption name SkipLoadingEval value true\n"
- send "setoption name Use NNUE value true\n"
+ send "setoption name Use NNUE value pure\n"
  send "setoption name Threads value $threads\n"
  send "isready\n"
  send "learn targetdir training_data epochs 1 sfen_read_size 100 thread_buffer_size 10 batchsize 100 use_draw_in_training 1 use_draw_in_validation 1 lr 1 eval_limit 32000 nn_batch_size 30 newbob_decay 0.5 eval_save_interval 30 loss_output_interval 10 validation_set_file_name validation_data/validation_data.bin\n"


### PR DESCRIPTION
Qsearch is not a pure function. It contains internal state like history tables. Noob has reported wild deviations for validation loss when continuing the training and they come from qsearch improving itself over time. This PR replaces the qsearch in validation loss computation with plain nnue evaluation. This is more in line with what happens in most of the search and is more deterministic.