### PR TITLE
[WIP] Questionable arithmetic in backpropagation for the feature transformer.

### DIFF
--- a/src/nnue/trainer/trainer_feature_transformer.h
+++ b/src/nnue/trainer/trainer_feature_transformer.h
@@ -490,7 +490,7 @@ namespace Eval::NNUE {
                                 observed_features.set(feature_index);
 
                                 const auto scale = static_cast<LearnFloatType>(
-                                    effective_learning_rate / feature.get_count());
+                                    effective_learning_rate * feature.get_count());
 
 #if defined (USE_BLAS)
 


### PR DESCRIPTION
I'd like to raise some discussion on this. The mathematically correct way is to do it like this: 
https://cdn.discordapp.com/attachments/718853716266188890/790601761131855902/unknown.png

What the current implementation does is it multiplies by the vector containing inverses of the inputs. Effectively lowering the learning rate by a factor of x^2 for features with count != 1 (which right now is only the halfK feature).

I trained two nets (albeit with halfkae5 architecture) with 100M depth 9 positions at LR 1.
```
setoption name SkipLoadingEval value true
setoption name Threads value 3
setoption name Use NNUE value pure
learn targetdir data epochs 1000 batchsize 100000 use_draw_in_training 1 use_draw_in_validation 1 lr 1 lambda 1 eval_limit 9000 nn_batch_size 1000 newbob_decay 0.99 eval_save_interval 25000000 loss_output_interval 1000000 max_grad 0.3 smart_fen_skipping set_recommended_uci_options
ucinewgame
```

logs:
baseline: https://pastebin.com/DHhyqbp8
'fixed': https://pastebin.com/Z4HR6p5F

results of a 25k nodes per move game:
tuna = 'fixed', stockfish = baseline
```
Score of tuna vs stockfish: 356 - 319 - 325  [0.518] 1000
Elo difference: 12.86 +/- 17.69
```
inconclusive, but suggests further investigation

We think that this is either a mistake (looks like a mistake) or a specific adjustment for the lr for this particular type of features.