### PR TITLE
Reduce the amount of sfens buffered for the validation step.

### DIFF
--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -576,7 +576,7 @@ namespace Learner
                 SfenReaderMode::Cyclic,
                 1,
                 std::to_string(prng.next_random_seed()),
-                prm.sfen_read_size,
+                std::min<size_t>(prm.validation_count * 10, 1000000),
                 prm.thread_buffer_size),
             learn_loss_sum{}
         {

--- a/src/learn/sfen_reader.h
+++ b/src/learn/sfen_reader.h
@@ -50,7 +50,9 @@ namespace Learner{
         ) :
             filenames(filenames_.begin(), filenames_.end()),
             mode(mode_),
-            sfen_read_size(read_size),
+            // Due to the implementation of waiting for buffer empty a bit
+            // the read size must be at least twice the buffer size.
+            sfen_read_size(std::max(read_size, buffer_size * 2)),
             thread_buffer_size(buffer_size),
             prng(seed)
         {


### PR DESCRIPTION
Used to be 10M, now we bound it by a multiple of `validation_count`, and at most 1M. This reduces the RAM usage greatly.