### PR TITLE
Accumulate clipping statistics to a 64 bit integer to prevent overflow for larger batch sizes.

### DIFF
--- a/src/nnue/trainer/trainer_clipped_relu.h
+++ b/src/nnue/trainer/trainer_clipped_relu.h
@@ -295,8 +295,6 @@ namespace Eval::NNUE {
         // number of samples in mini-batch
         IndexType batch_size_;
 
-        IndexType num_total_;
-
         const LearnFloatType* input_;
 
         // Trainer of the previous layer
@@ -316,8 +314,8 @@ namespace Eval::NNUE {
             // Health check statistics
             LearnFloatType min_activations_[kOutputDimensions];
             LearnFloatType max_activations_[kOutputDimensions];
-            IndexType num_clipped_;
-            IndexType num_total_;
+            uint64_t num_clipped_;
+            uint64_t num_total_;
 
             ThreadState() { reset(); }
 

--- a/src/nnue/trainer/trainer_feature_transformer.h
+++ b/src/nnue/trainer/trainer_feature_transformer.h
@@ -679,8 +679,6 @@ namespace Eval::NNUE {
         // layer to learn
         LayerType* const target_layer_;
 
-        IndexType num_total_;
-
         // parameter
         alignas(kCacheLineSize) LearnFloatType biases_[kHalfDimensions];
         alignas(kCacheLineSize)
@@ -706,8 +704,8 @@ namespace Eval::NNUE {
             alignas(kCacheLineSize) LearnFloatType max_activations_[kHalfDimensions];
             LearnFloatType min_pre_activation_;
             LearnFloatType max_pre_activation_;
-            IndexType num_clipped_;
-            IndexType num_total_;
+            uint64_t num_clipped_;
+            uint64_t num_total_;
 
             ThreadStatState() { reset(); }
 


### PR DESCRIPTION
Fixes #256 