### PR TITLE
Add optional warmup step for training.

### DIFF
--- a/docs/learn.md
+++ b/docs/learn.md
@@ -20,11 +20,15 @@ Currently the following options are available:
 
 `epochs` - the number of weight update cycles (epochs) to train the network for. One such cycle is `epoch_size` positions. If not specified then the training will loop forever.
 
+`warmup_epochs` - the number of epochs to "pretrain" the net for with `warmup_lr` learning rate. Default: 0.
+
 `epoch_size` - The number of positions per epoch. Should be kept lowish as the current implementation loads all into memory before processing. Default is already high enough. The epoch size is not tied to validation nor net serialization, there are more specific options for that. Default: 1000000
 
 `basedir` - the base directory for the paths. Default: "" (current directory)
 
 `lr` - initial learning rate. Default: 1.
+
+`warmup_lr` - the learning rate to use during warmup epochs. Default: 0.1.
 
 `use_draw_games_in_training` - either 0 or 1. If 1 then draws will be used in training too. Default: 1.
 

--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -526,6 +526,7 @@ namespace Learner
             bool smart_fen_skipping_for_validation = false;
 
             double learning_rate = 1.0;
+            double warmup_learning_rate = 0.1;
             double max_grad = 1.0;
 
             string validation_set_file_name;
@@ -597,7 +598,7 @@ namespace Learner
             }
         }
 
-        void learn(uint64_t epochs);
+        void learn(uint64_t epochs, uint64_t warmup_epochs = 0);
 
     private:
         static void set_learning_search_limits();
@@ -607,6 +608,7 @@ namespace Learner
         void learn_worker(Thread& th, std::atomic<uint64_t>& counter, uint64_t limit);
 
         void update_weights(const PSVector& psv, uint64_t epoch);
+        void update_weights_warmup(uint64_t warmup_epoch);
 
         void calc_loss(const PSVector& psv, uint64_t epoch);
 
@@ -715,7 +717,7 @@ namespace Learner
         return validation_data;
     }
 
-    void LearnerThink::learn(uint64_t epochs)
+    void LearnerThink::learn(uint64_t epochs, uint64_t warmup_epochs)
     {
 #if defined(_OPENMP)
         omp_set_num_threads((int)Options["Threads"]);
@@ -739,6 +741,36 @@ namespace Learner
             return;
         }
 
+        stop_flag = false;
+
+        if (warmup_epochs > 0)
+        {
+            cout << "Doing " << warmup_epochs << " warmup epochs." << endl;
+        }
+
+        for(uint64_t warmup_epoch = 1; warmup_epoch <= warmup_epochs; ++warmup_epoch)
+        {
+            std::atomic<uint64_t> counter{0};
+
+            Threads.execute_with_workers([this, &counter](auto& th){
+                learn_worker(th, counter, params.mini_batch_size);
+            });
+
+            total_done += params.mini_batch_size;
+
+            Threads.wait_for_workers_finished();
+
+            if (stop_flag)
+                break;
+
+            update_weights_warmup(warmup_epoch);
+
+            if (stop_flag)
+                break;
+
+            cout << "Finished " << warmup_epoch << " out of " << warmup_epochs << " warmup epochs." << endl;
+        }
+
         if (params.newbob_decay != 1.0) {
 
             calc_loss(validation_data, 0);
@@ -750,8 +782,6 @@ namespace Learner
             auto out = sync_region_cout.new_region();
             out << "INFO (learn): initial loss = " << best_loss << endl;
         }
-
-        stop_flag = false;
 
         for(uint64_t epoch = 1; epoch <= epochs; ++epoch)
         {
@@ -870,6 +900,17 @@ namespace Learner
             // Since we have reached the end phase of PV, add the slope here.
             pos_add_grad();
         }
+    }
+
+    void LearnerThink::update_weights_warmup(uint64_t warmup_epoch)
+    {
+        // I'm not sure this fencing is correct. But either way there
+        // should be no real issues happening since
+        // the read/write phases are isolated.
+        atomic_thread_fence(memory_order_seq_cst);
+        Eval::NNUE::update_parameters(
+            Threads, warmup_epoch, params.verbose, params.warmup_learning_rate, params.max_grad, get_loss);
+        atomic_thread_fence(memory_order_seq_cst);
     }
 
     void LearnerThink::update_weights(const PSVector& psv, uint64_t epoch)
