### PR TITLE
[WIP] Automatic sigmoid scaling for the data eval to perf. Separate scaling for data and player.

### DIFF
--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -78,7 +78,7 @@ namespace Learner
     static double winning_probability_coefficient = 1.0 / PawnValueEg / 4.0 * std::log(10.0);
 
     static double in_sigmoid_scale = winning_probability_coefficient;
-    static double out_sigmoid_scale = winning_probability_coefficient;
+    static double out_sigmoid_scale = 1.0 / 900.0; // empirically derived from static classical and nnue eval.
     static bool auto_adjust_in_sigmoid_scale = true;
 
     // Score scale factors. ex) If we set src_score_min_value = 0.0,

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -681,12 +681,13 @@ namespace Learner
         constexpr double step_change_on_plateou = 0.1;
         constexpr double satisfactory_error = 0.01;
         constexpr double initial_step = 0.01;
+        constexpr int bin_size = 16;
 
         struct WDL { int w=0, d=0, l=0; };
         std::map<int, WDL> perfs;
         for (auto& ps : in_sigmoid_scale_adjust_buffer)
         {
-            auto& p = perfs[ps.score];
+            auto& p = perfs[ps.score / bin_size * bin_size];
             if (ps.game_result == -1) p.l += 1;
             else if (ps.game_result == 1) p.w += 1;
             else p.d += 1;
@@ -745,7 +746,7 @@ namespace Learner
         }
         in_sigmoid_scale = k;
     }
-    
+
     PSVector LearnerThink::fetch_next_validation_set()
     {
         PSVector validation_data;


### PR DESCRIPTION
This PR is work in progress. It is motivated by the following data that relates performance to eval for different datasets:
https://docs.google.com/document/d/11OoStfHPa-RISSxbUx5NKLBLtKtXMBSg3fDp5DGTu8Q/edit#

Normally we use the same sigmoid scaling for both the player and the data, default is `~= 1/361`. The data above suggests that this is very wrong. In fact it looks like the static eval (be it classical or nnue) is generally at `~= 1/900` at least for the rescored dataset from depth 4 gensfen. (I'll rescore depth 9 and higher to see how much it changes). This may change.

The more important thing here is the scaling for the training data. The correct scaling differs between datasets (we assume the wdl information in the generated data is a good proxy after averaging). In this PR an (optional) automatic adjustment for this parameter based on the training data is introduced. For each epoch up to 100000 positions are collected and we try to fit a simple sigmoid curve to the aggregated perf% data. This is fairly accurate compared to the data from 10M positions as seen in the above document. It's also possible to disable the automatic adjustments and set `out_sigmoid_scale` manually (should be disabled in the results don't match the data or are placeholders). The parameters are not documented yet.

Preliminary results for training on 100M positions vs baseline. Depth 9 data (coefficient is about `1/500`):
baseline logs: https://pastebin.com/S7qTf6X2
pr logs: master: https://pastebin.com/ZK4jnr5K
games, 25k nodes per move:
```
Score of tuna vs stockfish: 347 - 304 - 349  [0.521] 1000
Elo difference: 14.95 +/- 17.37
```

As one can see the strength is at least on par. The loss is much better. I think we can at least use this to improve the loss correlation with strength, if not make the trained nets much stronger. It also might be helpful when lambda<1 as it increases correlation of eval with the result.

