### PR TITLE
Revert "Add additional checks for en-passant possiblity when fixing the erroneus ep flag from a fen."

### DIFF
--- a/src/extra/nnue_data_binpack_format.h
+++ b/src/extra/nnue_data_binpack_format.h
@@ -6115,26 +6115,6 @@ namespace chess
             return false;
         }
 
-        if (pieceAt(epSquare) != Piece::none())
-        {
-            return false;
-        }
-
-        const auto forward =
-            sideToMove == chess::Color::White
-            ? FlatSquareOffset(0, 1)
-            : FlatSquareOffset(0, -1);
-
-        if (pieceAt(epSquare + forward) != Piece::none())
-        {
-            return false;
-        }
-
-        if (pieceAt(epSquare + -forward) != Piece(PieceType::Pawn, !sideToMove))
-        {
-            return false;
-        }
-
         return isEpPossibleColdPath(epSquare, pawnsAttackingEpSquare, sideToMove);
     }
 


### PR DESCRIPTION
This reverts commit 6afcdaa928c4b7a9711b3df53d4cbb70616975f5.

Some old binpacks seem to have been affected by this change and no longer can be converted back. This means that there were likely some false ep squares already in the historical data and fixing it breaks the encoding...