@@ -1178,6 +1219,7 @@ namespace Learner
 
         // Number of epochs
         uint64_t epochs = std::numeric_limits<uint64_t>::max();
+        uint64_t warmup_epochs = 0;
 
         // Game file storage folder (get game file with relative path from here)
         string base_dir;
@@ -1216,6 +1258,7 @@ namespace Learner
 
             // Specify the number of loops
             else if (option == "epochs") is >> epochs;
+            else if (option == "warmup_epochs") is >> warmup_epochs;
 
             // Game file storage folder (get game file with relative path from here)
             else if (option == "basedir") is >> base_dir;
@@ -1227,6 +1270,7 @@ namespace Learner
 
             // learning rate
             else if (option == "lr") is >> params.learning_rate;
+            else if (option == "warmup_lr") is >> params.warmup_learning_rate;
             else if (option == "max_grad") is >> params.max_grad;
 
             // Accept also the old option name.
@@ -1338,7 +1382,9 @@ namespace Learner
 
         out << "  - validation count         : " << params.validation_count << endl;
         out << "  - epochs                   : " << epochs << endl;
-        out << "  - epochs * minibatch size  : " << epochs * params.mini_batch_size << endl;
+        out << "  - positions                : " << epochs * params.mini_batch_size << endl;
+        out << "  - warmup epochs            : " << warmup_epochs << endl;
+        out << "  - warmup positions         : " << warmup_epochs * params.mini_batch_size << endl;
         out << "  - eval_limit               : " << params.eval_limit << endl;
         out << "  - save_only_once           : " << (params.save_only_once ? "true" : "false") << endl;
         out << "  - shuffle on read          : " << (params.shuffle ? "true" : "false") << endl;
@@ -1350,6 +1396,7 @@ namespace Learner
         out << "  - nn_options               : " << nn_options << endl;
 
         out << "  - learning rate            : " << params.learning_rate << endl;
+        out << "  - warmup learning rate     : " << params.warmup_learning_rate << endl;
         out << "  - max_grad                 : " << params.max_grad << endl;
         out << "  - use draws in training    : " << params.use_draw_games_in_training << endl;
         out << "  - use draws in validation  : " << params.use_draw_games_in_validation << endl;
@@ -1407,7 +1454,7 @@ namespace Learner
         out.unlock();
 
         // Start learning.
-        learn_think.learn(epochs);
+        learn_think.learn(epochs, warmup_epochs);
     }
 
 } // namespace Learner


### PR DESCRIPTION
Specified with `warmup_epochs`, uses `warmup_lr`.
The purpose is to put the net into a somewhat stable state so that the gradients are not as high during the early stages of the training and don't "accidentally" break the net.

Default values preserve the old behaviour.

Sample output:
```
INFO (initialize_training): Performing random net initialization.
Finished initialization.
info string NNUE evaluation using  enabled
INFO (sfen_reader): Opened file for reading: data/noob_master_d9_1B_0.binpack
INFO (sfen_reader): Opened file for reading: data/noob_master_d9_1B_0.binpack
Doing 10 warmup epochs.
.Finished 1 out of 10 warmup epochs.
.Finished 2 out of 10 warmup epochs.
.Finished 3 out of 10 warmup epochs.
.Finished 4 out of 10 warmup epochs.
.Finished 5 out of 10 warmup epochs.
.Finished 6 out of 10 warmup epochs.
.Finished 7 out of 10 warmup epochs.
.Finished 8 out of 10 warmup epochs.
.Finished 9 out of 10 warmup epochs.
.Finished 10 out of 10 warmup epochs.

PROGRESS (calc_loss): Thu Mar 25 14:42:36 2021, 1000000 sfens, 6266 sfens/second
, epoch 0
  - learning rate = 1
  - startpos eval = 10
  - val_loss       = 0.169671
  - norm = 24825
  - move accuracy = 1.3%
INFO (learn): initial loss = 0.169671
```

Closes #300 