### PR TITLE
Don't unload evalfile on set nnue false

### DIFF
--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -253,9 +253,15 @@ void init() {
 
   useNNUE = nnue_mode_from_option(Options["Use NNUE"]);
 
-  if (Options["SkipLoadingEval"] || useNNUE == UseNNUEMode::False)
+  if (Options["SkipLoadingEval"])
   {
     eval_file_loaded.clear();
+    return;
+  }
+
+  if (useNNUE == UseNNUEMode::False)
+  {
+    // Keep the eval file loaded. Useful for mixed bench.
     return;
   }
 


### PR DESCRIPTION
bench repeatedly does `use nnue value true` `use nnue value false` and it constantly unloads and loads the evalfile. This makes the mixed bench meaningless. This PR makes it not unload the previously loaded evalfile. It's not needed to unload is, it's enough that useNNUE is set to false.